### PR TITLE
Fix robot geometry and reduce laser rate

### DIFF
--- a/beluga_example/models/turtlebot.model.yaml
+++ b/beluga_example/models/turtlebot.model.yaml
@@ -5,8 +5,8 @@ bodies:
     color: [1, 1, 1, 0.75]
     footprints:
       - type: circle
-        radius: 0.5
-        center: [-1, 0.0]
+        radius: 0.3
+        center: [0.0, 0.0]
         density: 1.0
 
 plugins:
@@ -32,4 +32,4 @@ plugins:
     range: 20
     angle: {min: -2.356194490192345, max: 2.356194490192345, increment: 0.004363323129985824}
     noise_std_dev: 0.02
-    update_rate: 40
+    update_rate: 10

--- a/beluga_example/package.xml
+++ b/beluga_example/package.xml
@@ -20,6 +20,7 @@
   <exec_depend>nav2_map_server</exec_depend>
   <exec_depend>nav2_rviz_plugins</exec_depend>
   <exec_depend>rviz2</exec_depend>
+  <exec_depend>teleop_twist_keyboard</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
This patch fixes the geometry of the model so that it is controllable with `teleop_twist_keyboard` and reduces the laser publish rate to 10 Hz.