### PR TITLE
Parallelize motion model update

### DIFF
--- a/beluga/include/beluga/algorithm/particle_filter.hpp
+++ b/beluga/include/beluga/algorithm/particle_filter.hpp
@@ -57,16 +57,16 @@ struct BootstrapParticleFilter : public Mixin {
   }
 
   void sample() {
-    auto states = views::states(particles_);
+    const auto states = views::states(particles_);
     std::transform(
-        std::execution::par, states.begin(), states.end(), states.begin(),
+        std::execution::par, std::begin(states), std::end(states), std::begin(states),
         [this](const auto& state) { return this->self().apply_motion(state); });
   }
 
   void importance_sample() {
     const auto states = views::states(particles_);
     std::transform(
-        std::execution::par, states.begin(), states.end(), views::weights(particles_).begin(),
+        std::execution::par, std::begin(states), std::end(states), std::begin(views::weights(particles_)),
         [this](const auto& state) { return this->self().importance_weight(state); });
   }
 


### PR DESCRIPTION
This patch parallelizes the motion model update using standard C++ execution policies.

Particles: 2000
Points: 1080

  | Sequential Duration [ms] | Parallel Duration [ms] | Speed up
-- | -- | -- | --
Motion update | 10.0660 | 1.2060 | 8.346600332
Sensor update | 15.4800 * | 15.2250 | 1.016748768
Resampling | 11.5730 | 11.6670 | 0.9919430873
Total | 37.1190 | 28.0980 | 1.321054879

*The sensor update is parallelized in both columns.

Related to #3.