### PR TITLE
Add reinitialize method to the particle filter

### DIFF
--- a/beluga/test/beluga/algorithm/test_particle_filter.cpp
+++ b/beluga/test/beluga/algorithm/test_particle_filter.cpp
@@ -37,19 +37,19 @@ class MockMixin : public ciabatta::mixin<MockMixin<Mixin>, Mixin> {
   MOCK_METHOD(double, apply_motion, (double state));
   MOCK_METHOD(double, importance_weight, (double state));
 
-  std::size_t max_samples() { return 10.; }
+  std::size_t max_samples() const { return 10.; }
 
   template <class Particle>
-  auto generate_samples() {
+  auto generate_samples() const {
     return ranges::views::generate([]() { return std::make_pair(1., 1.); });
   }
 
   template <class Range>
-  auto generate_samples_from(Range&& range) {
+  auto generate_samples_from(Range&& range) const {
     return range | ranges::views::all;
   }
 
-  auto take_samples() { return ranges::views::take_exactly(max_samples()); }
+  auto take_samples() const { return ranges::views::take_exactly(max_samples()); }
 };
 
 template <class Mixin>

--- a/beluga_example/rviz/rviz.rviz
+++ b/beluga_example/rviz/rviz.rviz
@@ -224,7 +224,7 @@ Visualization Manager:
     - Class: rviz_default_plugins/SetInitialPose
       Covariance x: 0.25
       Covariance y: 0.25
-      Covariance yaw: 0.06853891909122467
+      Covariance yaw: 1.57
       Topic:
         Depth: 5
         Durability Policy: Volatile


### PR DESCRIPTION
Update particle filter to support re-initialization from a given particle range view. It also updates the initial_pose_callback in the ROS node to re-initialize the filter with the given pose and covariance matrix.

Related to #41.

https://user-images.githubusercontent.com/33042669/211308769-ddcf8870-9eb3-45cd-b883-03046d3e09ff.mp4