### PR TITLE
Update CI pipeline to use the `main` branch

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -2,9 +2,9 @@ name: CI pipeline
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build-test-lint:


### PR DESCRIPTION
The default branch was changed from `master` to `main`. This patch updates the CI pipeline.

Related to #38.