### PR TITLE
Fix node clean up

### DIFF
--- a/beluga_amcl/src/amcl_node.cpp
+++ b/beluga_amcl/src/amcl_node.cpp
@@ -449,13 +449,15 @@ AmclNode::CallbackReturn AmclNode::on_deactivate(const rclcpp_lifecycle::State &
   particle_cloud_pub_->on_deactivate();
   likelihood_field_pub_->on_deactivate();
   pose_pub_->on_deactivate();
-  laser_scan_sub_.reset();
   map_sub_.reset();
   initial_pose_sub_.reset();
-  bond_.reset();
+  laser_scan_connection_.disconnect();
+  laser_scan_filter_.reset();
+  laser_scan_sub_.reset();
   tf_listener_.reset();
   tf_broadcaster_.reset();
   tf_buffer_.reset();
+  bond_.reset();
   return CallbackReturn::SUCCESS;
 }
 

--- a/beluga_example/launch/example_rosbag_launch.py
+++ b/beluga_example/launch/example_rosbag_launch.py
@@ -66,13 +66,6 @@ def generate_launch_description():
                 output='screen',
                 parameters=[os.path.join(example_dir, 'config', 'params.yaml')],
                 arguments=['--ros-args', '--log-level', 'info'],
-                # TODO(nahuel): Investigate node shutdown process.
-                # On shutdown, the system escalates to SIGTERM to stop amcl_node.
-                # This is after the lifecycle node is destroyed.
-                # Incrementing the SIGTERM timeout doesn't help.
-                # This might be a problem if we want to use a command prefix
-                # to measure performance later on (e.g., time, timemory).
-                sigterm_timeout='10',
             ),
         ]
     )


### PR DESCRIPTION
This patch fixes the clean up order of node resources. Without it, the node would hang when shutting down due to circular dependencies with shared pointers.

Fixes #67.