### PR TITLE
Setup devel docker to speed up first build using ccache

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,3 +16,6 @@ services:
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
       - /tmp/.docker.xauth:/tmp/.docker.xauth
       - ..:/ws/src
+      - beluga_ccache:/home/developer/.ccache
+volumes:
+  beluga_ccache:

--- a/docker/files/colcon_defaults.yaml
+++ b/docker/files/colcon_defaults.yaml
@@ -1,0 +1,5 @@
+{
+    "build": {
+        "mixin": [ "ccache" ]
+    }
+}

--- a/docker/images/humble/Dockerfile
+++ b/docker/images/humble/Dockerfile
@@ -4,6 +4,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update \
   && apt-get install --no-install-recommends -y \
+    ccache \
     curl \
     doxygen \
     perl \
@@ -35,6 +36,11 @@ USER $USER:$GROUP
 ENV USER_WS /ws
 
 WORKDIR $USER_WS
+
+RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml \
+  && colcon mixin update default
+COPY --chown=$USER:$GROUP docker/files/colcon_defaults.yaml /home/$USER/.colcon/defaults.yaml
+RUN mkdir -p /home/$USER/.ccache
 
 COPY . $USER_WS/src
 


### PR DESCRIPTION
This proposal speeds up the first build after starting the container, and also if the `build` and `install` folders are cleared for any reason.

- Adds cccache to the container.
- Binds a new docker volume to keep the ccache cache files in the host machine.
- Installs [colcon mixins](https://github.com/colcon/colcon-mixin-repository) in the container to use the ccache mixin.
- Setups the[ defaults.yaml file of colcon](https://colcon.readthedocs.io/en/released/user/configuration.html#defaults-yaml) to default building using the ccache mixin.

The result is that when using the `colcon build` command all of the build process will go through `ccache`, speeding up the process considerably whenever the same file is built under the same conditions again. 

Note that there's a new warning during the build process because one of the `flatworld` packages seems to ignore the CMake ccache settings. Worst case that means that that part of the process will not be sped up.