### PR TITLE
Add launch params to select localization node

### DIFF
--- a/beluga_example/config/params.yaml
+++ b/beluga_example/config/params.yaml
@@ -26,3 +26,5 @@ amcl:
     z_rand: 0.5
     sigma_hit: 0.2
     transform_tolerance: 1.0
+    initial_pose: [0, 2, 0]
+    set_initial_pose: true

--- a/beluga_example/launch/utils/common_nodes_launch.py
+++ b/beluga_example/launch/utils/common_nodes_launch.py
@@ -30,6 +30,7 @@ def generate_launch_description():
                 package='rviz2',
                 executable='rviz2',
                 name='rviz2',
+                output='own_log',
                 arguments=[
                     '--display-config',
                     os.path.join(example_dir, 'rviz', 'rviz.rviz'),

--- a/beluga_example/package.xml
+++ b/beluga_example/package.xml
@@ -16,6 +16,7 @@
   <exec_depend>beluga_amcl</exec_depend>
   <exec_depend>flatland_server</exec_depend>
   <exec_depend>launch_ros</exec_depend>
+  <exec_depend>nav2_amcl</exec_depend>
   <exec_depend>nav2_lifecycle_manager</exec_depend>
   <exec_depend>nav2_map_server</exec_depend>
   <exec_depend>nav2_rviz_plugins</exec_depend>

--- a/docker/images/humble/Dockerfile
+++ b/docker/images/humble/Dockerfile
@@ -13,7 +13,9 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 RUN pip install \
-  pre-commit==2.20.0
+  pre-commit==2.20.0 \
+  # Note: Installing timemory takes a long time.
+  timemory==3.3.0rc4
 
 ARG USER=developer
 ARG GROUP=ekumen


### PR DESCRIPTION
This patch updates the rosbag launch example to take a command prefix and a localization node as parameters. This way we can use it to get CPU and memory usage reports and we can also compare against `nav2_amcl`.

The command to launch and get performance metrics from our implementation is:

```bash
ros2 launch beluga_example example_rosbag_launch.py prefix:='timem --'
```

For `nav2_amcl`:
```bash
ros2 launch beluga_example example_rosbag_launch.py package:=nav2_amcl node:=amcl prefix:='timem --'
```

Related to #35.