### PR TITLE
Fix ccache folder UID for some broken use cases

### DIFF
--- a/docker/files/fixuid_config.yml
+++ b/docker/files/fixuid_config.yml
@@ -1,0 +1,5 @@
+user: _USER_
+group: _GROUP_
+paths:
+  - /
+  - /home/_USER_/.ccache

--- a/docker/images/humble/Dockerfile
+++ b/docker/images/humble/Dockerfile
@@ -26,10 +26,12 @@ RUN addgroup --gid 1000 $GROUP \
   && adduser $USER sudo \
   && echo "$USER ALL=NOPASSWD: ALL" >> /etc/sudoers.d/$USER
 
+COPY docker/files/fixuid_config.yml /etc/fixuid/config.yml
 RUN curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - \
   && chmod 4755 /usr/local/bin/fixuid \
-  && mkdir -p /etc/fixuid \
-  && printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
+  && cd /etc/fixuid \
+  && sed -i "s/_USER_/$USER/" config.yml \
+  && sed -i "s/_GROUP_/$GROUP/" config.yml
 
 USER $USER:$GROUP
 


### PR DESCRIPTION
Fixes #90

## Summary

Updates the configuration for `fixuid` so that the ccache volume path is also processed.

## Checklist
- [x] Read the [contributing guidelines](https://github.com/ekumenlabs/beluga/blob/main/CONTRIBUTING.md).
- [x] Configured pre-commit and ran colcon test locally.
- [x] Signed all commits for DCO.
- [ ] Added tests (regression tests for bugs, coverage of new code for features).
- [ ] Updated documentation (as needed).
- [x] Checked that CI is passing.
