### PR TITLE
Avoid creating a dedicated tf thread

### DIFF
--- a/beluga_amcl/src/amcl_node.cpp
+++ b/beluga_amcl/src/amcl_node.cpp
@@ -533,9 +533,8 @@ void AmclNode::laser_callback(sensor_msgs::msg::LaserScan::ConstSharedPtr laser_
 
   auto odom_to_base_transform = Sophus::SE2d{};
   try {
-    // Use tf overload that does not wait for a transform within a timeout.
-    // This is not convenient in callbacks, the message filter we are using avoids the necessity of it,
-    // and it is also not allowed if not using a dedicated tf thread.
+    // Use the lookupTransform overload with no timeout since we're not using a dedicated
+    // tf thread. The message filter we are using avoids the need for it.
     tf2::convert(
       tf_buffer_->lookupTransform(
         get_parameter("odom_frame_id").as_string(),


### PR DESCRIPTION
Related to https://github.com/ekumenlabs/beluga/issues/35#issuecomment-1414314804

## Summary

This marginaly improves cpu usage, and avoids the creation of an unnecessary thread.

It also changes the code to lookup for tf transforms without a timeout, as it's not allowed if not using a dedicated thread.
It's also not necessary in this case, as we're using a message filter that makes sure that the callback is called when the transforms are available.

## Checklist
- [x] Read the [contributing guidelines](https://github.com/ekumenlabs/beluga/blob/main/CONTRIBUTING.md).
- [x] Configured pre-commit and ran colcon test locally.
- [x] Signed all commits for DCO.
- [x] Added tests (regression tests for bugs, coverage of new code for features).
- [x] Updated documentation (as needed).
- [x] Checked that CI is passing.
