### PR TITLE
Add cpplint to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
         language: system
 
       - id: ament_cpplint
-        name: "[others] Fix C++ format (cpplint)"
+        name: "[others] Check C++ format (cpplint)"
         entry: ament_cpplint
         exclude: beluga\/
         types: [c++]


### PR DESCRIPTION
## Summary
The cpplint tool is part of the ament_lint_common package used in ROS2 nodes, and is run in our repository using colcon test. This patch adds a hook to also run it with pre-commit for consistency.

## Checklist
- [x] Read the [contributing guidelines](https://github.com/ekumenlabs/beluga/blob/main/CONTRIBUTING.md).
- [x] Configured pre-commit and ran colcon test locally.
- [x] Signed all commits for DCO.
- [ ] Added tests (regression tests for bugs, coverage of new code for features).
- [ ] Updated documentation (as needed).
- [x] Checked that CI is passing.
