### PR TITLE
Add flake8 and pep257 to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,20 @@ repos:
         types: [c++]
         language: system
 
+      - id: ament_flake8
+        name: "[others] Check Python format (flake8)"
+        entry: ament_flake8
+        exclude: beluga\/
+        types: [python]
+        language: system
+
+      - id: ament_pep257
+        name: "[others] Check Python format (pep257)"
+        entry: ament_pep257
+        exclude: beluga\/
+        types: [python]
+        language: system
+
   - repo: https://github.com/psf/black
     rev:  22.10.0
     hooks:

--- a/beluga_example/beluga_example/launch_utils.py
+++ b/beluga_example/beluga_example/launch_utils.py
@@ -30,7 +30,7 @@ import yaml
 
 
 def with_launch_arguments(arguments_to_declare: List[DeclareLaunchArgument]):
-    """Decorator to resolve launch arguments early."""
+    """Decorate generate_launch_description function to resolve launch arguments early."""
 
     def decorator(get_launch_description_f):
         def wrapper():
@@ -72,7 +72,8 @@ def get_node_with_arguments_declared_from_params_file(
     Declare arguments from param file.
 
     Currently ROS 2 argument handling is a bit broken ...
-    If you specify a parameter file, there's no way to override the parameter value, except with other parameter file.
+    If you specify a parameter file, there's no way to override the parameter value, except with
+    other parameter file.
 
     Some magic to be able to easily override parameter values specified in a file from launch ...
     """
@@ -94,7 +95,8 @@ def get_node_with_arguments_declared_from_params_file(
     entries_for_node = params_file_dict[node_name_key]
     if 'ros__parameters' not in entries_for_node:
         launch.logging.get_logger().warning(
-            f"parameters file does not have a 'ros__parameters' entry for node '{full_name_without_starting_slash}'"
+            f"parameters file does not have a 'ros__parameters' entry for node "
+            f"'{full_name_without_starting_slash}'"
         )
         return [Node(name=name, namespace=namespace, **kwargs)]
     params_dict = entries_for_node['ros__parameters']


### PR DESCRIPTION
Fixes #112.

## Summary
This patch adds flake8 and pep257 to pre-commit hooks so we can catch formatting errors without running colcon test on the beluga_example package on CI (which would greatly increase our build time).

## Checklist
- [x] Read the [contributing guidelines](https://github.com/ekumenlabs/beluga/blob/main/CONTRIBUTING.md).
- [x] Configured pre-commit and ran colcon test locally.
- [x] Signed all commits for DCO.
- [x] Added tests (regression tests for bugs, coverage of new code for features).
- [x] Updated documentation (as needed).
- [x] Checked that CI is passing.
