### PR TITLE
Install latest Mesa version

### DIFF
--- a/docker/images/humble/Dockerfile
+++ b/docker/images/humble/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update \
 # Fix for the RViz black screen issue.
 # TODO(nahuel): Remove this when the Mesa version available
 # in Ubuntu 22.04 is 22.3.5 or greater.
+# See https://github.com/ekumenlabs/beluga/issues/123
 RUN apt-get update \
   && apt-get install --no-install-recommends -y \
     software-properties-common \


### PR DESCRIPTION
Fixes #123.

## Summary
This fixes a bug with RViz where it shows a black screen when using the current Mesa version on Ubuntu Jammy.

## Checklist
- [x] Read the [contributing guidelines](https://github.com/ekumenlabs/beluga/blob/main/CONTRIBUTING.md).
- [x] Configured pre-commit and ran colcon test locally.
- [x] Signed all commits for DCO.
- [ ] Added tests (regression tests for bugs, coverage of new code for features).
- [x] Updated documentation (as needed).
- [x] Checked that CI is passing.
