### PR TITLE
Update list of maintainers

### DIFF
--- a/beluga/package.xml
+++ b/beluga/package.xml
@@ -6,7 +6,8 @@
 
   <description>A generic MCL library for ROS2.</description>
 
-  <maintainer email="camistolo@ekumenlabs.com">Camila Stolowicz</maintainer>
+  <maintainer email="glpuga@ekumenlabs.com">Gerardo Puga</maintainer>
+  <maintainer email="ivanpauno@ekumenlabs.com">Ivan Paunovic</maintainer>
   <maintainer email="nespinosa@ekumenlabs.com">Nahuel Espinosa</maintainer>
 
   <license>Apache License 2.0</license>

--- a/beluga_amcl/package.xml
+++ b/beluga_amcl/package.xml
@@ -6,6 +6,8 @@
 
   <description>An AMCL node implementation for ROS2 using Beluga.</description>
 
+  <maintainer email="glpuga@ekumenlabs.com">Gerardo Puga</maintainer>
+  <maintainer email="ivanpauno@ekumenlabs.com">Ivan Paunovic</maintainer>
   <maintainer email="nespinosa@ekumenlabs.com">Nahuel Espinosa</maintainer>
 
   <license>Apache License 2.0</license>

--- a/beluga_benchmark/package.xml
+++ b/beluga_benchmark/package.xml
@@ -4,10 +4,11 @@
   <name>beluga_benchmark</name>
   <version>1.0.0</version>
 
-  <description>Scripts to benchmark, profile and compare beluga with other amcl implementations.</description>
+  <description>Scripts to benchmark, profile and compare beluga with other AMCL implementations.</description>
 
-  <maintainer email="nespinosa@ekumenlabs.com">Nahuel Espinosa</maintainer>
+  <maintainer email="glpuga@ekumenlabs.com">Gerardo Puga</maintainer>
   <maintainer email="ivanpauno@ekumenlabs.com">Ivan Paunovic</maintainer>
+  <maintainer email="nespinosa@ekumenlabs.com">Nahuel Espinosa</maintainer>
 
   <license>Apache License 2.0</license>
 

--- a/beluga_example/package.xml
+++ b/beluga_example/package.xml
@@ -6,6 +6,8 @@
 
   <description>Example launch files for Beluga AMCL.</description>
 
+  <maintainer email="glpuga@ekumenlabs.com">Gerardo Puga</maintainer>
+  <maintainer email="ivanpauno@ekumenlabs.com">Ivan Paunovic</maintainer>
   <maintainer email="nespinosa@ekumenlabs.com">Nahuel Espinosa</maintainer>
 
   <license>Apache License 2.0</license>


### PR DESCRIPTION
Related to #108.

## Summary
Long overdue update to the maintainer lists to add @ivanpauno and @glpuga.

## Checklist
- [x] Read the [contributing guidelines](https://github.com/ekumenlabs/beluga/blob/main/CONTRIBUTING.md).
- [x] Configured pre-commit and ran colcon test locally.
- [x] Signed all commits for DCO.
- [ ] Added tests (regression tests for bugs, coverage of new code for features).
- [ ] Updated documentation (as needed).
- [ ] Checked that CI is passing.
