### PR TITLE
Only keep one CI job running for pull request triggered jobs

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-test-lint:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary

Minor improvement.

If you push a new commit to a PR when CI is still running, it will cancel the previous one and run a new, instead of running both parallelly.
This will minimally reduce CI times.
It doesn't affect CI jobs triggered by "push to main", in that case we still run CI for all commits.

References:
- https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value
- https://docs.github.com/en/actions/learn-github-actions/contexts

## Checklist
- [x] Read the [contributing guidelines](https://github.com/ekumenlabs/beluga/blob/main/CONTRIBUTING.md).
- [x] Configured pre-commit and ran colcon test locally.
- [x] Signed all commits for DCO.
- [ ] Added tests (regression tests for bugs, coverage of new code for features).
- [ ] Updated documentation (as needed).
- [x] Checked that CI is passing.
