### PR TITLE
Integrate sensor probabilities across resampling iterations

### DIFF
--- a/beluga/include/beluga/sensor.hpp
+++ b/beluga/include/beluga/sensor.hpp
@@ -41,7 +41,7 @@
  * Then:
  * - `p.update_sensor(m)` will update the sensor model with `p`.
  *   This will not actually update the particle weights, but the update done here
- *   will be used in the nexts `importance_weight()` method calls.
+ *   will be used in the following `importance_weight()` method calls.
  * - `cp.importance_weight(s)` returns a `T::weight_type` instance representing the weight of the particle.
  * - `cp.make_random_state()` returns a `T::state_type` instance.
  *

--- a/beluga/include/beluga/type_traits/particle_traits.hpp
+++ b/beluga/include/beluga/type_traits/particle_traits.hpp
@@ -258,6 +258,7 @@ template <class Particle, class T = typename particle_traits<Particle>::state_ty
 constexpr auto make_from_state(T&& value) {
   auto particle = Particle{};
   state(particle) = std::forward<T>(value);
+  weight(particle) = 1.0;
   return particle;
 }
 

--- a/beluga/test/beluga/algorithm/test_particle_filter.cpp
+++ b/beluga/test/beluga/algorithm/test_particle_filter.cpp
@@ -15,17 +15,35 @@
 #include <gmock/gmock.h>
 
 #include <beluga/algorithm/particle_filter.hpp>
+#include <beluga/type_traits/particle_traits.hpp>
 #include <beluga/views.hpp>
+
 #include <ciabatta/ciabatta.hpp>
 #include <range/v3/range/conversion.hpp>
 #include <range/v3/view/generate.hpp>
 #include <range/v3/view/take_exactly.hpp>
 #include <range/v3/view/transform.hpp>
 
+namespace beluga {
+template <>
+struct particle_traits<std::pair<double, double>> {
+  template <typename T>
+  static constexpr auto state(T&& particle) {
+    return particle.first;
+  }
+
+  template <typename T>
+  static constexpr auto weight(T&& particle) {
+    return particle.second;
+  }
+};
+}  // namespace beluga
+
 namespace {
 
 using testing::Each;
 using testing::Return;
+using testing::ReturnPointee;
 
 template <class Mixin>
 class MockMixin : public Mixin {
@@ -33,6 +51,8 @@ class MockMixin : public Mixin {
   MOCK_METHOD(double, apply_motion, (double state), (const));
   MOCK_METHOD(double, importance_weight, (double state), (const));
   MOCK_METHOD(bool, do_resampling_vote, ());
+
+  auto particles() { return particles_ | ranges::views::common; }
 
   auto states() { return particles_ | beluga::views::elements<0>; }
 
@@ -50,7 +70,8 @@ class MockMixin : public Mixin {
 
   template <class Generator>
   auto generate_samples_from_particles(Generator&&) const {
-    return ranges::views::generate([]() { return 0.0; });
+    // for the purpose of the test, return the existing states unchanged
+    return particles_ | beluga::views::elements<0> | ranges::views::common;
   }
 
   auto take_samples() const {
@@ -77,16 +98,80 @@ TEST(BootstrapParticleFilter, InitializeParticles) {
   EXPECT_THAT(filter.weights() | ranges::to<std::vector>, Each(1.));
 }
 
-TEST(BootstrapParticleFilter, Update) {
+TEST(BootstrapParticleFilter, UpdateWithoutResampling) {
   auto filter = ParticleFilter{};
-  EXPECT_CALL(filter, apply_motion(0.)).WillRepeatedly(Return(2.));
-  EXPECT_CALL(filter, importance_weight(2.)).WillRepeatedly(Return(3.));
-  EXPECT_THAT(filter.states() | ranges::to<std::vector>, Each(0.));
-  filter.sample();
-  EXPECT_THAT(filter.states() | ranges::to<std::vector>, Each(2.));
-  EXPECT_THAT(filter.weights() | ranges::to<std::vector>, Each(1.));
-  filter.importance_sample();
-  EXPECT_THAT(filter.weights() | ranges::to<std::vector>, Each(3.));
+
+  const auto motion_increment = 2.0;
+  const auto weight_reduction_factor = 0.707;
+
+  auto expected_initial_state = 0.0;
+  auto expected_final_state = motion_increment;
+  auto expected_initial_weight = 1.0;
+  auto expected_final_weight = weight_reduction_factor;
+
+  EXPECT_CALL(filter, apply_motion(::testing::_)).WillRepeatedly(ReturnPointee(&expected_final_state));
+  EXPECT_CALL(filter, importance_weight(::testing::_)).WillRepeatedly(Return(weight_reduction_factor));
+  EXPECT_CALL(filter, do_resampling_vote()).WillRepeatedly(Return(false));
+
+  for (auto iteration = 0; iteration < 5; ++iteration) {
+    ASSERT_THAT(filter.states() | ranges::to<std::vector>, Each(expected_initial_state));
+    ASSERT_THAT(filter.weights() | ranges::to<std::vector>, Each(expected_initial_weight));
+
+    // apply motion on all particles, particles will have updated states, but unchanged weight
+    filter.sample();
+    ASSERT_THAT(filter.states() | ranges::to<std::vector>, Each(expected_final_state));
+    ASSERT_THAT(filter.weights() | ranges::to<std::vector>, Each(expected_initial_weight));
+
+    // updating particle weights, particles will have updated weights, but unchanged state
+    filter.importance_sample();
+    ASSERT_THAT(filter.states() | ranges::to<std::vector>, Each(expected_final_state));
+    ASSERT_THAT(filter.weights() | ranges::to<std::vector>, Each(expected_final_weight));
+
+    // resample, but with sampling policy preventing decimation
+    filter.resample();
+
+    expected_initial_state = expected_final_state;
+    expected_initial_weight = expected_final_weight;
+    expected_final_state += motion_increment;
+    expected_final_weight *= weight_reduction_factor;
+  }
+}
+
+TEST(BootstrapParticleFilter, UpdateWithResampling) {
+  auto filter = ParticleFilter{};
+
+  const auto motion_increment = 2.0;
+  const auto weight_reduction_factor = 0.707;
+
+  auto expected_initial_state = 0.0;
+  auto expected_final_state = motion_increment;
+  const auto expected_initial_weight = 1.0;
+  const auto expected_final_weight = weight_reduction_factor;
+
+  EXPECT_CALL(filter, apply_motion(::testing::_)).WillRepeatedly(ReturnPointee(&expected_final_state));
+  EXPECT_CALL(filter, importance_weight(::testing::_)).WillRepeatedly(Return(weight_reduction_factor));
+  EXPECT_CALL(filter, do_resampling_vote()).WillRepeatedly(Return(true));
+
+  for (auto iteration = 0; iteration < 4; ++iteration) {
+    ASSERT_THAT(filter.states() | ranges::to<std::vector>, Each(expected_initial_state));
+    ASSERT_THAT(filter.weights() | ranges::to<std::vector>, Each(expected_initial_weight));
+
+    // apply motion on all particles, particles will have updated states, but unchanged weight
+    filter.sample();
+    ASSERT_THAT(filter.states() | ranges::to<std::vector>, Each(expected_final_state));
+    ASSERT_THAT(filter.weights() | ranges::to<std::vector>, Each(expected_initial_weight));
+
+    // updating particle weights, particles will have updated weights, but unchanged state
+    filter.importance_sample();
+    ASSERT_THAT(filter.states() | ranges::to<std::vector>, Each(expected_final_state));
+    ASSERT_THAT(filter.weights() | ranges::to<std::vector>, Each(expected_final_weight));
+
+    // resample, resampling will reset weights
+    filter.resample();
+
+    expected_initial_state = expected_final_state;
+    expected_final_state += motion_increment;
+  }
 }
 
 }  // namespace

--- a/beluga/test/beluga/sensor/test_likelihood_field_model.cpp
+++ b/beluga/test/beluga/sensor/test_likelihood_field_model.cpp
@@ -102,11 +102,11 @@ TEST(LikelihoodFieldModel, LikelihoodField) {
     kResolution};
 
   const double expected_likelihood_field[] = {  // NOLINT(modernize-avoid-c-arrays)
-    0.025, 0.025, 0.025, 0.070, 1.020,
-    0.025, 0.027, 0.070, 1.020, 0.070,
-    0.025, 0.070, 1.020, 0.070, 0.025,
-    0.070, 1.020, 0.070, 0.027, 0.025,
-    1.020, 0.070, 0.025, 0.025, 0.025
+    0.025, 0.025, 0.025, 0.069, 1.022,
+    0.025, 0.027, 0.069, 1.022, 0.069,
+    0.025, 0.069, 1.022, 0.069, 0.025,
+    0.069, 1.022, 0.069, 0.027, 0.025,
+    1.022, 0.069, 0.025, 0.025, 0.025
   };
   // clang-format on
 
@@ -131,19 +131,19 @@ TEST(LikelihoodFieldModel, ImportanceWeight) {
   auto mixin = UUT{params, grid};
 
   mixin.update_sensor(std::vector<std::pair<double, double>>{{1.25, 1.25}});
-  ASSERT_NEAR(1.020, mixin.importance_weight(grid.origin()), 0.003);
+  ASSERT_NEAR(2.068, mixin.importance_weight(grid.origin()), 0.003);
 
   mixin.update_sensor(std::vector<std::pair<double, double>>{{2.25, 2.25}});
-  ASSERT_NEAR(0.025, mixin.importance_weight(grid.origin()), 0.003);
+  ASSERT_NEAR(1.000, mixin.importance_weight(grid.origin()), 0.003);
 
   mixin.update_sensor(std::vector<std::pair<double, double>>{{-50.0, 50.0}});
-  ASSERT_NEAR(0.000, mixin.importance_weight(grid.origin()), 0.003);
+  ASSERT_NEAR(1.000, mixin.importance_weight(grid.origin()), 0.003);
 
   mixin.update_sensor(std::vector<std::pair<double, double>>{{1.20, 1.20}, {1.25, 1.25}, {1.30, 1.30}});
-  ASSERT_NEAR(3.060, mixin.importance_weight(grid.origin()), 0.01);
+  ASSERT_NEAR(4.205, mixin.importance_weight(grid.origin()), 0.01);
 
   mixin.update_sensor(std::vector<std::pair<double, double>>{{0.0, 0.0}});
-  ASSERT_NEAR(1.020, mixin.importance_weight(Sophus::SE2d{Sophus::SO2d{}, Eigen::Vector2d{1.25, 1.25}}), 0.003);
+  ASSERT_NEAR(2.068, mixin.importance_weight(Sophus::SE2d{Sophus::SO2d{}, Eigen::Vector2d{1.25, 1.25}}), 0.003);
 }
 
 TEST(LikelihoodFieldModel, GridWithOffset) {
@@ -163,10 +163,10 @@ TEST(LikelihoodFieldModel, GridWithOffset) {
   auto mixin = UUT{params, grid};
 
   mixin.update_sensor(std::vector<std::pair<double, double>>{{4.5, 4.5}});
-  ASSERT_NEAR(1.020, mixin.importance_weight(Sophus::SE2d{}), 0.003);
+  ASSERT_NEAR(2.068, mixin.importance_weight(Sophus::SE2d{}), 0.003);
 
   mixin.update_sensor(std::vector<std::pair<double, double>>{{9.5, 9.5}});
-  ASSERT_NEAR(1.020, mixin.importance_weight(grid.origin()), 0.003);
+  ASSERT_NEAR(2.068, mixin.importance_weight(grid.origin()), 0.003);
 }
 
 TEST(LikelihoodFieldModel, GridWithRotation) {
@@ -186,10 +186,10 @@ TEST(LikelihoodFieldModel, GridWithRotation) {
   auto mixin = UUT{params, grid};
 
   mixin.update_sensor(std::vector<std::pair<double, double>>{{-9.5, 9.5}});
-  ASSERT_NEAR(1.020, mixin.importance_weight(Sophus::SE2d{}), 0.003);
+  ASSERT_NEAR(2.068, mixin.importance_weight(Sophus::SE2d{}), 0.003);
 
   mixin.update_sensor(std::vector<std::pair<double, double>>{{9.5, 9.5}});
-  ASSERT_NEAR(1.020, mixin.importance_weight(grid.origin()), 0.003);
+  ASSERT_NEAR(2.068, mixin.importance_weight(grid.origin()), 0.003);
 }
 
 TEST(LikelihoodFieldModel, GridWithRotationAndOffset) {
@@ -212,10 +212,10 @@ TEST(LikelihoodFieldModel, GridWithRotationAndOffset) {
   auto mixin = UUT{params, grid};
 
   mixin.update_sensor(std::vector<std::pair<double, double>>{{-4.5, 4.5}});
-  ASSERT_NEAR(1.020, mixin.importance_weight(Sophus::SE2d{}), 0.003);
+  ASSERT_NEAR(2.068, mixin.importance_weight(Sophus::SE2d{}), 0.003);
 
   mixin.update_sensor(std::vector<std::pair<double, double>>{{9.5, 9.5}});
-  ASSERT_NEAR(1.020, mixin.importance_weight(grid.origin()), 0.003);
+  ASSERT_NEAR(2.068, mixin.importance_weight(grid.origin()), 0.003);
 }
 
 }  // namespace

--- a/beluga/test/benchmark/benchmark_sampling.cpp
+++ b/beluga/test/benchmark/benchmark_sampling.cpp
@@ -56,7 +56,7 @@ void BM_FixedResample(benchmark::State& state) {
   }
 
   for (auto _ : state) {
-    auto&& samples = ranges::views::generate(beluga::random_sample(
+    auto&& samples = ranges::views::generate(beluga::make_multinomial_sampler(
                          beluga::views::all(container), beluga::views::weights(container), generator)) |
                      ranges::views::take_exactly(container_size) | ranges::views::common;
     auto first = std::begin(beluga::views::all(new_container));
@@ -93,9 +93,9 @@ void BM_AdaptiveResample(benchmark::State& state) {
   double kld_z = 3.;
 
   for (auto _ : state) {
-    auto&& samples = ranges::views::generate(beluga::random_sample(
+    auto&& samples = ranges::views::generate(beluga::make_multinomial_sampler(
                          beluga::views::all(container), beluga::views::weights(container), generator)) |
-                     ranges::views::transform(beluga::set_cluster(hasher)) |
+                     ranges::views::transform(beluga::make_clusterization_function(hasher)) |
                      ranges::views::take_while(
                          beluga::kld_condition(min_samples, kld_epsilon, kld_z), beluga::cluster<const Particle&>) |
                      ranges::views::take(container_size) | ranges::views::common;


### PR DESCRIPTION
Related to #57.

## Summary

- Initializes weight to 1
- Incorporates previous weight to the new weight calculation during the importance weight step.
- Corrects importance_weight formula
- Updates related tests
- Minor documentation and testing updates.

## Checklist
- [x] Read the [contributing guidelines](https://github.com/ekumenlabs/beluga/blob/main/CONTRIBUTING.md).
- [x] Configured pre-commit and ran colcon test locally.
- [x] Signed all commits for DCO.
- [x] Added tests (regression tests for bugs, coverage of new code for features).
- [x] Updated documentation (as needed).
- [x] Checked that CI is passing.
