### PR TITLE
Rename `importance_sample` method to `reweight`

### DIFF
--- a/beluga/include/beluga/algorithm/particle_filter.hpp
+++ b/beluga/include/beluga/algorithm/particle_filter.hpp
@@ -36,7 +36,7 @@
  *
  * The following is satisfied:
  * - `b.sample()` updates the particles based on the latest motion update.
- * - `b.importance_sample()` updates the particles weight based on the latest sensor update.
+ * - `b.reweight()` updates the particles weight based on the latest sensor update.
  * - `b.resample()` generates new particles from the old ones based on their importance weights.
  *
  * \section BaseParticleFilterLinks See also
@@ -75,19 +75,19 @@ struct BaseParticleFilterInterface {
    * to incorporate measurements. The importance is proportional to the
    * probability of seeing the measurement given the current particle state.
    */
-  virtual void importance_sample() = 0;
+  virtual void reweight() = 0;
 
   /**
    * \overload
    * It allows specifying a sequenced execution policy.
    */
-  virtual void importance_sample(std::execution::sequenced_policy) { return this->importance_sample(); };
+  virtual void reweight(std::execution::sequenced_policy) { return this->reweight(); };
 
   /**
    * \overload
    * It allows specifying a parallel execution policy.
    */
-  virtual void importance_sample(std::execution::parallel_policy) { return this->importance_sample(); };
+  virtual void reweight(std::execution::parallel_policy) { return this->reweight(); };
 
   /// Resample particles based on their weights.
   /**
@@ -151,18 +151,18 @@ class BootstrapParticleFilter : public Mixin {
   void sample(std::execution::parallel_policy policy) final { this->sample_impl(policy); }
 
   /**
-   * \copydoc BaseParticleFilterInterface::importance_sample()
+   * \copydoc BaseParticleFilterInterface::reweight()
    *
    * The update will be done based on the `Mixin` implementation of the
    * \ref SensorModelPage "SensorModel" named requirements.
    */
-  void importance_sample() final { this->importance_sample_impl(std::execution::seq); }
+  void reweight() final { this->reweight_impl(std::execution::seq); }
 
-  /// \copydoc BaseParticleFilterInterface::importance_sample(std::execution::sequenced_policy policy)
-  void importance_sample(std::execution::sequenced_policy policy) final { this->importance_sample_impl(policy); }
+  /// \copydoc BaseParticleFilterInterface::reweight(std::execution::sequenced_policy policy)
+  void reweight(std::execution::sequenced_policy policy) final { this->reweight_impl(policy); }
 
-  /// \copydoc BaseParticleFilterInterface::importance_sample(std::execution::parallel_policy policy)
-  void importance_sample(std::execution::parallel_policy policy) final { this->importance_sample_impl(policy); }
+  /// \copydoc BaseParticleFilterInterface::reweight(std::execution::parallel_policy policy)
+  void reweight(std::execution::parallel_policy policy) final { this->reweight_impl(policy); }
 
   /**
    * \copydoc BaseParticleFilterInterface::resample()
@@ -191,7 +191,7 @@ class BootstrapParticleFilter : public Mixin {
   }
 
   template <typename ExecutionPolicy>
-  void importance_sample_impl(ExecutionPolicy&& policy) {
+  void reweight_impl(ExecutionPolicy&& policy) {
     auto states = this->self().states() | ranges::views::common;
     auto weights = this->self().weights() | ranges::views::common;
     std::transform(

--- a/beluga/test/beluga/algorithm/test_particle_filter.cpp
+++ b/beluga/test/beluga/algorithm/test_particle_filter.cpp
@@ -123,7 +123,7 @@ TEST(BootstrapParticleFilter, UpdateWithoutResampling) {
     ASSERT_THAT(filter.weights() | ranges::to<std::vector>, Each(expected_initial_weight));
 
     // updating particle weights, particles will have updated weights, but unchanged state
-    filter.importance_sample();
+    filter.reweight();
     ASSERT_THAT(filter.states() | ranges::to<std::vector>, Each(expected_final_state));
     ASSERT_THAT(filter.weights() | ranges::to<std::vector>, Each(expected_final_weight));
 
@@ -162,7 +162,7 @@ TEST(BootstrapParticleFilter, UpdateWithResampling) {
     ASSERT_THAT(filter.weights() | ranges::to<std::vector>, Each(expected_initial_weight));
 
     // updating particle weights, particles will have updated weights, but unchanged state
-    filter.importance_sample();
+    filter.reweight();
     ASSERT_THAT(filter.states() | ranges::to<std::vector>, Each(expected_final_state));
     ASSERT_THAT(filter.weights() | ranges::to<std::vector>, Each(expected_final_weight));
 

--- a/beluga_amcl/src/amcl_node.cpp
+++ b/beluga_amcl/src/amcl_node.cpp
@@ -846,7 +846,7 @@ void AmclNode::laser_callback(
         static_cast<std::size_t>(get_parameter("max_beams").as_int()),
         static_cast<float>(get_parameter("laser_min_range").as_double()),
         static_cast<float>(get_parameter("laser_max_range").as_double())));
-    particle_filter_->importance_sample(exec_policy);
+    particle_filter_->reweight(exec_policy);
     const auto time3 = std::chrono::high_resolution_clock::now();
     particle_filter_->resample();
     const auto time4 = std::chrono::high_resolution_clock::now();

--- a/beluga_system_tests/test/test_system.cpp
+++ b/beluga_system_tests/test/test_system.cpp
@@ -94,7 +94,7 @@ TEST_P(BelugaSystemTest, testEstimatedPath) {
     pf.sample();
     auto scan_copy = data_point.scan;
     pf.update_sensor(std::move(scan_copy));
-    pf.importance_sample();
+    pf.reweight();
     pf.resample();
     auto estimation = pf.estimate();
     auto error = data_point.ground_truth.inverse() * estimation.first;


### PR DESCRIPTION
Fixes #151.

## Summary
The term "importance sample" means the act of drawing samples with replacement with probabilities given by the importance factors, and that is not what this method does in code.

## Checklist
- [x] Read the [contributing guidelines](https://github.com/ekumenlabs/beluga/blob/main/CONTRIBUTING.md).
- [x] Configured pre-commit and ran colcon test locally.
- [x] Signed all commits for DCO.
- [x] Added tests (regression tests for bugs, coverage of new code for features).
- [x] Updated documentation (as needed).
- [x] Checked that CI is passing.
