### PR TITLE
Add WeightedStateEstimator2d mixin

### DIFF
--- a/beluga/include/beluga/algorithm/estimation.hpp
+++ b/beluga/include/beluga/algorithm/estimation.hpp
@@ -18,8 +18,11 @@
 #include <range/v3/range/access.hpp>
 #include <range/v3/range/primitives.hpp>
 #include <range/v3/view/common.hpp>
+#include <range/v3/view/repeat_n.hpp>
 #include <range/v3/view/transform.hpp>
 #include <sophus/se2.hpp>
+
+#include <numeric>
 
 /**
  * \file
@@ -45,7 +48,55 @@
 
 namespace beluga {
 
-/// Calculates the covariance of a range given its mean.
+/// Calculates the covariance of a range given its mean and the weights of each element.
+/**
+ * \tparam Range A [sized range](https://en.cppreference.com/w/cpp/ranges/sized_range) type whose
+ *  value type is `Eigen::Vector2<Scalar>`.
+ * \tparam WeightsRange A [sized range](https://en.cppreference.com/w/cpp/ranges/sized_range) type whose
+ *  value type is `Scalar`.
+ * \tparam Scalar A scalar type, e.g. double or float.
+ * \param range Range to be used to calculate the covariance.
+ * \param normalized_weights Range with the normalized (total weight 1.0) weights of the samples in 'range'.
+ * \param mean The previously calculated mean of range. The value must be correct for the resulting
+ *  covariance to be correct.
+ * \return The calculated covariance, as a `Eigen::Matrix2<Scalar>`.
+ */
+template <class Range, class WeightsRange, class Scalar>
+Eigen::Matrix2<Scalar>
+calculate_covariance(Range&& range, WeightsRange&& normalized_weights, const Eigen::Vector2<Scalar>& mean) {
+  auto translations_view = range | ranges::views::common;
+  auto normalized_weights_view = normalized_weights | ranges::views::common;
+
+  auto calculate_weighted_sample_covariance = [mean](const auto& value, const auto& weight) {
+    const auto centered = value - mean;
+    return Eigen::Vector3<Scalar>{
+        weight * centered.x() * centered.x(),  // weighted sample x autocovariance
+        weight * centered.x() * centered.y(),  // weighted sample xy cross-covariance
+        weight * centered.y() * centered.y(),  // weighted sample y autocovariance
+    };
+  };
+
+  // calculate the averaging factor for the weighted covariance estimate
+  // See https://en.wikipedia.org/wiki/Sample_mean_and_covariance#Weighted_samples
+  const auto squared_weight_sum = std::transform_reduce(
+      normalized_weights_view.begin(), normalized_weights_view.end(), Scalar{0.0}, std::plus{},
+      [](const auto& weight) { return (weight * weight); });
+
+  // calculate the x autocovariance, xy cross-covariance, and y autocovariance
+  Eigen::Vector3<Scalar> coefficients =
+      std::transform_reduce(
+          translations_view.begin(), translations_view.end(), normalized_weights_view.begin(),
+          Eigen::Vector3<Scalar>::Zero().eval(), std::plus{}, calculate_weighted_sample_covariance) /
+      (1.0 - squared_weight_sum);
+
+  // create the symmetric 2x2 translation covariance matrix from the coefficients
+  auto covariance_matrix = Eigen::Matrix2<Scalar>{};
+  covariance_matrix << coefficients(0), coefficients(1), coefficients(1), coefficients(2);
+  return covariance_matrix;
+}
+
+/// Convenience overload that calculates the covariance of a range given its mean for the case where all
+/// samples have the same weight.
 /**
  * \tparam Range A [sized range](https://en.cppreference.com/w/cpp/ranges/sized_range) type whose
  *  value type is `Eigen::Vector2<Scalar>`.
@@ -56,21 +107,12 @@ namespace beluga {
  * \return The calculated covariance, as a `Eigen::Matrix2<Scalar>`.
  */
 template <class Range, class Scalar>
-Eigen::Matrix2<Scalar> covariance(Range&& range, const Eigen::Vector2<Scalar>& mean) {
-  auto view = range | ranges::views::common;
-  Eigen::Vector3<Scalar> coefficients = std::transform_reduce(
-      view.begin(), view.end(), Eigen::Vector3<Scalar>::Zero().eval(), std::plus{}, [mean](const auto& value) {
-        const auto centered = value - mean;
-        return Eigen::Vector3<Scalar>{
-            centered.x() * centered.x(),
-            centered.x() * centered.y(),
-            centered.y() * centered.y(),
-        };
-      });
-  coefficients /= (static_cast<Scalar>(view.size() - 1));
-  auto covariance_matrix = Eigen::Matrix2<Scalar>{};
-  covariance_matrix << coefficients(0), coefficients(1), coefficients(1), coefficients(2);
-  return covariance_matrix;
+Eigen::Matrix2<Scalar> calculate_covariance(Range&& range, const Eigen::Vector2<Scalar>& mean) {
+  const auto sample_count = range.size();
+  return calculate_covariance(
+      range,
+      ranges::views::repeat_n(1.0 / static_cast<Scalar>(sample_count), static_cast<std::ptrdiff_t>(sample_count)),
+      mean);
 }
 
 /// Returns a pair consisting of the estimated mean pose and its covariance.
@@ -81,47 +123,89 @@ Eigen::Matrix2<Scalar> covariance(Range&& range, const Eigen::Vector2<Scalar>& m
  * of the rotation angles to create a 3x3 covariance matrix.
  * It does not take into account the particle weights.
  *
- * \tparam Range A [sized range](https://en.cppreference.com/w/cpp/ranges/sized_range) type whose
+ * \tparam Poses A [sized range](https://en.cppreference.com/w/cpp/ranges/sized_range) type whose
  *  value type is `Sophus::SE2<Scalar>`.
+ * \tparam Weights A [sized range](https://en.cppreference.com/w/cpp/ranges/sized_range) type whose
+ *  value type is `Scalar`.
  * \tparam Pose The pose value type of the given range.
  * \tparam Scalar A scalar type, e.g. double or float.
- * \param range Range of equally weighted 2D poses.
+ * \param poses Poses of equally weighted 2D poses.
+ * \param weights Poses of equally weighted 2D poses.
  * \return The estimated pose and its 3x3 covariance matrix.
  */
 template <
-    class Range,
-    class Pose = ranges::range_value_t<Range>,
+    class Poses,
+    class Weights,
+    class Pose = ranges::range_value_t<Poses>,
     class Scalar = typename Pose::Scalar,
     typename = std::enable_if_t<std::is_same_v<Pose, typename Sophus::SE2<Scalar>>>>
-std::pair<Sophus::SE2<Scalar>, Eigen::Matrix3<Scalar>> estimate(Range&& range) {
-  auto pose_view = range | ranges::views::common;
-  auto translation_view = range | ranges::views::transform([](const auto& pose) { return pose.translation(); });
+std::pair<Sophus::SE2<Scalar>, Eigen::Matrix3<Scalar>> estimate(Poses&& poses, Weights&& weights) {
+  auto translation_view = poses | ranges::views::transform([](const auto& pose) { return pose.translation(); });
+  auto weights_view = weights | ranges::views::common;
+  const auto weights_sum = std::accumulate(weights_view.begin(), weights_view.end(), 0.0);
+  auto normalized_weights_view =
+      weights_view | ranges::views::transform([weights_sum](const auto& weight) { return weight / weights_sum; });
 
-  // Compute the average of all the coefficients of the SE(2) group elements and
-  // construct a new SE(2) element.
-  const Eigen::Vector4<Scalar> sum_vector = std::transform_reduce(
-      pose_view.begin(), pose_view.end(), Eigen::Vector4<Scalar>::Zero().eval(), std::plus{},
-      [](const auto& pose) { return Eigen::Map<const Eigen::Vector4<Scalar>>{pose.data()}; });
-  const Eigen::Vector4<Scalar> mean_vector = sum_vector / static_cast<double>(pose_view.size());
-  Sophus::SE2<Scalar> mean = Eigen::Map<const Sophus::SE2<Scalar>>{mean_vector.data()};
+  // map sophus pose 2D pose into a 4D Eigen vector. Mapping exploits that Sophus stores the 2D transform
+  // as two elements for the linear translation, and two more for the orientation (in complex number form)
+  const auto pose_to_weighted_eigen_vector = [](const auto& pose, const auto& weight) {
+    return Eigen::Map<const Eigen::Vector4<Scalar>>{pose.data()} * weight;
+  };
+
+  // Compute the average of all the coefficients of the SE2 group elements and construct a new SE2 element. Notice
+  // that after averaging the complex representation of the orientation the resulting complex is not on the unit circle.
+  // This is expected and the value will be renormalized after having used the non-normal result to estimate the
+  // orientation autocovariance.
+  const Eigen::Vector4<Scalar> mean_pose_vector = std::transform_reduce(
+      poses.begin(), poses.end(), normalized_weights_view.begin(), Eigen::Vector4<Scalar>::Zero().eval(), std::plus{},
+      pose_to_weighted_eigen_vector);
+
+  // Calculate the weighted pose estimation
+  Sophus::SE2<Scalar> estimated_pose = Eigen::Map<const Sophus::SE2<Scalar>>{mean_pose_vector.data()};
+
+  Eigen::Matrix3<Scalar> covariance_matrix = Eigen::Matrix3<Scalar>::Zero();
 
   // Compute the covariance of the translation part.
-  Eigen::Matrix3<Scalar> covariance_matrix = Eigen::Matrix3<Scalar>::Zero();
-  covariance_matrix.template topLeftCorner<2, 2>() = covariance(translation_view, mean.translation());
+  covariance_matrix.template topLeftCorner<2, 2>() =
+      calculate_covariance(translation_view, normalized_weights_view, estimated_pose.translation());
 
-  // Compute the circular variance and re-normalize the rotation component.
-  if (mean.so2().unit_complex().norm() < std::numeric_limits<double>::epsilon()) {
+  // Compute the orientation variance and re-normalize the rotation component.
+  if (estimated_pose.so2().unit_complex().norm() < std::numeric_limits<double>::epsilon()) {
     // Handle the case where both averages are too close to zero.
     // Return zero yaw and infinite variance.
     covariance_matrix.coeffRef(2, 2) = std::numeric_limits<double>::infinity();
-    mean.so2() = Sophus::SO2<Scalar>{0.0};
+    estimated_pose.so2() = Sophus::SO2<Scalar>{0.0};
   } else {
     // See circular standard deviation in
     // https://en.wikipedia.org/wiki/Directional_statistics#Dispersion.
-    covariance_matrix.coeffRef(2, 2) = -2.0 * std::log(mean.so2().unit_complex().norm());
-    mean.so2().normalize();
+    covariance_matrix.coeffRef(2, 2) = -2.0 * std::log(estimated_pose.so2().unit_complex().norm());
+    estimated_pose.so2().normalize();
   }
-  return std::pair{mean, covariance_matrix};
+  return std::pair{estimated_pose, covariance_matrix};
+}
+
+/// Returns a pair consisting of the estimated mean pose and its covariance.
+/**
+ * Given a range of poses, computes the estimated pose by averaging the translation
+ * and rotation parts, assuming all poses are equally weighted.
+ * Computes the covariance matrix of the translation parts and the circular variance
+ * of the rotation angles to create a 3x3 covariance matrix.
+ * It does not take into account the particle weights.
+ *
+ * \tparam Poses A [sized range](https://en.cppreference.com/w/cpp/ranges/sized_range) type whose
+ *  value type is `Sophus::SE2<Scalar>`.
+ * \tparam Pose The pose value type of the given range.
+ * \tparam Scalar A scalar type, e.g. double or float.
+ * \param poses Poses of equally weighted 2D poses.
+ * \return The estimated pose and its 3x3 covariance matrix.
+ */
+template <
+    class Poses,
+    class Pose = ranges::range_value_t<Poses>,
+    class Scalar = typename Pose::Scalar,
+    typename = std::enable_if_t<std::is_same_v<Pose, typename Sophus::SE2<Scalar>>>>
+std::pair<Sophus::SE2<Scalar>, Eigen::Matrix3<Scalar>> estimate(Poses&& poses) {
+  return beluga::estimate(poses, ranges::views::repeat_n(1.0, static_cast<std::ptrdiff_t>(poses.size())));
 }
 
 /// Pure abstract class representing the estimation interface.
@@ -167,6 +251,38 @@ class SimpleStateEstimator<Mixin, Sophus::SE2d> : public Mixin {
 /// An alias template for the simple state estimator in 2D.
 template <class Mixin>
 using SimpleStateEstimator2d = SimpleStateEstimator<Mixin, Sophus::SE2d>;
+
+/// Primary template for a weighted state estimator.
+template <class Mixin, class State>
+class WeightedStateEstimator;
+
+/// Partial template specialization for weighted state estimator in 2D.
+/**
+ * This class implements the EstimationInterface2d interface
+ * and satisfies \ref StateEstimatorPage.
+ *
+ * It's an estimator that calculates the pose mean and covariance using all the particles.
+ */
+template <class Mixin>
+class WeightedStateEstimator<Mixin, Sophus::SE2d> : public Mixin {
+ public:
+  /// Constructs a WeightedStateEstimator instance.
+  /**
+   * \tparam ...Args Arguments types for the remaining mixin constructors.
+   * \param ...args Arguments that are not used by this part of the mixin, but by others.
+   */
+  template <class... Args>
+  explicit WeightedStateEstimator(Args&&... args) : Mixin(std::forward<Args>(args)...) {}
+
+  /// \copydoc EstimationInterface2d::estimate()
+  [[nodiscard]] std::pair<Sophus::SE2d, Eigen::Matrix3d> estimate() const final {
+    return beluga::estimate(this->self().states(), this->self().weights());
+  }
+};
+
+/// An alias template for the weighted state estimator in 2D.
+template <class Mixin>
+using WeightedStateEstimator2d = WeightedStateEstimator<Mixin, Sophus::SE2d>;
 
 }  // namespace beluga
 

--- a/beluga/include/beluga/localization.hpp
+++ b/beluga/include/beluga/localization.hpp
@@ -75,7 +75,7 @@ template <class MotionDescriptor, class SensorDescriptor>
 using MonteCarloLocalization2d = ciabatta::mixin<
     BootstrapParticleFilter,
     ciabatta::curry<StructureOfArrays, Sophus::SE2d, beluga::Weight>::mixin,
-    SimpleStateEstimator2d,
+    WeightedStateEstimator2d,
     RandomStateGenerator,
     NaiveSampler,
     FixedLimiter,
@@ -96,7 +96,7 @@ template <class MotionDescriptor, class SensorDescriptor>
 using AdaptiveMonteCarloLocalization2d = ciabatta::mixin<
     BootstrapParticleFilter,
     ciabatta::curry<StructureOfArrays, Sophus::SE2d, beluga::Weight, beluga::Cluster>::mixin,
-    SimpleStateEstimator2d,
+    WeightedStateEstimator2d,
     RandomStateGenerator,
     AdaptiveSampler,
     ciabatta::curry<KldLimiter, Sophus::SE2d>::mixin,

--- a/beluga/src/clang_tidy_findable.cpp
+++ b/beluga/src/clang_tidy_findable.cpp
@@ -22,4 +22,6 @@
 
 #include <beluga/beluga.hpp>
 
-int main() {}
+int main() {
+  return 0;
+}

--- a/beluga/test/beluga/algorithm/test_estimation.cpp
+++ b/beluga/test/beluga/algorithm/test_estimation.cpp
@@ -31,10 +31,90 @@ using Eigen::Vector2d;
 using Sophus::SE2d;
 using Sophus::SO2d;
 
-TEST(SimpleEstimation, Position) {
+struct CovarianceCalculation : public testing::Test {};
+
+TEST_F(CovarianceCalculation, UniformWeightOverload) {
+  // Covariance matrix calculated for items with uniform weights.
+  // The following Octave code was used to validate the results:
+  /*
+      translations = [ 0 2 0 2 0 2 0 2 0 2; 0 2 0 2 0 0 2 2 2 0 ]';
+      cov_matrix = cov(translations)
+  */
+  const auto translation_vector = std::vector{
+      Eigen::Vector2<double>{0, 0}, Eigen::Vector2<double>{2, 2}, Eigen::Vector2<double>{0, 0},
+      Eigen::Vector2<double>{2, 2}, Eigen::Vector2<double>{0, 0}, Eigen::Vector2<double>{2, 0},
+      Eigen::Vector2<double>{0, 2}, Eigen::Vector2<double>{2, 2}, Eigen::Vector2<double>{0, 2},
+      Eigen::Vector2<double>{2, 0},
+  };
+  const auto translation_mean = Eigen::Vector2<double>{1, 1};
+  const auto covariance = beluga::calculate_covariance(translation_vector, translation_mean);
+  ASSERT_NEAR(covariance(0, 0), 1.1111, 0.001);
+  ASSERT_NEAR(covariance(0, 1), 0.2222, 0.001);
+  ASSERT_NEAR(covariance(1, 0), 0.2222, 0.001);
+  ASSERT_NEAR(covariance(1, 1), 1.1111, 0.001);
+}
+
+TEST_F(CovarianceCalculation, NonUniformWeightOverload) {
+  // Covariance matrix calculated with non-uniform weights.
+  // The following Octave code was used to validate the results:
+  /*
+      translations = [ 0 2 0 2 0 2 0 2 0 2; 0 2 0 2 0 0 2 2 2 0 ]';
+      weights = [0 1 2 1 0 1 2 1 0 1]';
+      normalized_weight = weights ./ sum(weights);
+      weighted_mean = sum(normalized_weight .* translations)
+      deviations = translations - weighted_mean;
+      weighted_cov_matrix =  (normalized_weight .* deviations)' * deviations ./ (1 - sum(normalized_weight.^2))
+  */
+  const auto translation_vector = std::vector{
+      Eigen::Vector2<double>{0, 0}, Eigen::Vector2<double>{2, 2}, Eigen::Vector2<double>{0, 0},
+      Eigen::Vector2<double>{2, 2}, Eigen::Vector2<double>{0, 0}, Eigen::Vector2<double>{2, 0},
+      Eigen::Vector2<double>{0, 2}, Eigen::Vector2<double>{2, 2}, Eigen::Vector2<double>{0, 2},
+      Eigen::Vector2<double>{2, 0},
+  };
+  auto weights = std::vector{0.0, 1.0, 2.0, 1.0, 0.0, 1.0, 2.0, 1.0, 0.0, 1.0};
+  const auto total_weight = std::accumulate(weights.begin(), weights.end(), 0.0);
+  std::for_each(weights.begin(), weights.end(), [total_weight](auto& weight) { weight /= total_weight; });
+  const auto translation_mean = Eigen::Vector2<double>{1.1111, 1.1111};
+  const auto covariance = beluga::calculate_covariance(translation_vector, weights, translation_mean);
+  ASSERT_NEAR(covariance(0, 0), 1.1765, 0.001);
+  ASSERT_NEAR(covariance(0, 1), 0.1176, 0.001);
+  ASSERT_NEAR(covariance(1, 0), 0.1176, 0.001);
+  ASSERT_NEAR(covariance(1, 1), 1.1765, 0.001);
+}
+
+struct PoseCovarianceEstimation : public testing::Test {
+  // The following Octave code can be used to validate the results in the tests that derive from this fixture:
+  /*
+     # inputs
+     translations = [ x1 y1 rot1; x2 y2 rot2; x3 y3 yaw3; ... xn yn rotn ] ;
+     weights = [w1 w2 w3 ... wn]; ]';
+
+     # auxiliar variables
+     xy_translation = translations(:, 1:2);
+     complex_rotation = exp(i* translations(:, 3));
+     normalized_weight = weights ./ sum(weights);
+     complex_rotation_mean = sum(normalized_weight .* complex_rotation);
+     R = abs(complex_rotation_mean);
+     # mean estimations
+     xy_mean = sum(normalized_weight .* xy_translation);
+     rot_mean = imag(log(complex_rotation_mean / abs(complex_rotation_mean)));
+     # covariance estimations
+     xy_deviations = xy_translation - xy_mean;
+     xy_cov_matrix =  (normalized_weight .* xy_deviations)' * xy_deviations ./ (1 - sum(normalized_weight.^2));
+     rot_cov = -2 * log(R);
+     # results
+     means = [ xy_mean, rot_mean ]
+     covariance_matrix = [xy_cov_matrix, [0; 0]; [0 0], rot_cov]
+  */
+};
+
+TEST_F(PoseCovarianceEstimation, PureTranslation) {
+  // test the mean and covariance estimations for states that have different translations but the same rotation
   const auto states = std::vector{SE2d{SO2d{0.0}, Vector2d{1.0, 2.0}}, SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}}};
-  const auto [pose, covariance] = beluga::estimate(states);
+  const auto weights = std::vector(states.size(), 1.0);
+  const auto [pose, covariance] = beluga::estimate(states, weights);
   ASSERT_THAT(pose.translation(), Vector2Eq(Vector2d{0.5, 1.0}));
+  ASSERT_THAT(pose.so2(), SO2Eq(SO2d{0.0}));
   ASSERT_NEAR(covariance(0, 0), 0.5, 0.001);
   ASSERT_NEAR(covariance(0, 1), 1.0, 0.001);
   ASSERT_NEAR(covariance(0, 2), 0.0, 0.001);
@@ -46,10 +126,13 @@ TEST(SimpleEstimation, Position) {
   ASSERT_NEAR(covariance(2, 2), 0.0, 0.001);
 }
 
-TEST(SimpleEstimation, Rotation) {
+TEST_F(PoseCovarianceEstimation, PureRotation) {
+  // test the mean and covariance estimations for states that have different rotations but the same translation
   const auto states =
       std::vector{SE2d{SO2d{-Constants::pi() / 2}, Vector2d{0.0, 0.0}}, SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}}};
-  const auto [pose, covariance] = beluga::estimate(states);
+  const auto weights = std::vector(states.size(), 1.0);
+  const auto [pose, covariance] = beluga::estimate(states, weights);
+  ASSERT_THAT(pose.translation(), Vector2Eq(Vector2d{0.0, 0.0}));
   ASSERT_THAT(pose.so2(), SO2Eq(SO2d{-Constants::pi() / 4}));
   ASSERT_NEAR(covariance(0, 0), 0.000, 0.001);
   ASSERT_NEAR(covariance(0, 1), 0.000, 0.001);
@@ -62,11 +145,14 @@ TEST(SimpleEstimation, Rotation) {
   ASSERT_NEAR(covariance(2, 2), 0.693, 0.001);
 }
 
-TEST(SimpleEstimation, ThreePoints) {
+TEST_F(PoseCovarianceEstimation, JointTranslationAndRotation) {
+  // test the mean and covariance estimations for states that have different translations and rotations
   const auto states = std::vector{
       SE2d{SO2d{Constants::pi() / 6}, Vector2d{0.0, -3.0}}, SE2d{SO2d{Constants::pi() / 2}, Vector2d{1.0, -2.0}},
       SE2d{SO2d{Constants::pi() / 3}, Vector2d{2.0, -1.0}}, SE2d{SO2d{0.0}, Vector2d{3.0, 0.0}}};
-  const auto [pose, covariance] = beluga::estimate(states);
+  const auto weights = std::vector(states.size(), 1.0);
+  const auto [pose, covariance] = beluga::estimate(states, weights);
+  ASSERT_THAT(pose.translation(), Vector2Eq(Vector2d{1.5, -1.5}));
   ASSERT_THAT(pose.so2(), SO2Eq(SO2d{Constants::pi() / 4}));
   ASSERT_NEAR(covariance(0, 0), 1.666, 0.001);
   ASSERT_NEAR(covariance(0, 1), 1.666, 0.001);
@@ -79,10 +165,14 @@ TEST(SimpleEstimation, ThreePoints) {
   ASSERT_NEAR(covariance(2, 2), 0.357, 0.001);
 }
 
-TEST(SimpleEstimation, CanceledOutAngles) {
+TEST_F(PoseCovarianceEstimation, CancellingOrientations) {
+  // test mean and covariance for two states with opposite angles that cause a singularity in angular covariance
+  // estimation
   const auto states = std::vector{
       SE2d{SO2d{Constants::pi() / 2}, Vector2d{0.0, 0.0}}, SE2d{SO2d{-Constants::pi() / 2}, Vector2d{0.0, 0.0}}};
-  const auto [pose, covariance] = beluga::estimate(states);
+  const auto weights = std::vector(states.size(), 1.0);
+  const auto [pose, covariance] = beluga::estimate(states, weights);
+  ASSERT_THAT(pose.translation(), Vector2Eq(Vector2d{0.0, 0.0}));
   ASSERT_THAT(pose.so2(), SO2Eq(SO2d{0.0}));
   ASSERT_NEAR(covariance(0, 0), 0.0, 0.001);
   ASSERT_NEAR(covariance(0, 1), 0.0, 0.001);
@@ -95,21 +185,132 @@ TEST(SimpleEstimation, CanceledOutAngles) {
   ASSERT_EQ(covariance(2, 2), std::numeric_limits<double>::infinity());
 }
 
+TEST_F(PoseCovarianceEstimation, RandomWalkWithSmoothRotationWithUniformWeights) {
+  // test the mean and covariance estimations for states with random variations of translation and rotation
+  const auto states = std::vector{
+      SE2d{SO2d{Constants::pi() * 0.1}, Vector2d{0.0, -2.0}},  //
+      SE2d{SO2d{Constants::pi() * 0.2}, Vector2d{1.0, -1.0}},  //
+      SE2d{SO2d{Constants::pi() * 0.3}, Vector2d{2.0, 1.0}},   //
+      SE2d{SO2d{Constants::pi() * 0.2}, Vector2d{3.0, 2.0}},   //
+      SE2d{SO2d{Constants::pi() * 0.2}, Vector2d{2.0, 1.0}},   //
+      SE2d{SO2d{Constants::pi() * 0.2}, Vector2d{1.0, -1.0}},  //
+      SE2d{SO2d{Constants::pi() * 0.3}, Vector2d{2.0, -2.0}},  //
+      SE2d{SO2d{Constants::pi() * 0.4}, Vector2d{3.0, -1.0}},  //
+      SE2d{SO2d{Constants::pi() * 0.5}, Vector2d{2.0, 1.0}},   //
+      SE2d{SO2d{Constants::pi() * 0.4}, Vector2d{1.0, 2.0}},   //
+  };
+  const auto weights = std::vector(states.size(), 1.0);
+  const auto [pose, covariance] = beluga::estimate(states, weights);
+  ASSERT_THAT(pose.translation(), Vector2Eq(Vector2d{1.700, 0.0}));
+  ASSERT_THAT(pose.so2(), SO2Eq(SO2d{0.8762}));
+  ASSERT_NEAR(covariance(0, 0), 0.900, 0.001);
+  ASSERT_NEAR(covariance(0, 1), 0.5556, 0.001);
+  ASSERT_NEAR(covariance(0, 2), 0.0000, 0.001);
+  ASSERT_NEAR(covariance(1, 0), 0.5556, 0.001);
+  ASSERT_NEAR(covariance(1, 1), 2.4444, 0.001);
+  ASSERT_NEAR(covariance(1, 2), 0.0000, 0.001);
+  ASSERT_NEAR(covariance(2, 0), 0.0000, 0.001);
+  ASSERT_NEAR(covariance(2, 1), 0.0000, 0.001);
+  ASSERT_NEAR(covariance(2, 2), 0.1355, 0.001);
+}
+
+TEST_F(PoseCovarianceEstimation, WeightsCanSingleOutOneSample) {
+  // test the weights have effect by selecting a few states and ignoring others
+  const auto states = std::vector{
+      SE2d{SO2d{Constants::pi() / 6}, Vector2d{0.0, -3.0}},  //
+      SE2d{SO2d{Constants::pi() / 2}, Vector2d{1.0, -2.0}},  //
+      SE2d{SO2d{Constants::pi() / 3}, Vector2d{2.0, -1.0}},  //
+      SE2d{SO2d{Constants::pi() / 2}, Vector2d{1.0, -2.0}},  //
+  };
+  const auto weights = std::vector{0.0, 1.0, 0.0, 1.0};
+  const auto [pose, covariance] = beluga::estimate(states, weights);
+  ASSERT_THAT(pose.translation(), Vector2Eq(Vector2d{1.0, -2.0}));
+  ASSERT_THAT(pose.so2(), SO2Eq(SO2d{Constants::pi() / 2}));
+  ASSERT_NEAR(covariance(0, 0), 0.000, 0.001);
+  ASSERT_NEAR(covariance(0, 1), 0.000, 0.001);
+  ASSERT_NEAR(covariance(0, 2), 0.000, 0.001);
+  ASSERT_NEAR(covariance(1, 0), 0.000, 0.001);
+  ASSERT_NEAR(covariance(1, 1), 0.000, 0.001);
+  ASSERT_NEAR(covariance(1, 2), 0.000, 0.001);
+  ASSERT_NEAR(covariance(2, 0), 0.000, 0.001);
+  ASSERT_NEAR(covariance(2, 1), 0.000, 0.001);
+  ASSERT_NEAR(covariance(2, 2), 0.000, 0.001);
+}
+
+TEST_F(PoseCovarianceEstimation, RandomWalkWithSmoothRotationAndNonUniformWeights) {
+  // test the mean and covariance estimations for states with random variations of translation, rotation and weights
+  const auto states = std::vector{
+      SE2d{SO2d{Constants::pi() * 0.1}, Vector2d{0.0, -2.0}},  //
+      SE2d{SO2d{Constants::pi() * 0.2}, Vector2d{1.0, -1.0}},  //
+      SE2d{SO2d{Constants::pi() * 0.3}, Vector2d{2.0, 1.0}},   //
+      SE2d{SO2d{Constants::pi() * 0.2}, Vector2d{3.0, 2.0}},   //
+      SE2d{SO2d{Constants::pi() * 0.2}, Vector2d{2.0, 1.0}},   //
+      SE2d{SO2d{Constants::pi() * 0.2}, Vector2d{1.0, -1.0}},  //
+      SE2d{SO2d{Constants::pi() * 0.3}, Vector2d{2.0, -2.0}},  //
+      SE2d{SO2d{Constants::pi() * 0.4}, Vector2d{3.0, -1.0}},  //
+      SE2d{SO2d{Constants::pi() * 0.5}, Vector2d{2.0, 1.0}},   //
+      SE2d{SO2d{Constants::pi() * 0.4}, Vector2d{1.0, 2.0}},   //
+  };
+  const auto weights = std::vector{0.1, 0.4, 0.7, 0.1, 0.9, 0.2, 0.2, 0.4, 0.1, 0.4};
+  const auto [pose, covariance] = beluga::estimate(states, weights);
+  ASSERT_THAT(pose.translation(), Vector2Eq(Vector2d{1.800, 0.3143}));
+  ASSERT_THAT(pose.so2(), SO2Eq(SO2d{0.8687}));
+  ASSERT_NEAR(covariance(0, 0), 0.5946, 0.001);
+  ASSERT_NEAR(covariance(0, 1), 0.0743, 0.001);
+  ASSERT_NEAR(covariance(0, 2), 0.0000, 0.001);
+  ASSERT_NEAR(covariance(1, 0), 0.0743, 0.001);
+  ASSERT_NEAR(covariance(1, 1), 1.8764, 0.001);
+  ASSERT_NEAR(covariance(1, 2), 0.0000, 0.001);
+  ASSERT_NEAR(covariance(2, 0), 0.0000, 0.001);
+  ASSERT_NEAR(covariance(2, 1), 0.0000, 0.001);
+  ASSERT_NEAR(covariance(2, 2), 0.0855, 0.001);
+}
+
 template <class Mixin>
 class MockMixin : public Mixin {
  public:
   MOCK_METHOD(const std::vector<Sophus::SE2d>&, states, (), (const));
+  MOCK_METHOD(const std::vector<double>&, weights, (), (const));
 };
 
-TEST(SimpleStateEstimator, ThreePoints) {
-  const auto mixin = ciabatta::mixin<
-      beluga::SimpleStateEstimator2d, MockMixin, ciabatta::provides<beluga::EstimationInterface2d>::mixin>{};
+TEST(SimpleStateEstimator, SimpleStateEstimatorUsesUniformWeights) {
+  // test that the simple state estimator uses uniform weights for mean and covariance estimation
+  using UUT = ciabatta::mixin<
+      beluga::SimpleStateEstimator2d, MockMixin, ciabatta::provides<beluga::EstimationInterface2d>::mixin>;
+  const auto mixin = UUT{};
   const auto states = std::vector{
       SE2d{SO2d{Constants::pi() / 6}, Vector2d{0.0, -3.0}}, SE2d{SO2d{Constants::pi() / 2}, Vector2d{1.0, -2.0}},
       SE2d{SO2d{Constants::pi() / 3}, Vector2d{2.0, -1.0}}, SE2d{SO2d{0.0}, Vector2d{3.0, 0.0}}};
-  EXPECT_CALL(mixin, states()).WillOnce(ReturnRef(states));
+  const auto weights = std::vector(states.size(), 1.0);
+  EXPECT_CALL(mixin, states).WillRepeatedly(ReturnRef(states));
+  EXPECT_CALL(mixin, weights).Times(0);
   const auto [pose, covariance] = mixin.estimate();
-  const auto [expected_pose, expected_covariance] = beluga::estimate(states);
+  const auto [expected_pose, expected_covariance] = beluga::estimate(states, weights);
+  ASSERT_THAT(pose, SE2Eq(expected_pose));
+  ASSERT_NEAR(covariance(0, 0), expected_covariance(0, 0), 0.001);
+  ASSERT_NEAR(covariance(0, 1), expected_covariance(0, 1), 0.001);
+  ASSERT_NEAR(covariance(0, 2), expected_covariance(0, 2), 0.001);
+  ASSERT_NEAR(covariance(1, 0), expected_covariance(1, 0), 0.001);
+  ASSERT_NEAR(covariance(1, 1), expected_covariance(1, 1), 0.001);
+  ASSERT_NEAR(covariance(1, 2), expected_covariance(1, 2), 0.001);
+  ASSERT_NEAR(covariance(2, 0), expected_covariance(2, 0), 0.001);
+  ASSERT_NEAR(covariance(2, 1), expected_covariance(2, 1), 0.001);
+  ASSERT_NEAR(covariance(2, 2), expected_covariance(2, 2), 0.001);
+}
+
+TEST(WeightedStateEstimator, WeightedStateEstimatorDoesWeightedEstimation) {
+  // test that the weighted state estimator uses the provided weights for mean and covariance estimation
+  using UUT = ciabatta::mixin<
+      beluga::WeightedStateEstimator2d, MockMixin, ciabatta::provides<beluga::EstimationInterface2d>::mixin>;
+  const auto mixin = UUT{};
+  const auto states = std::vector{
+      SE2d{SO2d{Constants::pi() / 6}, Vector2d{0.0, -3.0}}, SE2d{SO2d{Constants::pi() / 2}, Vector2d{1.0, -2.0}},
+      SE2d{SO2d{Constants::pi() / 3}, Vector2d{2.0, -1.0}}, SE2d{SO2d{0.0}, Vector2d{3.0, 0.0}}};
+  const auto weights = std::vector{0.1, 0.5, 0.5, 0.1};
+  EXPECT_CALL(mixin, states).WillRepeatedly(ReturnRef(states));
+  EXPECT_CALL(mixin, weights).WillRepeatedly(ReturnRef(weights));
+  const auto [pose, covariance] = mixin.estimate();
+  const auto [expected_pose, expected_covariance] = beluga::estimate(states, weights);
   ASSERT_THAT(pose, SE2Eq(expected_pose));
   ASSERT_NEAR(covariance(0, 0), expected_covariance(0, 0), 0.001);
   ASSERT_NEAR(covariance(0, 1), expected_covariance(0, 1), 0.001);

--- a/beluga/test/beluga/random/test_multivariate_normal_distribution.cpp
+++ b/beluga/test/beluga/random/test_multivariate_normal_distribution.cpp
@@ -70,7 +70,7 @@ TEST_P(MultivariateNormalDistributionWithParam, DistributionCovarianceAndMean) {
   const auto mean = Eigen::Vector2d{sum / sequence.size()};
   ASSERT_NEAR(mean(0), expected_mean(0), 0.01);
   ASSERT_NEAR(mean(1), expected_mean(1), 0.01);
-  const auto covariance = beluga::covariance(sequence, mean);
+  const auto covariance = beluga::calculate_covariance(sequence, mean);
   ASSERT_NEAR(covariance(0, 0), expected_covariance(0, 0), 0.01);
   ASSERT_NEAR(covariance(0, 1), expected_covariance(0, 1), 0.01);
   ASSERT_NEAR(covariance(1, 0), expected_covariance(1, 0), 0.01);


### PR DESCRIPTION
Related to #57 

## Summary

- Refactor `estimate()` function to use weights instead of assuming uniform weight for samples
- Adds WeightedStateEstimator
- Refactors SimpleStateEstimator to work as a subcase of estimation where all weights are 1.0.
- Add testing for WeightedStateEstimator and also do a few minor refactors to the SimpleStateEstimator test cases.
 
## Checklist
- [x] Read the [contributing guidelines](https://github.com/ekumenlabs/beluga/blob/main/CONTRIBUTING.md).
- [x] Configured pre-commit and ran colcon test locally.
- [x] Signed all commits for DCO.
- [x] Added tests (regression tests for bugs, coverage of new code for features).
- [x] Updated documentation (as needed).
- [x] Checked that CI is passing.
