### PR TITLE
Update URLs after transfer

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation_issue_report.md
+++ b/.github/ISSUE_TEMPLATE/documentation_issue_report.md
@@ -16,7 +16,7 @@ Description of what the error consists of, it could be a typographical error,
 incorrect documentation, missing content, etc.
 
 Important: If you're trying to report a functional bug, open a Bug Report instead
-(see https://github.com/ekumenlabs/beluga/issues/new/choose).
+(see https://github.com/Ekumen-OS/beluga/issues/new/choose).
 -->
 
 ## Additional information

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ NOTE: The larger description should be done in the linked issue, not here.
 -->
 
 ## Checklist
-- [ ] Read the [contributing guidelines](https://github.com/ekumenlabs/beluga/blob/main/CONTRIBUTING.md).
+- [ ] Read the [contributing guidelines](https://github.com/Ekumen-OS/beluga/blob/main/CONTRIBUTING.md).
 - [ ] Configured pre-commit and ran colcon test locally.
 - [ ] Signed all commits for DCO.
 - [ ] Added tests (regression tests for bugs, coverage of new code for features).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ the code they are contributing to the project according to the
 #### Create a new issue
 
 If you spot a problem or have a feature request you'd like to discuss, [search if an issue already exists](https://docs.github.com/en/github/searching-for-information-on-github/searching-on-github/searching-issues-and-pull-requests#search-by-the-title-body-or-comments).
-If a related issue doesn't exist, you can [open a new issue](https://github.com/ekumenlabs/beluga/issues/new/choose).
+If a related issue doesn't exist, you can [open a new issue](https://github.com/Ekumen-OS/beluga/issues/new/choose).
 
 ### Make changes
 
@@ -46,7 +46,7 @@ If a related issue doesn't exist, you can [open a new issue](https://github.com/
 
 1. Clone the repository.
    ```bash
-   git clone --recursive git@github.com:ekumenlabs/beluga.git
+   git clone --recursive git@github.com:Ekumen-OS/beluga.git
    ```
 
 1. Build and run the development docker container.
@@ -103,7 +103,7 @@ If a related issue doesn't exist, you can [open a new issue](https://github.com/
    ros2 run teleop_twist_keyboard teleop_twist_keyboard
    ```
 
-1. Push your changes and [create a PR](https://github.com/ekumenlabs/beluga/compare)!
+1. Push your changes and [create a PR](https://github.com/Ekumen-OS/beluga/compare)!
 
 1. At the time a feature branch is squashed-and-merged into `main`, the commit message should adhere to the following good practices:
    - Limit the subject line to 50 characters.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Beluga
 
-![CI badge](https://github.com/ekumenlabs/beluga/actions/workflows/ci_pipeline.yml/badge.svg?event=push)
+![CI badge](https://github.com/Ekumen-OS/beluga/actions/workflows/ci_pipeline.yml/badge.svg?event=push)
 
 ## Overview
 

--- a/beluga/include/beluga/sensor/beam_model.hpp
+++ b/beluga/include/beluga/sensor/beam_model.hpp
@@ -154,7 +154,7 @@ class BeamSensorModel : public Mixin {
       }
 
       // TODO(glpuga): Investigate why AMCL and QuickMCL both use this formula for the weight.
-      // See https://github.com/ekumenlabs/beluga/issues/153
+      // See https://github.com/Ekumen-OS/beluga/issues/153
       return pz * pz * pz;
     });
   }

--- a/beluga/include/beluga/sensor/likelihood_field_model.hpp
+++ b/beluga/include/beluga/sensor/likelihood_field_model.hpp
@@ -167,7 +167,7 @@ class LikelihoodFieldModel : public Mixin {
     const auto transform = grid_.origin().inverse() * state;
     const auto lock = std::shared_lock<std::shared_mutex>{points_mutex_};
     // TODO(glpuga): Investigate why AMCL and QuickMCL both use this formula for the weight.
-    // See https://github.com/ekumenlabs/beluga/issues/153
+    // See https://github.com/Ekumen-OS/beluga/issues/153
     return std::transform_reduce(
         points_.cbegin(), points_.cend(), 1.0, std::plus{},
         [this, x_offset = transform.translation().x(), y_offset = transform.translation().y(),

--- a/docker/images/humble/Dockerfile
+++ b/docker/images/humble/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
 # Fix for the RViz black screen issue.
 # TODO(nahuel): Remove this when the Mesa version available
 # in Ubuntu 22.04 is 22.3.5 or greater.
-# See https://github.com/ekumenlabs/beluga/issues/123
+# See https://github.com/Ekumen-OS/beluga/issues/123
 RUN apt-get update \
   && apt-get install --no-install-recommends -y \
     software-properties-common \

--- a/docker/images/rolling/Dockerfile
+++ b/docker/images/rolling/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
 # Fix for the RViz black screen issue.
 # TODO(nahuel): Remove this when the Mesa version available
 # in Ubuntu 22.04 is 22.3.5 or greater.
-# See https://github.com/ekumenlabs/beluga/issues/123
+# See https://github.com/Ekumen-OS/beluga/issues/123
 RUN apt-get update \
   && apt-get install --no-install-recommends -y \
     software-properties-common \


### PR DESCRIPTION
Related to #108.

## Summary
The repository was transferred to Ekumen-OS, this patch updates the URLs accordingly.

## Checklist
- [x] Read the [contributing guidelines](https://github.com/ekumenlabs/beluga/blob/main/CONTRIBUTING.md).
- [x] Configured pre-commit and ran colcon test locally.
- [x] Signed all commits for DCO.
- [ ] Added tests (regression tests for bugs, coverage of new code for features).
- [x] Updated documentation (as needed).
- [x] Checked that CI is passing.
