### PR TITLE
Add missing documentation links

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -64,7 +64,7 @@
 
    ```bash
    cd /ws
-   ./src/beluga/docs/generate_docs.sh
+   ./src/beluga/beluga/docs/generate_docs.sh
    ```
 
 ## Next steps

--- a/beluga/README.md
+++ b/beluga/README.md
@@ -18,6 +18,10 @@ The current set of features includes:
 - Likelihood field and beam sensor models.
 - Differential drive and omnidirectional motion models.
 
+## Documentation
+
+Auto-generated Doxygen documentation can be found in [ekumen-os.github.io/beluga/](https://ekumen-os.github.io/beluga/) .
+
 ## Dependencies
 
 Beluga is built on top of the following open source libraries:

--- a/beluga/README.md
+++ b/beluga/README.md
@@ -20,7 +20,7 @@ The current set of features includes:
 
 ## Documentation
 
-Auto-generated Doxygen documentation can be found in [ekumen-os.github.io/beluga/](https://ekumen-os.github.io/beluga/) .
+Auto-generated Doxygen documentation can be found in https://ekumen-os.github.io/beluga/.
 
 ## Dependencies
 

--- a/beluga/include/beluga/algorithm/estimation.hpp
+++ b/beluga/include/beluga/algorithm/estimation.hpp
@@ -44,6 +44,7 @@
  *
  * \section StateEstimationLinks See also
  * - beluga::SimpleStateEstimator<Mixin, Sophus::SE2d>
+ * - beluga::WeightedStateEstimator<Mixin, Sophus::SE2d>
  */
 
 namespace beluga {

--- a/beluga/include/beluga/sensor.hpp
+++ b/beluga/include/beluga/sensor.hpp
@@ -48,6 +48,7 @@
  *
  * \section SensorModelLinks See also
  * - beluga::LikelihoodFieldModel
+ * - beluga::BeamSensorModel
  */
 
 namespace beluga {


### PR DESCRIPTION
### Proposed changes

Adds missing documentation links:
- BeamSensorModel in Sensors page
- WeightedStateEstimator in StateEstimation page

Adds a section with a link to the Doxygen documentation from the Beluga README.md (before the only link was in the landing page of the repository).

Also fixes the path to the document generation script in GETTING_STARTED.md

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [x] 📚 Documentation (change which fixes or extends documentation)

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commmits have been signed for [DCO](https://developercertificate.org/)
