### PR TITLE
Remove shared_mutexes to address concurrency performance

### DIFF
--- a/beluga_benchmark/docs/BENCHMARKING.md
+++ b/beluga_benchmark/docs/BENCHMARKING.md
@@ -55,14 +55,20 @@ This will print APE metrics (mean, median, max, std, rmse, etc), and also plot A
 
 ## Comparing parameterized runs
 
-This is useful to compare beluga vs another amcl node, e.g. `nav2_amcl`.
-It's also useful to compare beluga using different settings.
+The following command allows to compare the results of different benchmarking runs in a single plot for each metric being measured.
 
-```
-ros2 run beluga_benchmark compare_results -b <BELUGA_RESULTS_PATH> -o <OTHER_RESULTS_PATH>
-```
+This can be used to compare different `beluga_amcl` and/or `nav2_amcl` runs, or to compare the same node with different base configuration settings.
 
-The results path should be the one where `parameterized_run` was run, i.e. the one containing the `benchmark_*_particles_output` directories.
+The command is
+```
+ros2 run beluga_benchmark compare_results -s <PATH1> -l <LABEL1> -s <PATH2> -l <LABEL2> ...
+```
+where `PATH1` and `PATH2` are the paths to the output directories of the benchmarking runs to compare, and `LABEL1` and `LABEL2` are the labels to use in the plot for each of them. Any number of runs can be added in the same plot by providing additional `-s <PATH> -l <LABEL>` pairs.
+
+Additionally, the Y axis of the plot can be configured to be plotted in log scale using the `--use-logy` flag. If not specificied, the plot will default to linear scale.
+
+Notice that the result paths passed to `compare_results` must be the ones where `parameterized_run` was run, i.e. the one containing the `benchmark_*_particles_output` directories.
+
 The script will plot the following metrics vs the number of particles:
 
 - RSS memory


### PR DESCRIPTION
### Proposed changes

Removes the `shared_mutex` locks, that were not currently in use since there's no concurrency in how different steps of the filter are applied, but that was causing performance issues.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] All commmits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

Pre (before change) and post (after change) performance of the node.

#### Likelihood Sensor Model (linear scale)

![likelihood_linear](https://github.com/Ekumen-OS/beluga/assets/17802342/90e99d3c-18a3-417a-b957-a9aa3adb017b)

#### Likelihood Sensor Model (log scale)

![likelihood_log](https://github.com/Ekumen-OS/beluga/assets/17802342/51795405-2427-42bb-ae61-19d8e4d7fb27)

#### Beam Sensor Model (linear scale)

![beam_linear](https://github.com/Ekumen-OS/beluga/assets/17802342/be7e82d1-998e-4a33-a6d3-bf3954bc87ef)

#### Beam Sensor Model (log scale)

![beam_log](https://github.com/Ekumen-OS/beluga/assets/17802342/db974cc1-9ce1-4c5b-9e09-37d23a2725aa)
