### PR TITLE
Optimize beam sensor model runtime performance

### DIFF
--- a/beluga/include/beluga/sensor/beam_model.hpp
+++ b/beluga/include/beluga/sensor/beam_model.hpp
@@ -122,42 +122,47 @@ class BeamSensorModel : public Mixin {
    */
   [[nodiscard]] weight_type importance_weight(const state_type& state) const {
     const auto beam = Ray2d{grid_, state, params_.beam_max_range};
-    return std::transform_reduce(points_.cbegin(), points_.cend(), 0.0, std::plus{}, [this, &beam](const auto& point) {
-      // TODO(Ramiro): We're converting from range + bearing to cartesian points in the ROS node, but we want range +
-      // bearing here. We might want to make that conversion in the likelihood model instead, and let the measurement
-      // type be range, bearing instead of x, y.
+    const double n = 1. / (std::sqrt(2. * M_PI) * params_.sigma_hit);
+    return std::transform_reduce(
+        points_.cbegin(), points_.cend(), 0.0, std::plus{}, [this, &beam, n](const auto& point) {
+          // TODO(Ramiro): We're converting from range + bearing to cartesian points in the ROS node, but we want range
+          // + bearing here. We might want to make that conversion in the likelihood model instead, and let the
+          // measurement type be range, bearing instead of x, y.
 
-      // Compute the range according to the measurement.
-      const double z = std::sqrt(point.first * point.first + point.second * point.second);
+          // Compute the range according to the measurement.
+          const double z = std::sqrt(point.first * point.first + point.second * point.second);
 
-      // Compute range according to the map (raycasting).
-      const auto beam_bearing = Sophus::SO2d{point.first, point.second};
-      const double z_mean = beam.cast(beam_bearing).value_or(params_.beam_max_range);
+          // dirty hack to prevent SO2d from calculating the hypot again to normalize the vector.
+          auto beam_bearing = Sophus::SO2d{};
+          beam_bearing.data()[0] = point.first / z;
+          beam_bearing.data()[1] = point.second / z;
 
-      // 1: Correct range with local measurement noise.
-      const double eta_hit = 2. / (std::erf((params_.beam_max_range - z_mean) / (std::sqrt(2.) * params_.sigma_hit)) -
-                                   std::erf(-z_mean / (std::sqrt(2.) * params_.sigma_hit)));
-      const double d = (z - z_mean) / params_.sigma_hit;
-      const double n = 1. / (std::sqrt(2. * M_PI) * params_.sigma_hit);
-      double pz = params_.z_hit * eta_hit * n * std::exp(-(d * d) / 2.);
+          // Compute range according to the map (raycasting).
+          const double z_mean = beam.cast(beam_bearing).value_or(params_.beam_max_range);
+          // 1: Correct range with local measurement noise.
+          const double eta_hit =
+              2. / (std::erf((params_.beam_max_range - z_mean) / (std::sqrt(2.) * params_.sigma_hit)) -
+                    std::erf(-z_mean / (std::sqrt(2.) * params_.sigma_hit)));
+          const double d = (z - z_mean) / params_.sigma_hit;
+          double pz = params_.z_hit * eta_hit * n * std::exp(-(d * d) / 2.);
 
-      // 2: Unexpected objects.
-      if (z < z_mean) {
-        const double eta_short = 1. / (1. - std::exp(-params_.lambda_short * z_mean));
-        pz += params_.z_short * params_.lambda_short * eta_short * std::exp(-params_.lambda_short * z);
-      }
+          // 2: Unexpected objects.
+          if (z < z_mean) {
+            const double eta_short = 1. / (1. - std::exp(-params_.lambda_short * z_mean));
+            pz += params_.z_short * params_.lambda_short * eta_short * std::exp(-params_.lambda_short * z);
+          }
 
-      // 3 and 4: Max range return or random return.
-      if (z < params_.beam_max_range) {
-        pz += params_.z_rand / params_.beam_max_range;
-      } else {
-        pz += params_.z_max;
-      }
+          // 3 and 4: Max range return or random return.
+          if (z < params_.beam_max_range) {
+            pz += params_.z_rand / params_.beam_max_range;
+          } else {
+            pz += params_.z_max;
+          }
 
-      // TODO(glpuga): Investigate why AMCL and QuickMCL both use this formula for the weight.
-      // See https://github.com/Ekumen-OS/beluga/issues/153
-      return pz * pz * pz;
-    });
+          // TODO(glpuga): Investigate why AMCL and QuickMCL both use this formula for the weight.
+          // See https://github.com/Ekumen-OS/beluga/issues/153
+          return pz * pz * pz;
+        });
   }
 
   /// \copydoc LaserSensorModelInterface2d::update_sensor(measurement_type&& points)

--- a/beluga/include/beluga/sensor/data/regular_grid.hpp
+++ b/beluga/include/beluga/sensor/data/regular_grid.hpp
@@ -99,9 +99,8 @@ class BaseRegularGrid2 : public ciabatta::ciabatta_top<Derived> {
    * \return Plane coordinates of the cell centroid.
    */
   [[nodiscard]] Eigen::Vector2d coordinates_at(int xi, int yi) const {
-    return Eigen::Vector2d{
-        (static_cast<double>(xi) + 0.5) * this->self().resolution(),
-        (static_cast<double>(yi) + 0.5) * this->self().resolution()};
+    const auto resolution = this->self().resolution();
+    return Eigen::Vector2d{(static_cast<double>(xi) + 0.5), (static_cast<double>(yi) + 0.5)} * resolution;
   }
 
   /// Compute plane coordinates given grid cell coordinates.

--- a/beluga_amcl/src/amcl_node.cpp
+++ b/beluga_amcl/src/amcl_node.cpp
@@ -641,7 +641,7 @@ AmclNode::CallbackReturn AmclNode::on_activate(const rclcpp_lifecycle::State &)
     // Message filter that caches laser scan readings until it is possible to transform
     // from laser frame to odom frame and update the particle filter.
     laser_scan_filter_ = std::make_unique<tf2_ros::MessageFilter<sensor_msgs::msg::LaserScan>>(
-      *laser_scan_sub_, *tf_buffer_, get_parameter("odom_frame_id").as_string(), 50,
+      *laser_scan_sub_, *tf_buffer_, get_parameter("odom_frame_id").as_string(), 10,
       get_node_logging_interface(),
       get_node_clock_interface(),
       tf2::durationFromSec(1.0));


### PR DESCRIPTION
### Proposed changes

Minor optimizations to the tightest execution loops in the beam sensor model.

While these changes do improve performance a bit, they barely make a difference in the performance disadvantage we have against Nav2 AMCL. We are still missing something much bigger than these optimizations.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commmits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

These changes change the performance profile, as seen through `perf` from this:

![baseline_flamegraph](https://github.com/Ekumen-OS/beluga/assets/17802342/3d21fc32-7774-439d-bfb6-569f616b462e)

to this:

![commit6_flamegraph](https://github.com/Ekumen-OS/beluga/assets/17802342/a5052eda-9d5c-46bc-a76a-54917aa7c195)

**Note: These flamegraphs assume the changes in #199 have already been merged, since there are grid optimizations that are common to both Likelihood and Beam.**

Notice that relative to the unmodified the `beluga::Bresenham2i::Line` block of code (that had no changes done to it, neither in performance per execution nor in total number of executions), the overall time spent in the  `importance_weight` function seems to have reduced significantly.

Notice also the removal of the second stack call tower on the right, which appears to be related to queuing in the `MessageFilter`. 

However, these changes barely changed the cpu usage profile:

![beam_vs_beluga_par](https://github.com/Ekumen-OS/beluga/assets/17802342/65cb3df9-9097-4b2e-ad89-d1a2103f1b57)

![beam_vs_beluga_seq](https://github.com/Ekumen-OS/beluga/assets/17802342/5da9a187-dff2-4280-995c-98a74f01c906)

And the change is barely noticeable in the difference against `Nav2 AMCL`.

![beam_vs_beluga_vs_nav2_seq](https://github.com/Ekumen-OS/beluga/assets/17802342/9cdefcc5-df61-4a26-a875-d6daf97b2975)

While it's still possible our implementation of Bresenham is less peforming than Nav2's, even if we somehow reduced the tracing runtime cost to 0 with some magic implementation, that would still get us to perform at basically the same level as `Nav2 amcl`. To me that indicates that the problem is somewhere else. 

I suspect we are actually _doing more work_ than Nav2, but I haven't been able to find any proof of that.

Further work is still needed.
