### PR TITLE
Extend raycast microbenchmarks

### DIFF
--- a/beluga/test/beluga/include/beluga/test/raycasting.hpp
+++ b/beluga/test/beluga/include/beluga/test/raycasting.hpp
@@ -1,0 +1,81 @@
+// Copyright 2023 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BELUGA_TEST_RAYCASTING_HPP
+#define BELUGA_TEST_RAYCASTING_HPP
+
+#include <Eigen/Core>
+
+namespace beluga::testing {
+
+template <class Map>
+std::optional<double> raycast(const Map& map, Eigen::Vector2i source, Eigen::Vector2i target) {
+  const bool steep = std::abs(target.y() - source.y()) > std::abs(target.x() - source.x());
+
+  if (steep) {
+    std::swap(source.x(), source.y());
+    std::swap(target.x(), target.y());
+  }
+
+  const auto delta = Eigen::Vector2i{
+      std::abs(target.x() - source.x()),
+      std::abs(target.y() - source.y()),
+  };
+
+  int error = 0;
+
+  const auto step = Eigen::Vector2i{
+      source.x() < target.x() ? 1 : -1,
+      source.y() < target.y() ? 1 : -1,
+  };
+
+  auto current = source;
+
+  do {
+    if (steep) {
+      if (auto opt = map.data_at(current.y(), current.x()); opt.has_value()) {
+        if (opt.value()) {
+          break;
+        }
+      } else {
+        return std::nullopt;
+      }
+    } else {
+      if (auto opt = map.data_at(current.x(), current.y()); opt.has_value()) {
+        if (opt.value()) {
+          break;
+        }
+      } else {
+        return std::nullopt;
+      }
+    }
+
+    current.x() += step.x();
+    error += delta.y();
+    if (delta.x() <= 2 * error) {
+      current.y() += step.y();
+      error -= delta.x();
+    }
+
+    if (current.x() == (target.x() + step.x())) {
+      return std::nullopt;
+    }
+  } while (true);
+
+  return (current - source).cast<double>().norm() * map.resolution();
+}
+
+}  // namespace beluga::testing
+
+#endif

--- a/beluga/test/benchmark/benchmark_raycasting.cpp
+++ b/beluga/test/benchmark/benchmark_raycasting.cpp
@@ -50,12 +50,163 @@ BENCHMARK_CAPTURE(BM_Bresenham2i, Modified, beluga::Bresenham2i::kModified)
 
 using beluga::testing::StaticOccupancyGrid;
 
+template <std::size_t Rows, std::size_t Cols>
+struct BaselineGrid {
+ public:
+  explicit BaselineGrid(std::initializer_list<bool>, double resolution) : resolution_{resolution} {
+    std::fill(std::begin(data()), std::end(data()), false);
+  }
+
+  [[nodiscard]] auto origin() const { return Sophus::SE2d{}; }
+
+  [[nodiscard]] const auto& data() const { return data_; }
+
+  [[nodiscard]] auto& data() { return data_; }
+
+  [[nodiscard]] double resolution() const { return resolution_; }
+
+  [[nodiscard]] auto index_at(int i, int j) const {
+    return static_cast<std::size_t>(i) + static_cast<std::size_t>(j) * kWidth;
+  }
+
+  [[nodiscard]] bool contains(int i, int j) const {
+    return (i >= 0) && (i < static_cast<int>(kWidth)) && (j >= 0) && (j < static_cast<int>(kHeight));
+  }
+
+  [[nodiscard]] bool contains(Eigen::Vector2i cell) const { return contains(cell.x(), cell.y()); }
+
+  [[nodiscard]] auto data_at(std::size_t index) const {
+    return index < Rows * Cols ? std::make_optional(data()[index]) : std::nullopt;
+  }
+
+  [[nodiscard]] auto data_at(int i, int j) const {
+    return contains(i, j) ? std::make_optional(data()[index_at(i, j)]) : std::nullopt;
+  }
+
+  [[nodiscard]] auto data_at(const Eigen::Vector2i& pi) const { return data_at(pi.x(), pi.y()); }
+
+  [[nodiscard]] auto cell_near(double x, double y) const {
+    const auto xi = static_cast<int>(std::floor(x / resolution()));
+    const auto yi = static_cast<int>(std::floor(y / resolution()));
+    return Eigen::Vector2i{xi, yi};
+  }
+
+  [[nodiscard]] auto cell_near(const Eigen::Vector2d& p) const { return cell_near(p.x(), p.y()); }
+
+  [[nodiscard]] bool free_at(std::size_t index) const {
+    const auto data = data_at(index);
+    if (!data.has_value()) {
+      return false;
+    }
+    return !data.value();
+  }
+
+  [[nodiscard]] bool free_at(int xi, int yi) const { return free_at(index_at(xi, yi)); }
+
+  [[nodiscard]] bool free_at(const Eigen::Vector2i& pi) const { return free_at(pi.x(), pi.y()); }
+
+  [[nodiscard]] auto coordinates_at(int xi, int yi) const {
+    return resolution() * Eigen::Vector2d{
+                              (static_cast<double>(xi) + 0.5),
+                              (static_cast<double>(yi) + 0.5),
+                          };
+  }
+
+  [[nodiscard]] auto coordinates_at(const Eigen::Vector2i& pi) const { return coordinates_at(pi.x(), pi.y()); }
+
+ private:
+  double resolution_;
+  static constexpr std::size_t kWidth = Cols;
+  static constexpr std::size_t kHeight = Rows;
+
+  std::array<bool, Rows * Cols> data_;
+};
+
+template <class Map>
+std::optional<double> baseline_raycast(const Map& map, Eigen::Vector2i source, Eigen::Vector2i target) {
+  const bool steep = std::abs(target.y() - source.y()) > std::abs(target.x() - source.x());
+
+  if (steep) {
+    std::swap(source.x(), source.y());
+    std::swap(target.x(), target.y());
+  }
+
+  const auto delta = Eigen::Vector2i{
+      std::abs(target.x() - source.x()),
+      std::abs(target.y() - source.y()),
+  };
+
+  int error = 0;
+
+  const auto step = Eigen::Vector2i{
+      source.x() < target.x() ? 1 : -1,
+      source.y() < target.y() ? 1 : -1,
+  };
+
+  auto current = source;
+
+  do {
+    if (steep) {
+      if (map.data_at(current.y(), current.x()).value_or(true)) {
+        break;
+      }
+    } else {
+      if (map.data_at(current.x(), current.y()).value_or(true)) {
+        break;
+      }
+    }
+
+    if (current.x() == (target.x() + step.x())) {
+      return std::nullopt;
+    }
+
+    current.x() += step.x();
+    error += delta.y();
+    if (delta.x() <= 2 * error) {
+      current.y() += step.y();
+      error -= delta.x();
+    }
+  } while (true);
+
+  return (current - source).norm() * map.resolution();
+}
+
+template <template <std::size_t, std::size_t> class Grid>
+void BM_RayCasting2d_BaselineRaycast(benchmark::State& state) {
+  constexpr double kMaxRange = 100.0;
+  constexpr double kResolution = 0.05;
+
+  Grid<1280, 1280> map{{}, kResolution};
+
+  const auto n = static_cast<int>(state.range(0));
+  map.data()[map.index_at(n, n)] = true;
+
+  const auto source_pose = Eigen::Vector2d{1., 1.};
+  const auto beam_bearing = Sophus::SO2d{Sophus::Constants<double>::pi() / 4.};
+
+  const auto source = map.cell_near(source_pose);
+  const auto target = map.cell_near(source_pose + kMaxRange * beam_bearing.unit_complex());
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(baseline_raycast(map, source, target));
+  }
+
+  state.SetComplexityN(n);
+}
+
+BENCHMARK_TEMPLATE(BM_RayCasting2d_BaselineRaycast, BaselineGrid)->RangeMultiplier(2)->Range(128, 1024)->Complexity();
+BENCHMARK_TEMPLATE(BM_RayCasting2d_BaselineRaycast, StaticOccupancyGrid)
+    ->RangeMultiplier(2)
+    ->Range(128, 1024)
+    ->Complexity();
+
+template <template <std::size_t, std::size_t> class Grid>
 void BM_RayCasting2d(benchmark::State& state) {
   constexpr double kMaxRange = 100.0;
   constexpr double kResolution = 0.05;
 
   const auto n = static_cast<int>(state.range(0));
-  auto grid = StaticOccupancyGrid<1280, 1280>{{}, kResolution};
+  auto grid = Grid<1280, 1280>{{}, kResolution};
   grid.data()[grid.index_at(n, n)] = true;
 
   const auto source_pose = Sophus::SE2d{0., Eigen::Vector2d{1., 1.}};
@@ -67,6 +218,7 @@ void BM_RayCasting2d(benchmark::State& state) {
   state.SetComplexityN(n);
 }
 
-BENCHMARK(BM_RayCasting2d)->RangeMultiplier(2)->Range(128, 1024)->Complexity();
+BENCHMARK_TEMPLATE(BM_RayCasting2d, BaselineGrid)->RangeMultiplier(2)->Range(128, 1024)->Complexity();
+BENCHMARK_TEMPLATE(BM_RayCasting2d, StaticOccupancyGrid)->RangeMultiplier(2)->Range(128, 1024)->Complexity();
 
 }  // namespace


### PR DESCRIPTION
### Proposed changes

Related to #167.

This patch extends existing microbenchmarks to use as reference to compare the performance of the raycast and occupancy grid implementation.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

The baseline raycast and occupancy grid implementations were inspired by `nav2_amcl`.

Command to run:
```bash
colcon build --packages-up-to beluga && ./build/beluga/test/benchmark/benchmark_beluga --benchmark_filter=Ray
```

First results:
```
Running ./build/beluga/test/benchmark/benchmark_beluga
Run on (16 X 3300 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 512 KiB (x8)
  L3 Unified 16384 KiB (x1)
Load Average: 0.92, 0.81, 0.76
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
----------------------------------------------------------------------------------------------------
Benchmark                                                          Time             CPU   Iterations
----------------------------------------------------------------------------------------------------
BM_RayCasting2d_BaselineRaycast<BaselineGrid>/128               50.1 ns         50.1 ns     13820496
BM_RayCasting2d_BaselineRaycast<BaselineGrid>/256                112 ns          112 ns      6260214
BM_RayCasting2d_BaselineRaycast<BaselineGrid>/512                238 ns          238 ns      3116621
BM_RayCasting2d_BaselineRaycast<BaselineGrid>/1024               480 ns          480 ns      1427829
BM_RayCasting2d_BaselineRaycast<BaselineGrid>_BigO              0.47 N          0.47 N    
BM_RayCasting2d_BaselineRaycast<BaselineGrid>_RMS                  3 %             3 %    
BM_RayCasting2d_BaselineRaycast<StaticOccupancyGrid>/128         154 ns          154 ns      4331608
BM_RayCasting2d_BaselineRaycast<StaticOccupancyGrid>/256         322 ns          322 ns      2081307
BM_RayCasting2d_BaselineRaycast<StaticOccupancyGrid>/512         661 ns          661 ns      1064237
BM_RayCasting2d_BaselineRaycast<StaticOccupancyGrid>/1024       1405 ns         1405 ns       495128
BM_RayCasting2d_BaselineRaycast<StaticOccupancyGrid>_BigO       1.35 N          1.35 N    
BM_RayCasting2d_BaselineRaycast<StaticOccupancyGrid>_RMS           4 %             4 %    
BM_RayCasting2d<StaticOccupancyGrid>/128                         175 ns          175 ns      3977466
BM_RayCasting2d<StaticOccupancyGrid>/256                         364 ns          364 ns      1927759
BM_RayCasting2d<StaticOccupancyGrid>/512                         752 ns          752 ns       927877
BM_RayCasting2d<StaticOccupancyGrid>/1024                       1610 ns         1609 ns       437840
BM_RayCasting2d<StaticOccupancyGrid>_BigO                       0.16 NlgN       0.16 NlgN 
BM_RayCasting2d<StaticOccupancyGrid>_RMS                           4 %             4 % 
```

The baseline grid with the baseline raycast algorithm implementation is three times faster than those provided by the library.
Performance drop occurs when replacing `BaselineGrid` with `StaticOccupancyGrid`. More research is required, but I wanted to share the first results.