### PR TITLE
Change default threading mode to the less cpu-consuming one

### DIFF
--- a/beluga_amcl/src/amcl_node.cpp
+++ b/beluga_amcl/src/amcl_node.cpp
@@ -536,15 +536,15 @@ AmclNode::AmclNode(const rclcpp::NodeOptions & options)
       "Execution policy used to process particles [seq, par].";
     descriptor.read_only = true;
     auto execution_policy_string = declare_parameter(
-      "execution_policy", "par", descriptor);
+      "execution_policy", "seq", descriptor);
     try {
       execution_policy_ = beluga_amcl::execution::policy_from_string(execution_policy_string);
     } catch (const std::invalid_argument &) {
       RCLCPP_WARN_STREAM(
         get_logger(),
-        "execution_policy param should be [seq, par], got: " <<
-          execution_policy_string << "\nUsing the default parallel policy.");
-      execution_policy_ = std::execution::par;
+        "execution_policy param should be one of [seq, par], but got " <<
+          execution_policy_string << " instead, defaulting to using sequential policy.");
+      execution_policy_ = std::execution::seq;
     }
   }
 }


### PR DESCRIPTION
### Proposed changes

This PR proposes chaging the default threading mode to "sequential" on the basis that while parallel has lower latency, the required increase in CPU usage makes it expensive for users not concerned about latency in the lower end of particle counts. See #193 . 

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] All commmits have been signed for [DCO](https://developercertificate.org/)
