### PR TITLE
Disable branch and function coverage

### DIFF
--- a/.lcovrc
+++ b/.lcovrc
@@ -1,0 +1,27 @@
+# Specify size of tabs
+genhtml_num_spaces = 2
+
+# Include color legend in HTML output if non-zero
+genhtml_legend = 1
+
+# Include function coverage data display
+genhtml_function_coverage = 0
+
+# Include branch coverage data display
+genhtml_branch_coverage = 0
+
+# Specify if geninfo should try to automatically determine
+# the base-directory when collecting coverage data.
+geninfo_auto_base = 1
+
+# Specify whether to capture coverage data for external source
+# files
+geninfo_external = 0
+
+# Specify if function coverage data should be collected and
+# processed.
+lcov_function_coverage = 0
+
+# Specify if branch coverage data should be collected and
+# processed.
+lcov_branch_coverage = 0

--- a/beluga_amcl/src/amcl_node.cpp
+++ b/beluga_amcl/src/amcl_node.cpp
@@ -42,8 +42,6 @@
 #include "beluga_amcl/tf2_sophus.hpp"
 #include "beluga_amcl/private/execution_policy.hpp"
 
-// LCOV_EXCL_BR_START: Disable branch coverage.
-
 namespace beluga_amcl
 {
 
@@ -1077,5 +1075,3 @@ void AmclNode::global_localization_callback(
 }  // namespace beluga_amcl
 
 RCLCPP_COMPONENTS_REGISTER_NODE(beluga_amcl::AmclNode)
-
-// LCOV_EXCL_BR_STOP

--- a/tools/build-and-test.sh
+++ b/tools/build-and-test.sh
@@ -18,6 +18,8 @@
 
 [[ -z "${WITHIN_DEV}" ]] && echo -e "\033[1;33mWARNING: Try running this script inside the development container if you experience any issues.\033[0m"
 
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+
 set -o errexit
 
 ROS_PACKAGES="beluga beluga_amcl beluga_benchmark beluga_example beluga_system_tests"
@@ -36,7 +38,9 @@ colcon lcov-result --initial
 colcon test --packages-select ${ROS_PACKAGES} --event-handlers=console_cohesion+ --return-code-on-test-failure --mixin coverage-pytest
 echo "::endgroup::"
 
+LCOV_CONFIG_PATH=${SCRIPT_PATH}/../.lcovrc
+
 echo "::group::Generate code coverage results"
-colcon lcov-result --packages-select ${ROS_PACKAGES} --verbose
+colcon lcov-result --packages-select ${ROS_PACKAGES} --lcov-config-file ${LCOV_CONFIG_PATH} --verbose
 colcon coveragepy-result --packages-select ${ROS_PACKAGES} --verbose --coverage-report-args -m
 echo "::endgroup::"


### PR DESCRIPTION
### Proposed changes

Related to #101.

GCC records branch information for each line where a scope exit due to some thrown exception is possible. This sets too high a standard for us to meet. C++ templates may also add subtle distortions in coverage measurement, an so do inline functions.

This patch keeps only line coverage data collection while disabling branch and function coverage.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commmits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

https://stackoverflow.com/a/43726240
