### PR TITLE
Updates and fixes before updating performance report

### DIFF
--- a/beluga_amcl/src/amcl_node.cpp
+++ b/beluga_amcl/src/amcl_node.cpp
@@ -642,7 +642,7 @@ AmclNode::CallbackReturn AmclNode::on_activate(const rclcpp_lifecycle::State &)
       *laser_scan_sub_, *tf_buffer_, get_parameter("odom_frame_id").as_string(), 10,
       get_node_logging_interface(),
       get_node_clock_interface(),
-      tf2::durationFromSec(1.0));
+      tf2::durationFromSec(get_parameter("transform_tolerance").as_double()));
 
     using LaserCallback = std::function<void (sensor_msgs::msg::LaserScan::ConstSharedPtr)>;
     laser_scan_connection_ = laser_scan_filter_->registerCallback(

--- a/beluga_benchmark/beluga_benchmark/compare_results.py
+++ b/beluga_benchmark/beluga_benchmark/compare_results.py
@@ -86,7 +86,11 @@ def create_parameterized_series(results_path: Path):
             continue
         particles.append(int(m[1]))
         timem_results_output = timem_results.read_timem_output(dir)
-        rss, cpu = timem_results.get_timem_metrics_values(timem_results_output)
+        rss, cpu = (
+            timem_results.get_timem_metrics_values(timem_results_output)
+            if timem_results_output
+            else (None, None)
+        )
         peak_rss.append(rss)
         cpu_usage.append(cpu)
         run_evo_ape(dir)

--- a/beluga_benchmark/beluga_benchmark/timem_results.py
+++ b/beluga_benchmark/beluga_benchmark/timem_results.py
@@ -32,6 +32,8 @@ def read_timem_output(dir_path: Path):
             output = json.load(f)
     except (FileExistsError, FileNotFoundError) as ex:
         raise ScriptError(f"Failed to open file '{file.absolute()}': {ex}")
+    except json.decoder.JSONDecodeError:
+        return None
     return output['timemory']['timem'][0]
 
 

--- a/beluga_benchmark/scripts/benchmarking/parameterized_run
+++ b/beluga_benchmark/scripts/benchmarking/parameterized_run
@@ -27,14 +27,14 @@ Usage: $(basename $0) [...] <PARTICLES_0> ... <PARTICLES_N>\n
     [--initial-pose-yaw] Set initial yaw pose.\n
     [--params-file] Use a different params file, defaults to "beluga_example/config/params.yaml".\n
     [-b|--rosbag] Use a different rosbag, defaults to "beluga_example/bags/perfect_odometry".\n
-    [-f|--playback-frequency] Rosbag playback frequency, defaults to 3.\n
+    [-r|--playback-rate] Rosbag playback frequency, defaults to 1.\n
     [-p|--profile] Create a perf cpu profile of the benchmark.
 EOM
 
 set +o errexit
 VALID_ARGS=$( \
-    OPTERR=1 getopt -o b:f:ph --long \
-    package:,executable:,initial-pose-x:,initial-pose-y:,initial-pose-yaw:,rosbag:,playback-frequency:,params-file:,profile,help \
+    OPTERR=1 getopt -o b:r:ph --long \
+    package:,executable:,initial-pose-x:,initial-pose-y:,initial-pose-yaw:,rosbag:,playback-rate:,params-file:,profile,help \
     -- "$@")
 RET_CODE=$?
 set -o errexit
@@ -68,8 +68,8 @@ while : ;do
         EXTRA_LAUNCH_ARGS="$EXTRA_LAUNCH_ARGS rosbag_path:=$2"
         shift 2
         ;;
-    -f | --playback-frequency)
-        EXTRA_LAUNCH_ARGS="$EXTRA_LAUNCH_ARGS playback_frequency:=$2"
+    -r | --playback-rate)
+        EXTRA_LAUNCH_ARGS="$EXTRA_LAUNCH_ARGS playback_rate:=$2"
         shift 2
         ;;
     --params-file)

--- a/beluga_example/launch/example_rosbag_launch.py
+++ b/beluga_example/launch/example_rosbag_launch.py
@@ -62,7 +62,7 @@ def get_launch_arguments():
         ),
         DeclareLaunchArgument(
             name='playback_rate',
-            default_value='3.',
+            default_value='1.',
             description='Rate used to playback the bag.',
         ),
         DeclareLaunchArgument(


### PR DESCRIPTION
### Proposed changes

- Changes the tolerance value for the MessageFilter to match the value used by Nav2 (the same value as `transform_tolerance`).
- Fixes a problem in the `compare_results.py` script that causes it to fail to plot a whole series of data if a single bad sample is present (this happens frequently when capturing AMCL performance data in the high-end of particle counts).
- Fix a mismatch in the naming of the `playback_rate` command line argument of the `parameterized_run` script and the launchfile.
- Changes the default playback rate to be 1x to avoid distorting the captured CPU stats.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commmits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

The following plots show that the performance at 1x replay rate both before and after the change of the MessageFilter tolerance is the same.

![likelihood_before_vs_after](https://github.com/Ekumen-OS/beluga/assets/17802342/61aedabc-c010-41e8-949a-9e931cec939d)

![beam_before_vs_after](https://github.com/Ekumen-OS/beluga/assets/17802342/96af93a5-03bb-4f08-a827-2f0726a4f0c5)

