### PR TITLE
Support `beluga` builds on Ubuntu Focal

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,6 +14,9 @@ component_management:
         # The minimum coverage ratio to send a success status is the base
         # commit coverage (pull request base or parent commit).
         target: auto
+        # If the patch coverage is 100% and there are no unexpected changes,
+        # pass the project status.
+        removed_code_behavior: fully_covered_patch
 
   individual_components:
     - component_id: package_beluga

--- a/beluga/cmake/Config.cmake.in
+++ b/beluga/cmake/Config.cmake.in
@@ -8,4 +8,6 @@ find_dependency(TBB REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 
+set(@PROJECT_NAME@_LIBRARIES @PROJECT_NAME@::@PROJECT_NAME@)
+
 check_required_components($@PROJECT_NAME@)

--- a/beluga/include/beluga/algorithm/raycasting/bresenham.hpp
+++ b/beluga/include/beluga/algorithm/raycasting/bresenham.hpp
@@ -77,22 +77,22 @@ class Bresenham2i {
       using reference = Vector2&;
 
       /// Default constructor.
-      iterator() noexcept = default;
+      iterator() = default;
 
       /// Default copy constructor.
-      iterator(const iterator&) noexcept = default;
+      iterator(const iterator& other) = default;
 
       /// Default move constructor.
-      iterator(iterator&&) noexcept = default;
+      iterator(iterator&&) = default;  // NOLINT(performance-noexcept-move-constructor)
 
       /// Default copy assignment operator overload.
-      iterator& operator=(const iterator&) noexcept = default;
+      iterator& operator=(const iterator&) = default;
 
       /// Default move assignment operator overload.
-      iterator& operator=(iterator&&) noexcept = default;
+      iterator& operator=(iterator&&) = default;  // NOLINT(performance-noexcept-move-constructor)
 
       /// Constructs a Bresenham's 2D `line` iterator.
-      explicit iterator(const Line* line) noexcept : current_point_(line->p0_), x_(line->p0_.x()), y_(line->p0_.y()) {
+      explicit iterator(const Line* line) : current_point_(line->p0_), x_(line->p0_.x()), y_(line->p0_.y()) {
         xspan_ = line->p1_.x() - line->p0_.x();
         xstep_ = static_cast<decltype(xspan_)>(1);
         if (xspan_ < 0) {
@@ -215,19 +215,19 @@ class Bresenham2i {
     };
 
     /// Constructs point line.
-    Line() noexcept = default;
+    Line() = default;
 
     /// Default copy constructor.
-    Line(const Line&) noexcept = default;
+    Line(const Line&) = default;
 
     /// Default move constructor.
-    Line(Line&&) noexcept = default;
+    Line(Line&&) = default;  // NOLINT(performance-noexcept-move-constructor)
 
     /// Default copy assignment operator overload.
-    Line& operator=(const Line&) noexcept = default;
+    Line& operator=(const Line&) = default;
 
     /// Default move assignment operator overload.
-    Line& operator=(Line&&) noexcept = default;
+    Line& operator=(Line&&) = default;  // NOLINT(performance-noexcept-move-constructor)
 
     /// Constructs a Bresenham's 2D line drawing.
     /**
@@ -235,7 +235,7 @@ class Bresenham2i {
      * \param p1 Line end point in 2D space.
      * \param variant Bresenham's algorithm variant to be used.
      */
-    explicit Line(Vector2 p0, Vector2 p1, Variant variant) noexcept
+    explicit Line(Vector2 p0, Vector2 p1, Variant variant)
         : p0_(std::move(p0)), p1_(std::move(p1)), variant_(variant) {}
 
     /// Returns an iterator pointing to the first point in the line.

--- a/beluga/include/beluga/algorithm/raycasting/bresenham.hpp
+++ b/beluga/include/beluga/algorithm/raycasting/bresenham.hpp
@@ -79,18 +79,6 @@ class Bresenham2i {
       /// Default constructor.
       iterator() = default;
 
-      /// Default copy constructor.
-      iterator(const iterator& other) = default;
-
-      /// Default move constructor.
-      iterator(iterator&&) = default;  // NOLINT(performance-noexcept-move-constructor)
-
-      /// Default copy assignment operator overload.
-      iterator& operator=(const iterator&) = default;
-
-      /// Default move assignment operator overload.
-      iterator& operator=(iterator&&) = default;  // NOLINT(performance-noexcept-move-constructor)
-
       /// Constructs a Bresenham's 2D `line` iterator.
       explicit iterator(const Line* line) : current_point_(line->p0_), x_(line->p0_.x()), y_(line->p0_.y()) {
         xspan_ = line->p1_.x() - line->p0_.x();
@@ -216,18 +204,6 @@ class Bresenham2i {
 
     /// Constructs point line.
     Line() = default;
-
-    /// Default copy constructor.
-    Line(const Line&) = default;
-
-    /// Default move constructor.
-    Line(Line&&) = default;  // NOLINT(performance-noexcept-move-constructor)
-
-    /// Default copy assignment operator overload.
-    Line& operator=(const Line&) = default;
-
-    /// Default move assignment operator overload.
-    Line& operator=(Line&&) = default;  // NOLINT(performance-noexcept-move-constructor)
 
     /// Constructs a Bresenham's 2D line drawing.
     /**

--- a/beluga/include/beluga/mixin.hpp
+++ b/beluga/include/beluga/mixin.hpp
@@ -87,7 +87,8 @@ template <class Interface, template <class...> class Base, class... Args>
 auto make_mixin(Args&&... args) {
   return visit_everything(
       [](auto&&... args) {
-        using Concrete = mixin_from_descriptors_t<Base, filter<is_descriptor, decltype(args)...>>;
+        using InnerArgs = list<decltype(args)...>;  // avoid https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86859
+        using Concrete = mixin_from_descriptors_t<Base, filter<is_descriptor, InnerArgs>>;
         return std::apply(
             [](auto&&... args) -> std::unique_ptr<Interface> { return std::make_unique<Concrete>(args...); },
             make_tuple_with<is_not_descriptor>(params_or_forward(args)...));

--- a/beluga/include/beluga/random/multivariate_normal_distribution.hpp
+++ b/beluga/include/beluga/random/multivariate_normal_distribution.hpp
@@ -45,7 +45,7 @@ class MultivariateNormalDistribution {
   using Scalar = typename Matrix::Scalar;
 
   /// The eigen column vector from Matrix.
-  using Vector = typename Eigen::Vector<typename Matrix::Scalar, Matrix::RowsAtCompileTime>;
+  using Vector = typename Eigen::Matrix<typename Matrix::Scalar, Matrix::RowsAtCompileTime, 1>;
 
   /// Multivariate normal distribution parameter set class.
   class Param {

--- a/beluga/include/beluga/sensor/data/occupancy_grid.hpp
+++ b/beluga/include/beluga/sensor/data/occupancy_grid.hpp
@@ -181,6 +181,6 @@ class BaseOccupancyGrid2 : public BaseLinearGrid2<Derived> {
   }
 };
 
-};  // namespace beluga
+}  // namespace beluga
 
 #endif

--- a/beluga/package.xml
+++ b/beluga/package.xml
@@ -21,7 +21,7 @@
 
   <test_depend>clang-format</test_depend>
   <test_depend>clang-tidy</test_depend>
-  <test_depend>google_benchmark_vendor</test_depend>
+  <test_depend>benchmark</test_depend>
   <test_depend>gtest</test_depend>
   <test_depend>libgmock-dev</test_depend>
 

--- a/beluga/test/beluga/algorithm/raycasting/test_bresenham.cpp
+++ b/beluga/test/beluga/algorithm/raycasting/test_bresenham.cpp
@@ -24,6 +24,26 @@
 
 namespace beluga {
 
+TEST(Bresenham, MultiPassGuarantee) {
+  // See comparison between iterators in
+  // https://en.cppreference.com/w/cpp/iterator/forward_iterator
+  const auto algorithm = Bresenham2i{Bresenham2i::kStandard};
+
+  const auto line = algorithm({0, 0}, {5, 5});
+  for (auto it1 = line.begin(), it2 = line.begin(); it1 != line.end(); ++it1, ++it2) {
+    ASSERT_EQ(it1, it2);
+  }
+
+  // Test that iterating over the sequence using an independent
+  // iterator doesn't change what an existing iterator refers to.
+  auto it3 = line.begin();
+  ++it3;
+  auto it4 = it3;
+  const auto expected_value = *it3;
+  ++it4;
+  ASSERT_EQ(expected_value, *it3);
+}
+
 TEST(Bresenham, Standard) {
   auto algorithm = Bresenham2i{Bresenham2i::kStandard};
 

--- a/beluga/test/beluga/algorithm/test_estimation.cpp
+++ b/beluga/test/beluga/algorithm/test_estimation.cpp
@@ -41,12 +41,10 @@ TEST_F(CovarianceCalculation, UniformWeightOverload) {
       cov_matrix = cov(translations)
   */
   const auto translation_vector = std::vector{
-      Eigen::Vector2<double>{0, 0}, Eigen::Vector2<double>{2, 2}, Eigen::Vector2<double>{0, 0},
-      Eigen::Vector2<double>{2, 2}, Eigen::Vector2<double>{0, 0}, Eigen::Vector2<double>{2, 0},
-      Eigen::Vector2<double>{0, 2}, Eigen::Vector2<double>{2, 2}, Eigen::Vector2<double>{0, 2},
-      Eigen::Vector2<double>{2, 0},
+      Vector2d{0, 0}, Vector2d{2, 2}, Vector2d{0, 0}, Vector2d{2, 2}, Vector2d{0, 0},
+      Vector2d{2, 0}, Vector2d{0, 2}, Vector2d{2, 2}, Vector2d{0, 2}, Vector2d{2, 0},
   };
-  const auto translation_mean = Eigen::Vector2<double>{1, 1};
+  const auto translation_mean = Vector2d{1, 1};
   const auto covariance = beluga::calculate_covariance(translation_vector, translation_mean);
   ASSERT_NEAR(covariance(0, 0), 1.1111, 0.001);
   ASSERT_NEAR(covariance(0, 1), 0.2222, 0.001);
@@ -66,15 +64,13 @@ TEST_F(CovarianceCalculation, NonUniformWeightOverload) {
       weighted_cov_matrix =  (normalized_weight .* deviations)' * deviations ./ (1 - sum(normalized_weight.^2))
   */
   const auto translation_vector = std::vector{
-      Eigen::Vector2<double>{0, 0}, Eigen::Vector2<double>{2, 2}, Eigen::Vector2<double>{0, 0},
-      Eigen::Vector2<double>{2, 2}, Eigen::Vector2<double>{0, 0}, Eigen::Vector2<double>{2, 0},
-      Eigen::Vector2<double>{0, 2}, Eigen::Vector2<double>{2, 2}, Eigen::Vector2<double>{0, 2},
-      Eigen::Vector2<double>{2, 0},
+      Vector2d{0, 0}, Vector2d{2, 2}, Vector2d{0, 0}, Vector2d{2, 2}, Vector2d{0, 0},
+      Vector2d{2, 0}, Vector2d{0, 2}, Vector2d{2, 2}, Vector2d{0, 2}, Vector2d{2, 0},
   };
   auto weights = std::vector{0.0, 1.0, 2.0, 1.0, 0.0, 1.0, 2.0, 1.0, 0.0, 1.0};
   const auto total_weight = std::accumulate(weights.begin(), weights.end(), 0.0);
   std::for_each(weights.begin(), weights.end(), [total_weight](auto& weight) { weight /= total_weight; });
-  const auto translation_mean = Eigen::Vector2<double>{1.1111, 1.1111};
+  const auto translation_mean = Vector2d{1.1111, 1.1111};
   const auto covariance = beluga::calculate_covariance(translation_vector, weights, translation_mean);
   ASSERT_NEAR(covariance(0, 0), 1.1765, 0.001);
   ASSERT_NEAR(covariance(0, 1), 0.1176, 0.001);

--- a/beluga/test/beluga/include/beluga/test/utils/eigen_initializers.hpp
+++ b/beluga/test/beluga/include/beluga/test/utils/eigen_initializers.hpp
@@ -1,0 +1,37 @@
+// Copyright 2023 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BELUGA_TEST_UTILS_EIGEN_INITIALIZERS_HPP
+#define BELUGA_TEST_UTILS_EIGEN_INITIALIZERS_HPP
+
+#include <initializer_list>
+
+#include <range/v3/view/enumerate.hpp>
+
+namespace testing {
+
+template <typename Matrix, typename Scalar = typename Matrix::Scalar>
+Matrix as(std::initializer_list<std::initializer_list<Scalar>> rows) {
+  Matrix matrix;
+  for (auto&& [i, row] : ranges::views::enumerate(rows)) {
+    for (auto&& [j, coeff] : ranges::views::enumerate(row)) {
+      matrix(static_cast<typename Matrix::StorageIndex>(i), static_cast<typename Matrix::StorageIndex>(j)) = coeff;
+    }
+  }
+  return matrix;
+}
+
+}  // namespace testing
+
+#endif

--- a/beluga/test/beluga/include/beluga/test/utils/sophus_matchers.hpp
+++ b/beluga/test/beluga/include/beluga/test/utils/sophus_matchers.hpp
@@ -19,14 +19,15 @@
 
 #include <sophus/se2.hpp>
 #include <sophus/so2.hpp>
+#include <sophus/types.hpp>
 
 namespace testing {
 
 template <class Scalar>
-inline auto Vector2Eq(const Eigen::Vector2<Scalar>& expected) {
+inline auto Vector2Eq(const Sophus::Vector2<Scalar>& expected) {
   return AllOf(
-      Property("x", &Eigen::Vector2<Scalar>::x, DoubleNear(expected.x(), 0.001)),
-      Property("y", &Eigen::Vector2<Scalar>::y, DoubleNear(expected.y(), 0.001)));
+      Property("x", &Sophus::Vector2<Scalar>::x, DoubleNear(expected.x(), 0.001)),
+      Property("y", &Sophus::Vector2<Scalar>::y, DoubleNear(expected.y(), 0.001)));
 }
 
 template <class Scalar>
@@ -42,7 +43,7 @@ inline auto SE2Eq(const Sophus::SE2<Scalar>& expected) {
 }
 
 template <class Scalar>
-inline auto SE2Eq(const Sophus::SO2<Scalar>& rotation, const Eigen::Vector2<Scalar>& translation) {
+inline auto SE2Eq(const Sophus::SO2<Scalar>& rotation, const Sophus::Vector2<Scalar>& translation) {
   return SE2Eq<Scalar>(Sophus::SE2<Scalar>{rotation, translation});
 }
 

--- a/beluga/test/beluga/mixin/test_utility.cpp
+++ b/beluga/test/beluga/mixin/test_utility.cpp
@@ -21,9 +21,11 @@ namespace {
 struct Object {};
 
 TEST(Filter, FilterWithPredicate) {
-  using arithmetic_list = beluga::mixin::filter<std::is_arithmetic, int, float, Object, bool>;
+  using arithmetic_list = beluga::mixin::filter<std::is_arithmetic, beluga::mixin::list<int, float, Object, bool>>;
   static_assert(std::is_same_v<arithmetic_list, beluga::mixin::list<int, float, bool>>);
-  static_assert(std::is_same_v<beluga::mixin::filter<std::is_void, int, float, Object, bool>, beluga::mixin::list<>>);
+  static_assert(
+      std::is_same_v<
+          beluga::mixin::filter<std::is_void, beluga::mixin::list<int, float, Object, bool>>, beluga::mixin::list<>>);
 }
 
 TEST(IsVariant, Qualified) {

--- a/beluga/test/beluga/random/test_multivariate_normal_distribution.cpp
+++ b/beluga/test/beluga/random/test_multivariate_normal_distribution.cpp
@@ -20,6 +20,7 @@
 #include <range/v3/view/generate.hpp>
 #include <range/v3/view/take_exactly.hpp>
 
+#include "beluga/test/utils/eigen_initializers.hpp"
 #include "beluga/test/utils/sophus_matchers.hpp"
 
 namespace {
@@ -42,8 +43,7 @@ TEST(MultivariateNormalDistribution, NegativeEigenvaluesMatrix) {
 }
 
 TEST(MultivariateNormalDistribution, NonSymmetricMatrix) {
-  Eigen::Matrix3d covariance;
-  covariance << 1.0, 2.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0;
+  auto covariance = testing::as<Eigen::Matrix3d>({{1.0, 2.0, 0.0}, {1.0, 1.0, 0.0}, {0.0, 0.0, 1.0}});
   EXPECT_THROW(beluga::MultivariateNormalDistribution{covariance}, std::runtime_error);
 }
 
@@ -57,8 +57,8 @@ class MultivariateNormalDistributionWithParam
     : public ::testing::TestWithParam<std::pair<Eigen::Vector2d, Eigen::Matrix2d>> {};
 
 TEST_P(MultivariateNormalDistributionWithParam, DistributionCovarianceAndMean) {
-  const Eigen::Vector2d expected_mean = std::get<0>(GetParam());
-  const Eigen::Matrix2d expected_covariance = std::get<1>(GetParam());
+  const Eigen::Vector2d& expected_mean = std::get<0>(GetParam());
+  const Eigen::Matrix2d& expected_covariance = std::get<1>(GetParam());
   auto distribution = beluga::MultivariateNormalDistribution{expected_mean, expected_covariance};
   const auto sequence = ranges::views::generate([&]() {
                           static auto generator = std::mt19937{std::random_device()()};
@@ -81,9 +81,9 @@ INSTANTIATE_TEST_SUITE_P(
     MeanCovariancePairs,
     MultivariateNormalDistributionWithParam,
     testing::Values(
-        std::make_pair(Eigen::Vector2d{1.0, 2.0}, Eigen::Matrix2d{{0.0, 0.0}, {0.0, 0.0}}),
-        std::make_pair(Eigen::Vector2d{3.0, 4.0}, Eigen::Matrix2d{{1.0, 0.0}, {0.0, 1.0}}),
-        std::make_pair(Eigen::Vector2d{3.0, 4.0}, Eigen::Matrix2d{{1.5, -0.3}, {-0.3, 1.5}}),
-        std::make_pair(Eigen::Vector2d{5.0, 6.0}, Eigen::Matrix2d{{2.0, 0.7}, {0.7, 2.0}})));
+        std::make_pair(Eigen::Vector2d{1.0, 2.0}, testing::as<Eigen::Matrix2d>({{0.0, 0.0}, {0.0, 0.0}})),
+        std::make_pair(Eigen::Vector2d{3.0, 4.0}, testing::as<Eigen::Matrix2d>({{1.0, 0.0}, {0.0, 1.0}})),
+        std::make_pair(Eigen::Vector2d{3.0, 4.0}, testing::as<Eigen::Matrix2d>({{1.5, -0.3}, {-0.3, 1.5}})),
+        std::make_pair(Eigen::Vector2d{5.0, 6.0}, testing::as<Eigen::Matrix2d>({{2.0, 0.7}, {0.7, 2.0}}))));
 
 }  // namespace

--- a/beluga/test/beluga/resampling_policies/test_resample_on_motion_policy.cpp
+++ b/beluga/test/beluga/resampling_policies/test_resample_on_motion_policy.cpp
@@ -223,8 +223,8 @@ TEST_F(ResampleOnMotionPolicyTests, RandomWalkingTest) {
   ASSERT_FALSE(uut.do_resampling_vote());
 
   for (const auto& test_tuple : relative_motions) {
-    const auto relative_movement = std::get<0>(test_tuple);
-    const auto expected_resampling_flag = std::get<1>(test_tuple);
+    const auto& relative_movement = std::get<0>(test_tuple);
+    const auto& expected_resampling_flag = std::get<1>(test_tuple);
     // apply the relative motion on top of the current pose and test the result
     current_pose = current_pose * relative_movement;
     uut.update_motion(current_pose);

--- a/beluga/test/benchmark/CMakeLists.txt
+++ b/beluga/test/benchmark/CMakeLists.txt
@@ -6,10 +6,11 @@ add_executable(benchmark_beluga
   benchmark_raycasting.cpp
   benchmark_sampling.cpp
   benchmark_spatial_hash.cpp
-  benchmark_tuple_vector.cpp)
+  benchmark_tuple_vector.cpp
+  benchmark_main.cpp)
 target_include_directories(benchmark_beluga PRIVATE ../beluga/include)
 target_link_libraries(benchmark_beluga
-  PUBLIC benchmark::benchmark_main
+  PUBLIC benchmark::benchmark
   PRIVATE ${PROJECT_NAME} beluga_compile_options)
 set(TEST_RESULTS_DIR "${CMAKE_BINARY_DIR}/test_results/${PROJECT_NAME}")
 file(MAKE_DIRECTORY ${TEST_RESULTS_DIR})

--- a/beluga/test/benchmark/benchmark_main.cpp
+++ b/beluga/test/benchmark/benchmark_main.cpp
@@ -1,0 +1,17 @@
+// Copyright 2023 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "benchmark/benchmark.h"
+
+BENCHMARK_MAIN();

--- a/beluga/test/benchmark/benchmark_raycasting.cpp
+++ b/beluga/test/benchmark/benchmark_raycasting.cpp
@@ -122,17 +122,33 @@ void BM_RayCasting2d_BaselineRaycast(benchmark::State& state) {
 }
 
 BENCHMARK_TEMPLATE(BM_RayCasting2d_BaselineRaycast, BaselineGrid)
-    ->ArgsProduct({
-        {0, 1, 2},
-        {128, 256, 512, 1024},
-    })
+    ->Args({0, 128})
+    ->Args({0, 256})
+    ->Args({0, 512})
+    ->Args({0, 1024})
+    ->Args({1, 128})
+    ->Args({1, 256})
+    ->Args({1, 512})
+    ->Args({1, 1024})
+    ->Args({2, 128})
+    ->Args({2, 256})
+    ->Args({2, 512})
+    ->Args({2, 1024})
     ->Complexity();
 
 BENCHMARK_TEMPLATE(BM_RayCasting2d_BaselineRaycast, StaticOccupancyGrid)
-    ->ArgsProduct({
-        {0, 1, 2},
-        {128, 256, 512, 1024},
-    })
+    ->Args({0, 128})
+    ->Args({0, 256})
+    ->Args({0, 512})
+    ->Args({0, 1024})
+    ->Args({1, 128})
+    ->Args({1, 256})
+    ->Args({1, 512})
+    ->Args({1, 1024})
+    ->Args({2, 128})
+    ->Args({2, 256})
+    ->Args({2, 512})
+    ->Args({2, 1024})
     ->Complexity();
 
 template <template <std::size_t, std::size_t> class Grid>
@@ -158,17 +174,33 @@ void BM_RayCasting2d(benchmark::State& state) {
 }
 
 BENCHMARK_TEMPLATE(BM_RayCasting2d, BaselineGrid)
-    ->ArgsProduct({
-        {0, 1, 2},
-        {128, 256, 512, 1024},
-    })
+    ->Args({0, 128})
+    ->Args({0, 256})
+    ->Args({0, 512})
+    ->Args({0, 1024})
+    ->Args({1, 128})
+    ->Args({1, 256})
+    ->Args({1, 512})
+    ->Args({1, 1024})
+    ->Args({2, 128})
+    ->Args({2, 256})
+    ->Args({2, 512})
+    ->Args({2, 1024})
     ->Complexity();
 
 BENCHMARK_TEMPLATE(BM_RayCasting2d, StaticOccupancyGrid)
-    ->ArgsProduct({
-        {0, 1, 2},
-        {128, 256, 512, 1024},
-    })
+    ->Args({0, 128})
+    ->Args({0, 256})
+    ->Args({0, 512})
+    ->Args({0, 1024})
+    ->Args({1, 128})
+    ->Args({1, 256})
+    ->Args({1, 512})
+    ->Args({1, 1024})
+    ->Args({2, 128})
+    ->Args({2, 256})
+    ->Args({2, 512})
+    ->Args({2, 1024})
     ->Complexity();
 
 }  // namespace


### PR DESCRIPTION
### Proposed changes

Connected to #95. Before ROS Noetic support, we need `beluga` building on Ubuntu Focal: compiling with `gcc` 9.3, using an older version of Eigen3. This patch performs the necessary compatibility changes, with no functional side effects (or none that I have observed).

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works(*)
- [x] I have added necessary documentation (if appropriate)
- [x] All commmits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

(*) Note there is no development container or CI workflow here to validate these changes effectively help in Ubuntu Focal. That'll come in follow-up PRs, to limit scope.