### PR TITLE
Fix map to odom transform calculation

### DIFF
--- a/beluga_amcl/src/amcl_node.cpp
+++ b/beluga_amcl/src/amcl_node.cpp
@@ -998,7 +998,7 @@ void AmclNode::laser_callback(
       tf2::durationFromSec(get_parameter("transform_tolerance").as_double());
     message.header.frame_id = get_parameter("global_frame_id").as_string();
     message.child_frame_id = get_parameter("odom_frame_id").as_string();
-    message.transform = tf2::toMsg(odom_to_base_transform * pose.inverse());
+    message.transform = tf2::toMsg(pose * odom_to_base_transform.inverse());
     tf_broadcaster_->sendTransform(message);
   }
 }


### PR DESCRIPTION
### Proposed changes

This bug was not caught before because map to odom in our `perfect_odometry` bag is the identity.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commmits have been signed for [DCO](https://developercertificate.org/)
