### PR TITLE
Remove simulated odometry noise

### DIFF
--- a/beluga_example/models/turtlebot.model.yaml
+++ b/beluga_example/models/turtlebot.model.yaml
@@ -17,7 +17,6 @@ plugins:
     odom_frame_id: odom
     pub_rate: 10
     enable_odom_pub: true
-    odom_pose_noise: [0.005, 0.005, 0.01]
 
   - type: ModelTfPublisher
     name: tf_publisher

--- a/beluga_example/package.xml
+++ b/beluga_example/package.xml
@@ -17,6 +17,7 @@
 
   <exec_depend>beluga_amcl</exec_depend>
   <exec_depend>flatland_server</exec_depend>
+  <exec_depend>flatland_plugins</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>nav2_amcl</exec_depend>
   <exec_depend>nav2_lifecycle_manager</exec_depend>


### PR DESCRIPTION
### Proposed changes

Flatland odometry noise causes strange behavior that is not replicable in a real life setup. Lowering the noise parameters does not make this more usable. This patch also adds a missing execution dependency.

Current settings:

```
odom_pose_noise: [0.005, 0.005, 0.01]
```

https://github.com/Ekumen-OS/beluga/assets/33042669/9b5ab4e0-e776-41e2-82db-bc696df097a5

Lowered noise parameters:
```
odom_pose_noise: [0.00005, 0.00005, 0.000001]
```
https://github.com/Ekumen-OS/beluga/assets/33042669/8cf343ab-9ed8-4056-a379-6dd6c51289f2


#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] All commmits have been signed for [DCO](https://developercertificate.org/)
