### PR TITLE
Configure vcstool and use docker multi-stage builds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "flatland"]
-  path = flatland
-  url = git@github.com:avidbots/flatland.git
-  branch = ros2-humble

--- a/docker/files/humble.repos
+++ b/docker/files/humble.repos
@@ -1,0 +1,5 @@
+repositories:
+  flatland:
+    type: git
+    url: https://github.com/avidbots/flatland.git
+    version: ros2-humble

--- a/docker/files/rolling.repos
+++ b/docker/files/rolling.repos
@@ -1,0 +1,9 @@
+repositories:
+  flatland:
+    type: git
+    url: https://github.com/avidbots/flatland.git
+    version: ros2-humble
+  navigation2:
+    type: git
+    url: https://github.com/ros-planning/navigation2.git
+    version: main

--- a/docker/images/humble/Dockerfile
+++ b/docker/images/humble/Dockerfile
@@ -1,4 +1,18 @@
-FROM ros:humble-ros-base-jammy
+FROM ros:humble-ros-base-jammy AS cacher
+
+WORKDIR /ws/src
+
+COPY docker/files/humble.repos .
+RUN vcs import < humble.repos
+
+COPY . beluga/
+
+RUN mkdir -p /tmp/ws/src \
+  && find ./ -name "package.xml" | xargs cp --parents -t /tmp/ws/src \
+  && find ./ -name "COLCON_IGNORE" | xargs cp --parents -t /tmp/ws/src \
+  || true
+
+FROM ros:humble-ros-base-jammy AS builder
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -73,12 +87,14 @@ RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mix
 COPY --chown=$USER:$GROUP docker/files/colcon_defaults.yaml /home/$USER/.colcon/defaults.yaml
 RUN mkdir -p /home/$USER/.ccache $USER_WS/src
 
-COPY --chown=$USER:$GROUP . $USER_WS/src/beluga
+COPY --from=cacher --chown=$USER:$GROUP /tmp/ws/ $USER_WS/
 
 RUN sudo apt-get update \
   && rosdep update \
   && rosdep install -i --from-path src -y \
   && sudo rm -rf /var/lib/apt/lists/*
+
+COPY --from=cacher --chown=$USER:$GROUP /ws/ $USER_WS/
 
 ENV WITHIN_DEV 1
 

--- a/docker/images/rolling/Dockerfile
+++ b/docker/images/rolling/Dockerfile
@@ -1,4 +1,18 @@
-FROM ros:rolling-ros-base-jammy
+FROM ros:rolling-ros-base-jammy AS cacher
+
+WORKDIR /ws/src
+
+COPY docker/files/rolling.repos .
+RUN vcs import < rolling.repos
+
+COPY . beluga/
+
+RUN mkdir -p /tmp/ws/src \
+  && find ./ -name "package.xml" | xargs cp --parents -t /tmp/ws/src \
+  && find ./ -name "COLCON_IGNORE" | xargs cp --parents -t /tmp/ws/src \
+  || true
+
+FROM ros:rolling-ros-base-jammy as builder
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -73,14 +87,14 @@ RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mix
 COPY --chown=$USER:$GROUP docker/files/colcon_defaults.yaml /home/$USER/.colcon/defaults.yaml
 RUN mkdir -p /home/$USER/.ccache $USER_WS/src
 
-COPY --chown=$USER:$GROUP . $USER_WS/src/beluga
-
-RUN git -C $USER_WS/src clone https://github.com/ros-planning/navigation2.git
+COPY --from=cacher --chown=$USER:$GROUP /tmp/ws/ $USER_WS/
 
 RUN sudo apt-get update && sudo apt-get -y dist-upgrade \
   && rosdep update \
   && rosdep install -i --from-path src -y --skip-keys 'slam_toolbox' \
   && sudo rm -rf /var/lib/apt/lists/*
+
+COPY --from=cacher --chown=$USER:$GROUP /ws/ $USER_WS/
 
 ENV WITHIN_DEV 1
 


### PR DESCRIPTION
### Proposed changes

Related to #95 and mentioned #210.

This patch removes `git submodules` from the repository in favor of `vcstool` so we can better handle dependencies for different ROS versions. Additionally, it makes use of Docker's multistage builds to cache package manifest files.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commmits have been signed for [DCO](https://developercertificate.org/)
