### PR TITLE
Add ROS Noetic CI infrastructure

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -14,9 +14,9 @@ jobs:
   lint:
     runs-on: ubuntu-22.04
     container:
-      image: ros:rolling-ros-base
+      image: ros:humble-ros-base
     env:
-      ROS_DISTRO: rolling
+      ROS_DISTRO: humble
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -47,7 +47,6 @@ jobs:
         ros_distro:
           - noetic
           - humble
-          - rolling
     container:
       image: ros:${{ matrix.ros_distro }}-ros-base
     steps:

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -11,12 +11,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-test-lint:
+  lint:
     runs-on: ubuntu-22.04
-    env:
-      ROS_DISTRO: humble
     container:
-      image: ros:humble-ros-base-jammy
+      image: ros:rolling-ros-base
+    env:
+      ROS_DISTRO: rolling
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          path: ${{ github.workspace }}/src/beluga
+
+      - name: Lint
+        working-directory: ${{ github.workspace }}/src/beluga/
+        shell: bash
+        run: |
+          source /opt/ros/${{ env.ROS_DISTRO }}/setup.sh
+          pre-commit run --all-files --verbose --show-diff-on-failure
+
+  build-test:
+    runs-on: ubuntu-22.04
+    needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        ros_distro:
+          - noetic
+          - humble
+          - rolling
+    container:
+      image: ros:${{ matrix.ros_distro }}-ros-base
     steps:
       - name: Install debian packages
         run: |
@@ -35,7 +60,7 @@ jobs:
       - name: Install dependencies
         run: |
           rosdep update
-          rosdep install --rosdistro ${{ env.ROS_DISTRO }} -r --from-paths src/ --default-yes --ignore-src --dependency-types build --dependency-types test
+          rosdep install --rosdistro ${{ matrix.ros_distro }} -r --from-paths src/ --default-yes --ignore-src --dependency-types build --dependency-types test
           colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/c75e4b34a3959524564afb584e2aa33c7eec323c/index.yaml
           colcon mixin update default
 
@@ -65,20 +90,13 @@ jobs:
           fail_ci_if_error: true
           verbose: true
 
-      - name: Lint
-        working-directory: ${{ github.workspace }}/src/beluga/
-        shell: bash
-        run: |
-          source /opt/ros/${{ env.ROS_DISTRO }}/setup.sh
-          pre-commit run --all-files --verbose --show-diff-on-failure
-
       - name: Static analysis
         working-directory: ${{ github.workspace }}
         run: ./src/beluga/tools/run-clang-tidy.sh
 
   deploy-docs:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-    needs: build-test-lint
+    needs: build-test
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout documentation branch

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install clang-tidy lcov python3-colcon-common-extensions python3-colcon-mixin python3-colcon-coveragepy-result python3-pip -y
-          sudo apt-get install doxygen graphviz perl texlive-base texlive-binaries -y
+          sudo apt-get install git doxygen graphviz perl texlive-base texlive-binaries -y
 
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install debian packages
         run: |
           sudo apt-get update
-          sudo apt-get install clang-tidy lcov python3-colcon-coveragepy-result python3-pip -y
+          sudo apt-get install clang-tidy lcov python3-colcon-common-extensions python3-colcon-coveragepy-result python3-pip -y
           sudo apt-get install doxygen graphviz perl texlive-base texlive-binaries -y
 
       - name: Checkout repository

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           path: ${{ github.workspace }}/src/beluga
 
+      - name: Install python packages
+        run: pip install pre-commit==2.20.0
+
       - name: Lint
         working-directory: ${{ github.workspace }}/src/beluga/
         shell: bash
@@ -55,7 +58,7 @@ jobs:
           path: ${{ github.workspace }}/src/beluga
 
       - name: Install python packages
-        run: pip install colcon-lcov-result==0.5.0 pre-commit==2.20.0
+        run: pip install colcon-lcov-result==0.5.0
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -47,6 +47,9 @@ jobs:
         ros_distro:
           - noetic
           - humble
+        include:
+          - ros_distro: humble
+            upload_artifacts: true
     container:
       image: ros:${{ matrix.ros_distro }}-ros-base
     steps:
@@ -87,6 +90,7 @@ jobs:
           name: docs
           path: ./build/beluga/docs/html/
           retention-days: 7
+        if: ${{ matrix.upload_artifacts }}
 
       - name: Upload code coverage report
         uses: codecov/codecov-action@v3
@@ -96,6 +100,7 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: true
           verbose: true
+        if: ${{ matrix.upload_artifacts }}
 
       - name: Static analysis
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           path: ${{ github.workspace }}/src/beluga
 
+      - name: Install debian packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install python3-pip -y
+
       - name: Install python packages
         run: pip install pre-commit==2.20.0
 

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install debian packages
         run: |
           sudo apt-get update
-          sudo apt-get install clang-tidy lcov python3-colcon-common-extensions python3-colcon-coveragepy-result python3-pip -y
+          sudo apt-get install clang-tidy lcov python3-colcon-common-extensions python3-colcon-mixin python3-colcon-coveragepy-result python3-pip -y
           sudo apt-get install doxygen graphviz perl texlive-base texlive-binaries -y
 
       - name: Checkout repository

--- a/.github/workflows/docker_ci_pipeline.yml
+++ b/.github/workflows/docker_ci_pipeline.yml
@@ -17,6 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         ros_distro:
+          - noetic
           - humble
           - rolling
         platform:

--- a/beluga/CMakeLists.txt
+++ b/beluga/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 
 add_library(beluga_compile_options INTERFACE)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  target_compile_options(beluga_compile_options INTERFACE -Wall -Wconversion -Werror -Wextra -Wpedantic)
+  target_compile_options(beluga_compile_options INTERFACE -Wall -Wconversion -Werror -Wextra -Wpedantic -Wno-gnu-zero-variadic-macro-arguments)
 endif()
 
 find_package(Eigen3 REQUIRED NO_MODULE)

--- a/beluga/test/beluga/type_traits/test_strongly_typed_numeric.cpp
+++ b/beluga/test/beluga/type_traits/test_strongly_typed_numeric.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+
 #include <beluga/type_traits/strongly_typed_numeric.hpp>
 
 namespace beluga {

--- a/docker/images/noetic/Dockerfile
+++ b/docker/images/noetic/Dockerfile
@@ -2,10 +2,15 @@ FROM ros:noetic-ros-base-focal AS cacher
 
 WORKDIR /ws/src
 
-COPY beluga beluga/beluga
+COPY . beluga/
+RUN touch beluga/beluga_amcl/CATKIN_IGNORE \
+   beluga/beluga_benchmark/CATKIN_IGNORE \
+   beluga/beluga_example/CATKIN_IGNORE \
+   beluga/beluga_system_tests/CATKIN_IGNORE
 
 RUN mkdir -p /tmp/ws/src \
   && find ./ -name "package.xml" | xargs cp --parents -t /tmp/ws/src \
+  && find ./ -name "CATKIN_IGNORE" | xargs cp --parents -t /tmp/ws/src \
   && find ./ -name "COLCON_IGNORE" | xargs cp --parents -t /tmp/ws/src \
   || true
 

--- a/docker/images/noetic/Dockerfile
+++ b/docker/images/noetic/Dockerfile
@@ -1,0 +1,117 @@
+FROM ros:noetic-ros-base-focal AS cacher
+
+WORKDIR /ws/src
+
+COPY beluga beluga/beluga
+
+RUN mkdir -p /tmp/ws/src \
+  && find ./ -name "package.xml" | xargs cp --parents -t /tmp/ws/src \
+  && find ./ -name "COLCON_IGNORE" | xargs cp --parents -t /tmp/ws/src \
+  || true
+
+FROM ros:noetic-ros-base-focal AS builder
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update \
+  && apt-get install --no-install-recommends -y \
+    ccache \
+    curl \
+    doxygen \
+    gdb \
+    git \
+    graphviz \
+    lcov \
+    linux-cloud-tools-generic \
+    linux-tools-common \
+    linux-tools-generic \
+    perl \
+    python3-colcon-common-extensions \
+    python3-colcon-mixin \
+    python3-colcon-coveragepy-result \
+    python3-colcon-lcov-result \
+    python3-pip \
+    texlive-base \
+    texlive-binaries \
+    tmux \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install precommit dependencies
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
+    -o /usr/share/keyrings/ros-archive-keyring.gpg
+
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" \
+    | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+RUN apt-get update \
+  && apt-get install --no-install-recommends -y \
+    ros-rolling-ament-copyright ros-rolling-ament-uncrustify \
+    ros-rolling-ament-cpplint ros-rolling-ament-flake8 \
+    ros-rolling-ament-pep257
+
+RUN sed -i '/^source.*/ s%^%source "/opt/ros/rolling/setup.bash"\n%' /ros_entrypoint.sh
+
+# Fix for the RViz black screen issue.
+# TODO(nahuel): Remove this when the Mesa version available
+# in Ubuntu 22.04 is 22.3.5 or greater.
+# See https://github.com/Ekumen-OS/beluga/issues/123
+RUN apt-get update \
+  && apt-get install --no-install-recommends -y \
+    software-properties-common \
+  && add-apt-repository -y ppa:kisak/kisak-mesa \
+  && apt-get install --no-install-recommends -y \
+    libegl-mesa0 libglx-mesa0 \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN pip install \
+  evo==1.21.0 \
+  pre-commit==2.20.0 \
+  # Note: Installing timemory takes a long time.
+  timemory==3.3.0rc4
+
+# Check if perf is working, if not replace it with the perf version available
+RUN perf help || ( \
+  mv /usr/bin/perf /usr/bin/perf.bkp && \
+  ln -s $(ls -d /usr/lib/linux-tools/* | tail -n1)/perf /usr/bin/perf)
+
+ARG USER=developer
+ARG GROUP=ekumen
+
+RUN addgroup --gid 1000 $GROUP \
+  && adduser --uid 1000 --ingroup $GROUP --home /home/$USER --shell /bin/sh --disabled-password --gecos "" $USER \
+  && adduser $USER sudo \
+  && echo "$USER ALL=NOPASSWD: ALL" >> /etc/sudoers.d/$USER
+
+COPY docker/files/fixuid_config.yml /etc/fixuid/config.yml
+RUN curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - \
+  && chmod 4755 /usr/local/bin/fixuid \
+  && cd /etc/fixuid \
+  && sed -i "s/_USER_/$USER/" config.yml \
+  && sed -i "s/_GROUP_/$GROUP/" config.yml
+
+RUN cd /opt && git clone https://github.com/brendangregg/FlameGraph
+
+USER $USER:$GROUP
+
+ENV USER_WS /ws
+
+WORKDIR $USER_WS
+
+RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml \
+  && colcon mixin update default
+COPY --chown=$USER:$GROUP docker/files/colcon_defaults.yaml /home/$USER/.colcon/defaults.yaml
+RUN mkdir -p /home/$USER/.ccache $USER_WS/src
+
+COPY --from=cacher --chown=$USER:$GROUP /tmp/ws/ $USER_WS/
+
+RUN sudo apt-get update \
+  && rosdep update \
+  && rosdep install -i -y --from-path src \
+  && sudo rm -rf /var/lib/apt/lists/*
+
+COPY --from=cacher --chown=$USER:$GROUP /ws/ $USER_WS/
+
+ENV WITHIN_DEV 1
+
+ENV SHELL /bin/bash
+ENTRYPOINT ["fixuid", "-q", "/ros_entrypoint.sh", "/bin/bash"]

--- a/tools/build-and-test.sh
+++ b/tools/build-and-test.sh
@@ -22,7 +22,11 @@ SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 
 set -o errexit
 
-ROS_PACKAGES="beluga beluga_amcl beluga_benchmark beluga_example beluga_system_tests"
+if [ "${ROS_DISTRO}" != "noetic" ]; then
+    ROS_PACKAGES="beluga beluga_amcl beluga_benchmark beluga_example beluga_system_tests"
+else
+    ROS_PACKAGES="beluga"
+fi
 
 source /opt/ros/${ROS_DISTRO}/setup.sh
 

--- a/tools/run-clang-tidy.sh
+++ b/tools/run-clang-tidy.sh
@@ -20,7 +20,11 @@
 
 set -o errexit -o xtrace
 
-ROS_PACKAGES="beluga beluga_system_tests"
+if [ "${ROS_DISTRO}" != "noetic" ]; then
+    ROS_PACKAGES="beluga beluga_system_tests"
+else
+    ROS_PACKAGES="beluga"
+fi
 
 source /opt/ros/${ROS_DISTRO}/setup.sh
 colcon build --packages-up-to ${ROS_PACKAGES} --event-handlers=console_cohesion+ --symlink-install --mixin ccache


### PR DESCRIPTION
### Proposed changes

Follow-up PR after #209. This patch adds CI infrastructure to build `beluga` (and only `beluga` for now) against ROS Noetic in Ubuntu Focal.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)
