### PR TITLE
Fix flaky transform test

### DIFF
--- a/beluga_amcl/test/test_amcl_node.cpp
+++ b/beluga_amcl/test/test_amcl_node.cpp
@@ -849,9 +849,9 @@ TEST_F(TestNode, TransformValue)
     amcl_node->set_parameter(rclcpp::Parameter{"initial_pose.y", 2.0});
     amcl_node->set_parameter(
       rclcpp::Parameter{"initial_pose.yaw", Sophus::Constants<double>::pi() / 3});
-    amcl_node->set_parameter(rclcpp::Parameter{"initial_pose.covariance_x", 0.001});
-    amcl_node->set_parameter(rclcpp::Parameter{"initial_pose.covariance_y", 0.001});
-    amcl_node->set_parameter(rclcpp::Parameter{"initial_pose.covariance_yaw", 0.001});
+    amcl_node->set_parameter(rclcpp::Parameter{"initial_pose.covariance_x", 0.0});
+    amcl_node->set_parameter(rclcpp::Parameter{"initial_pose.covariance_y", 0.0});
+    amcl_node->set_parameter(rclcpp::Parameter{"initial_pose.covariance_yaw", 0.0});
     amcl_node->set_parameter(rclcpp::Parameter{"initial_pose.covariance_xy", 0.0});
     amcl_node->set_parameter(rclcpp::Parameter{"initial_pose.covariance_xyaw", 0.0});
     amcl_node->set_parameter(rclcpp::Parameter{"initial_pose.covariance_yyaw", 0.0});


### PR DESCRIPTION
### Proposed changes

The test added in #212 turned out to be flaky.

The failure rate is ~20% and can be evaluated with this command:

```bash
$ ./build/beluga_amcl/test/test_amcl_node --gtest_repeat=1000 --gtest_filter=TestNode.TransformValue 2> /dev/null | grep "1 FAILED" | wc -l
189
```

The error looks like this:

```bash
/ws/src/beluga/beluga_amcl/test/test_amcl_node.cpp:877: Failure
The difference between transform.translation().x() and -2.00 is 0.010270443192699208, which exceeds 0.01, where
transform.translation().x() evaluates to -2.0102704431926992,
-2.00 evaluates to -2, and
0.01 evaluates to 0.01.
/ws/src/beluga/beluga_amcl/test/test_amcl_node.cpp:878: Failure
The difference between transform.translation().y() and -2.00 is 0.01017702160925138, which exceeds 0.01, where
transform.translation().y() evaluates to -1.9898229783907486,
-2.00 evaluates to -2, and
0.01 evaluates to 0.01.
```

After this change, we get 0% failure rate:

```bash
$ ./build/beluga_amcl/test/test_amcl_node --gtest_repeat=1000 --gtest_filter=TestNode.TransformValue 2> /dev/null | grep "1 FAILED" | wc -l
0
```

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)
