### PR TITLE
Fix timem output in parameterized runs

### DIFF
--- a/beluga_benchmark/scripts/benchmarking/parameterized_run
+++ b/beluga_benchmark/scripts/benchmarking/parameterized_run
@@ -121,7 +121,7 @@ for N in $@; do
     touch timem-output.json  # if not, it's creating a directory by error and not a json....
     script -qefc " \
         ros2 launch beluga_example perfect_odometry.launch.xml amcl.max_particles:=${N} amcl.min_particles:=${N} \
-            record_bag:=True bagfile_output:=rosbag prefix:=\"timem -o timem-output --\" $EXTRA_LAUNCH_ARGS" \
+            record_bag:=True bagfile_output:=rosbag localization_prefix:=\"timem -o timem-output --\" $EXTRA_LAUNCH_ARGS" \
         /dev/null &
     while ! pgrep "$EXECUTABLE_NAME" > /dev/null; do
         sleep .1


### PR DESCRIPTION
### Proposed changes

Fixes a bug introduced in #211 that prevented us from generating timem output.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)
