### PR TITLE
Speed up docker builds in CI

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -90,9 +90,9 @@ jobs:
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
           update_packager_index: false
-          override_cache_key: ccache-${{ matrix.ros_distro }}-${{ github.head_ref || github.ref }}
+          override_cache_key: ccache-${{ matrix.ros_distro }}-${{ github.head_ref || github.ref_name }}
           override_cache_key_fallback: |
-            ccache-${{ matrix.ros_distro }}-${{ github.base_ref || github.ref }}
+            ccache-${{ matrix.ros_distro }}-${{ github.base_ref || github.ref_name }}
             ccache-${{ matrix.ros_distro }}-
 
       - name: Build and test

--- a/.github/workflows/docker_ci_pipeline.yml
+++ b/.github/workflows/docker_ci_pipeline.yml
@@ -20,16 +20,9 @@ jobs:
           - noetic
           - humble
           - rolling
-        platform:
-          - linux/amd64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          submodules: recursive
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -40,5 +33,6 @@ jobs:
           context: .
           file: docker/images/${{ matrix.ros_distro }}/Dockerfile
           tags: ekumen/beluga-${{ matrix.ros_distro }}-dev:latest
-          platforms: ${{ matrix.platform }}
           push: false
+          cache-from: type=gha,scope=docker-${{ matrix.ros_distro }}-${{ github.head_ref || github.ref_name }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.ros_distro }}-${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/docker_ci_pipeline.yml
+++ b/.github/workflows/docker_ci_pipeline.yml
@@ -34,5 +34,7 @@ jobs:
           file: docker/images/${{ matrix.ros_distro }}/Dockerfile
           tags: ekumen/beluga-${{ matrix.ros_distro }}-dev:latest
           push: false
-          cache-from: type=gha,scope=docker-${{ matrix.ros_distro }}-${{ github.head_ref || github.ref_name }}
+          cache-from: |
+            type=gha,scope=docker-${{ matrix.ros_distro }}-${{ github.head_ref || github.ref_name }}
+            type=gha,scope=docker-${{ matrix.ros_distro }}-${{ github.base_ref || github.ref_name }}
           cache-to: type=gha,mode=max,scope=docker-${{ matrix.ros_distro }}-${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/docker_ci_pipeline.yml
+++ b/.github/workflows/docker_ci_pipeline.yml
@@ -37,4 +37,4 @@ jobs:
           cache-from: |
             type=gha,scope=docker-${{ matrix.ros_distro }}-${{ github.head_ref || github.ref_name }}
             type=gha,scope=docker-${{ matrix.ros_distro }}-${{ github.base_ref || github.ref_name }}
-          cache-to: type=gha,mode=max,scope=docker-${{ matrix.ros_distro }}-${{ github.head_ref || github.ref_name }}
+          cache-to: type=gha,mode=min,scope=docker-${{ matrix.ros_distro }}-${{ github.head_ref || github.ref_name }}

--- a/docker/images/humble/Dockerfile
+++ b/docker/images/humble/Dockerfile
@@ -12,6 +12,31 @@ RUN mkdir -p /tmp/ws/src \
   && find ./ -name "COLCON_IGNORE" | xargs cp --parents -t /tmp/ws/src \
   || true
 
+FROM ros:humble-ros-base-jammy AS timem-builder
+
+RUN apt-get update \
+  && apt-get install --no-install-recommends -y \
+    git \
+    python3-pip \
+    python3-venv \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt
+
+RUN git clone -b develop https://github.com/NERSC/timemory.git \
+  && cd timemory \
+  && git checkout 415650ee26f358218908983c87212b620c3a0328 \
+  && python3 -m venv env \
+  && . env/bin/activate \
+  && pip install -r requirements.txt \
+  && cmake -B ./build \
+    -DTIMEMORY_INSTALL_HEADERS=OFF \
+    -DTIMEMORY_INSTALL_CONFIG=OFF \
+    -DTIMEMORY_INSTALL_ALL=OFF \
+    -DTIMEMORY_BUILD_TIMEM=ON \
+    . \
+  && cmake --build ./build --target timem
+
 FROM ros:humble-ros-base-jammy AS builder
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -29,6 +54,7 @@ RUN apt-get update \
     python3-colcon-coveragepy-result \
     python3-colcon-lcov-result \
     python3-pip \
+    python3-venv \
     tmux \
   && rm -rf /var/lib/apt/lists/*
 
@@ -46,9 +72,10 @@ RUN apt-get update \
 
 RUN pip install \
   evo==1.21.0 \
-  pre-commit==2.20.0 \
-  # Note: Installing timemory takes a long time.
-  timemory==3.3.0rc4
+  pre-commit==2.20.0
+
+COPY --from=timem-builder --chown=$USER:$GROUP /opt/timemory/ /opt/timemory
+RUN . /opt/timemory/env/bin/activate && cmake --build /opt/timemory/build --target install
 
 # Check if perf is working, if not replace it with the perf version available
 RUN perf help || ( \

--- a/docker/images/humble/Dockerfile
+++ b/docker/images/humble/Dockerfile
@@ -17,8 +17,6 @@ FROM ros:humble-ros-base-jammy AS timem-builder
 RUN apt-get update \
   && apt-get install --no-install-recommends -y \
     git \
-    python3-pip \
-    python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt
@@ -26,9 +24,6 @@ WORKDIR /opt
 RUN git clone -b develop https://github.com/NERSC/timemory.git \
   && cd timemory \
   && git checkout 415650ee26f358218908983c87212b620c3a0328 \
-  && python3 -m venv env \
-  && . env/bin/activate \
-  && pip install -r requirements.txt \
   && cmake -B ./build \
     -DTIMEMORY_INSTALL_HEADERS=OFF \
     -DTIMEMORY_INSTALL_CONFIG=OFF \
@@ -54,7 +49,6 @@ RUN apt-get update \
     python3-colcon-coveragepy-result \
     python3-colcon-lcov-result \
     python3-pip \
-    python3-venv \
     tmux \
   && rm -rf /var/lib/apt/lists/*
 
@@ -75,7 +69,7 @@ RUN pip install \
   pre-commit==2.20.0
 
 COPY --from=timem-builder --chown=$USER:$GROUP /opt/timemory/ /opt/timemory
-RUN . /opt/timemory/env/bin/activate && cmake --build /opt/timemory/build --target install
+RUN cmake --build /opt/timemory/build --target install
 
 # Check if perf is working, if not replace it with the perf version available
 RUN perf help || ( \

--- a/docker/images/noetic/Dockerfile
+++ b/docker/images/noetic/Dockerfile
@@ -22,6 +22,31 @@ RUN mkdir -p /tmp/ws/src \
   && find ./ -name "COLCON_IGNORE" | xargs cp --parents -t /tmp/ws/src \
   || true
 
+FROM ros:noetic-ros-base-focal AS timem-builder
+
+RUN apt-get update \
+  && apt-get install --no-install-recommends -y \
+    git \
+    python3-pip \
+    python3-venv \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt
+
+RUN git clone -b develop https://github.com/NERSC/timemory.git \
+  && cd timemory \
+  && git checkout 415650ee26f358218908983c87212b620c3a0328 \
+  && python3 -m venv env \
+  && . env/bin/activate \
+  && pip install -r requirements.txt \
+  && cmake -B ./build \
+    -DTIMEMORY_INSTALL_HEADERS=OFF \
+    -DTIMEMORY_INSTALL_CONFIG=OFF \
+    -DTIMEMORY_INSTALL_ALL=OFF \
+    -DTIMEMORY_BUILD_TIMEM=ON \
+    . \
+  && cmake --build ./build --target timem
+
 FROM ros:noetic-ros-base-focal AS builder
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -41,6 +66,7 @@ RUN apt-get update \
     python3-colcon-lcov-result \
     python3-colcon-mixin \
     python3-pip \
+    python3-venv \
     tmux \
   && rm -rf /var/lib/apt/lists/*
 
@@ -62,9 +88,10 @@ RUN sed -i '/^source.*/ s%^%source "/opt/ros/rolling/setup.bash"\n%' /ros_entryp
 
 RUN pip install \
   evo==1.21.0 \
-  pre-commit==2.20.0 \
-  # Note: Installing timemory takes a long time.
-  timemory==3.3.0rc4
+  pre-commit==2.20.0
+
+COPY --from=timem-builder --chown=$USER:$GROUP /opt/timemory/ /opt/timemory
+RUN . /opt/timemory/env/bin/activate && cmake --build /opt/timemory/build --target install
 
 # Check if perf is working, if not replace it with the perf version available
 RUN perf help || ( \

--- a/docker/images/noetic/Dockerfile
+++ b/docker/images/noetic/Dockerfile
@@ -27,8 +27,6 @@ FROM ros:noetic-ros-base-focal AS timem-builder
 RUN apt-get update \
   && apt-get install --no-install-recommends -y \
     git \
-    python3-pip \
-    python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt
@@ -36,9 +34,6 @@ WORKDIR /opt
 RUN git clone -b develop https://github.com/NERSC/timemory.git \
   && cd timemory \
   && git checkout 415650ee26f358218908983c87212b620c3a0328 \
-  && python3 -m venv env \
-  && . env/bin/activate \
-  && pip install -r requirements.txt \
   && cmake -B ./build \
     -DTIMEMORY_INSTALL_HEADERS=OFF \
     -DTIMEMORY_INSTALL_CONFIG=OFF \
@@ -66,7 +61,6 @@ RUN apt-get update \
     python3-colcon-lcov-result \
     python3-colcon-mixin \
     python3-pip \
-    python3-venv \
     tmux \
   && rm -rf /var/lib/apt/lists/*
 
@@ -91,7 +85,7 @@ RUN pip install \
   pre-commit==2.20.0
 
 COPY --from=timem-builder --chown=$USER:$GROUP /opt/timemory/ /opt/timemory
-RUN . /opt/timemory/env/bin/activate && cmake --build /opt/timemory/build --target install
+RUN cmake --build /opt/timemory/build --target install
 
 # Check if perf is working, if not replace it with the perf version available
 RUN perf help || ( \

--- a/docker/images/rolling/Dockerfile
+++ b/docker/images/rolling/Dockerfile
@@ -12,6 +12,31 @@ RUN mkdir -p /tmp/ws/src \
   && find ./ -name "COLCON_IGNORE" | xargs cp --parents -t /tmp/ws/src \
   || true
 
+FROM ros:rolling-ros-base-jammy AS timem-builder
+
+RUN apt-get update \
+  && apt-get install --no-install-recommends -y \
+    git \
+    python3-pip \
+    python3-venv \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt
+
+RUN git clone -b develop https://github.com/NERSC/timemory.git \
+  && cd timemory \
+  && git checkout 415650ee26f358218908983c87212b620c3a0328 \
+  && python3 -m venv env \
+  && . env/bin/activate \
+  && pip install -r requirements.txt \
+  && cmake -B ./build \
+    -DTIMEMORY_INSTALL_HEADERS=OFF \
+    -DTIMEMORY_INSTALL_CONFIG=OFF \
+    -DTIMEMORY_INSTALL_ALL=OFF \
+    -DTIMEMORY_BUILD_TIMEM=ON \
+    . \
+  && cmake --build ./build --target timem
+
 FROM ros:rolling-ros-base-jammy AS builder
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -29,6 +54,7 @@ RUN apt-get update \
     python3-colcon-coveragepy-result \
     python3-colcon-lcov-result \
     python3-pip \
+    python3-venv \
     tmux \
   && rm -rf /var/lib/apt/lists/*
 
@@ -46,9 +72,10 @@ RUN apt-get update \
 
 RUN pip install \
   evo==1.21.0 \
-  pre-commit==2.20.0 \
-  # Note: Installing timemory takes a long time.
-  timemory==3.3.0rc4
+  pre-commit==2.20.0
+
+COPY --from=timem-builder --chown=$USER:$GROUP /opt/timemory/ /opt/timemory
+RUN . /opt/timemory/env/bin/activate && cmake --build /opt/timemory/build --target install
 
 # Check if perf is working, if not replace it with the perf version available
 RUN perf help || ( \

--- a/docker/images/rolling/Dockerfile
+++ b/docker/images/rolling/Dockerfile
@@ -17,8 +17,6 @@ FROM ros:rolling-ros-base-jammy AS timem-builder
 RUN apt-get update \
   && apt-get install --no-install-recommends -y \
     git \
-    python3-pip \
-    python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt
@@ -26,9 +24,6 @@ WORKDIR /opt
 RUN git clone -b develop https://github.com/NERSC/timemory.git \
   && cd timemory \
   && git checkout 415650ee26f358218908983c87212b620c3a0328 \
-  && python3 -m venv env \
-  && . env/bin/activate \
-  && pip install -r requirements.txt \
   && cmake -B ./build \
     -DTIMEMORY_INSTALL_HEADERS=OFF \
     -DTIMEMORY_INSTALL_CONFIG=OFF \
@@ -54,7 +49,6 @@ RUN apt-get update \
     python3-colcon-coveragepy-result \
     python3-colcon-lcov-result \
     python3-pip \
-    python3-venv \
     tmux \
   && rm -rf /var/lib/apt/lists/*
 
@@ -75,7 +69,7 @@ RUN pip install \
   pre-commit==2.20.0
 
 COPY --from=timem-builder --chown=$USER:$GROUP /opt/timemory/ /opt/timemory
-RUN . /opt/timemory/env/bin/activate && cmake --build /opt/timemory/build --target install
+RUN cmake --build /opt/timemory/build --target install
 
 # Check if perf is working, if not replace it with the perf version available
 RUN perf help || ( \


### PR DESCRIPTION
### Proposed changes

Build `timem` (and only `timem`) in a separate stage in our Dockerfiles.
Use [GitHub Actions cache backend](https://docs.docker.com/build/cache/backends/) in the Docker CI pipeline.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)
