### PR TITLE
Change default AMCL params

### DIFF
--- a/beluga_amcl/config/Amcl.cfg
+++ b/beluga_amcl/config/Amcl.cfg
@@ -38,7 +38,7 @@ gen.add(
     "base_frame_id", str_t, 0,
     "The name of the coordinate frame "
     "to use for the robot base.",
-    default="base_footprint"
+    default="base_link"
 )
 
 gen.add(
@@ -58,7 +58,7 @@ gen.add(
     "use_map_topic", bool_t, 0,
     "Whether to subscribe to the map topic or "
     "call the map service to get a map to localize on.",
-    default=True
+    default=False
 )
 
 gen.add(
@@ -91,14 +91,14 @@ gen.add(
     "recovery_alpha_slow", double_t, 0,
     "Exponential decay rate for the slow average weight filter, "
     "used in deciding when to recover by adding random poses.",
-    default=0.001, min=0., max=1.
+    default=0, min=0., max=1.
 )
 
 gen.add(
     "recovery_alpha_fast", double_t, 0,
     "Exponential decay rate for the fast average weight filter, "
     "used in deciding when to recover by adding random poses.",
-    default=0.1, min=0., max=1.)
+    default=0, min=0., max=1.)
 
 gen.add(
     "kld_err", double_t, 0,
@@ -111,28 +111,28 @@ gen.add(
     "kld_z", double_t, 0,
     "Upper standard normal quantile for P, where P is the probability "
     "that the error in the estimated distribution will be less than pf_err "
-    "in KLD resampling.", default=3.0
+    "in KLD resampling.", default=0.99
 )
 
 gen.add(
     "spatial_resolution_x", double_t, 0,
     "Resolution in meters for the X axis used to divide "
     "the space in buckets for KLD resampling.",
-    default=0.1, min=0.
+    default=0.5, min=0.
 )
 
 gen.add(
     "spatial_resolution_y", double_t, 0,
     "Resolution in meters for the Y axis used to divide "
     "the space in buckets for KLD resampling.",
-    default=0.1, min=0.
+    default=0.5, min=0.
 )
 
 gen.add(
     "spatial_resolution_theta", double_t, 0,
     "Resolution in radians for the theta axis to divide "
     "the space in buckets for KLD resampling.",
-    default=math.pi / 4, min=0., max=2 * math.pi
+    default=(10 * math.pi / 180), min=0., max=2 * math.pi
 )
 
 gen.add(
@@ -254,25 +254,25 @@ gen.add(
 gen.add(
     "laser_z_hit", double_t, 0,
     "Mixture weight for the probability of hitting an obstacle.",
-    default=0.5, min=0., max=1.
+    default=0.95, min=0., max=1.
 )
 
 gen.add(
     "laser_z_rand", double_t, 0,
     "Mixture weight for the probability of getting random measurements.",
-    default=0.5, min=0., max=1.
+    default=0.05, min=0., max=1.
 )
 
 gen.add(
     "laser_z_max", double_t, 0,
     "Mixture weight for the probability of getting max range measurements.",
-    default=0.5, min=0., max=1.
+    default=0.05, min=0., max=1.
 )
 
 gen.add(
     "laser_z_short", double_t, 0,
     "Mixture weight for the probability of getting short measurements.",
-    default=0.5, min=0., max=1.
+    default=0.1, min=0., max=1.
 )
 
 gen.add(
@@ -325,17 +325,17 @@ gen.add(
 
 gen.add(
     "initial_cov_xx", double_t, 0,
-    "Initial pose x axis covariance.", default=0.5**2
+    "Initial pose x axis covariance.", default=0
 )
 
 gen.add(
     "initial_cov_yy", double_t, 0,
-    "Initial pose y axis covariance.", default=0.5**2
+    "Initial pose y axis covariance.", default=0
 )
 
 gen.add(
     "initial_cov_aa", double_t, 0,
-    "Initial pose yaw covariance.", default=(math.pi / 12)**2
+    "Initial pose yaw covariance.", default=0
 )
 
 gen.add(
@@ -357,7 +357,7 @@ gen.add(
     "save_pose_rate", double_t, 0,
     "Rate at which to store the last estimated pose "
     "and covariance to the parameter server.",
-    default=0.0
+    default=0.5
 )
 
 execution_policy_enum = gen.enum([
@@ -368,7 +368,7 @@ execution_policy_enum = gen.enum([
 gen.add(
     "execution_policy", str_t, 0,
     "Execution policy used to process particles.",
-    default="par", edit_method=execution_policy_enum
+    default="seq", edit_method=execution_policy_enum
 )
 
 gen.add(

--- a/beluga_amcl/config/Amcl.cfg
+++ b/beluga_amcl/config/Amcl.cfg
@@ -91,14 +91,14 @@ gen.add(
     "recovery_alpha_slow", double_t, 0,
     "Exponential decay rate for the slow average weight filter, "
     "used in deciding when to recover by adding random poses.",
-    default=0, min=0., max=1.
+    default=0.001, min=0., max=1.
 )
 
 gen.add(
     "recovery_alpha_fast", double_t, 0,
     "Exponential decay rate for the fast average weight filter, "
     "used in deciding when to recover by adding random poses.",
-    default=0, min=0., max=1.)
+    default=0.1, min=0., max=1.)
 
 gen.add(
     "kld_err", double_t, 0,

--- a/beluga_amcl/config/Amcl.cfg
+++ b/beluga_amcl/config/Amcl.cfg
@@ -58,7 +58,7 @@ gen.add(
     "use_map_topic", bool_t, 0,
     "Whether to subscribe to the map topic or "
     "call the map service to get a map to localize on.",
-    default=False
+    default=True
 )
 
 gen.add(

--- a/beluga_amcl/src/amcl_node.cpp
+++ b/beluga_amcl/src/amcl_node.cpp
@@ -81,7 +81,7 @@ AmclNode::AmclNode(const rclcpp::NodeOptions& options) : rclcpp_lifecycle::Lifec
   {
     auto descriptor = rcl_interfaces::msg::ParameterDescriptor();
     descriptor.description = "Topic to subscribe to in order to receive the initial pose of the robot.";
-    declare_parameter("initial_pose_topic", rclcpp::ParameterValue("initial_pose"), descriptor);
+    declare_parameter("initial_pose_topic", rclcpp::ParameterValue("initialpose"), descriptor);
   }
 
   {
@@ -119,7 +119,7 @@ AmclNode::AmclNode(const rclcpp::NodeOptions& options) : rclcpp_lifecycle::Lifec
     descriptor.floating_point_range[0].from_value = 0;
     descriptor.floating_point_range[0].to_value = 1;
     descriptor.floating_point_range[0].step = 0;
-    declare_parameter("recovery_alpha_slow", rclcpp::ParameterValue(0.001), descriptor);
+    declare_parameter("recovery_alpha_slow", rclcpp::ParameterValue(0.0), descriptor);
   }
 
   {
@@ -131,7 +131,7 @@ AmclNode::AmclNode(const rclcpp::NodeOptions& options) : rclcpp_lifecycle::Lifec
     descriptor.floating_point_range[0].from_value = 0;
     descriptor.floating_point_range[0].to_value = 1;
     descriptor.floating_point_range[0].step = 0;
-    declare_parameter("recovery_alpha_fast", rclcpp::ParameterValue(0.1), descriptor);
+    declare_parameter("recovery_alpha_fast", rclcpp::ParameterValue(0.0), descriptor);
   }
 
   {
@@ -153,7 +153,7 @@ AmclNode::AmclNode(const rclcpp::NodeOptions& options) : rclcpp_lifecycle::Lifec
         "Upper standard normal quantile for P, where P is the probability "
         "that the error in the estimated distribution will be less than pf_err "
         "in KLD resampling.";
-    declare_parameter("pf_z", rclcpp::ParameterValue(3.0), descriptor);
+    declare_parameter("pf_z", rclcpp::ParameterValue(0.99), descriptor);
   }
 
   {
@@ -164,7 +164,7 @@ AmclNode::AmclNode(const rclcpp::NodeOptions& options) : rclcpp_lifecycle::Lifec
     descriptor.floating_point_range[0].from_value = 0;
     descriptor.floating_point_range[0].to_value = std::numeric_limits<double>::max();
     descriptor.floating_point_range[0].step = 0;
-    declare_parameter("spatial_resolution_x", rclcpp::ParameterValue(0.1), descriptor);
+    declare_parameter("spatial_resolution_x", rclcpp::ParameterValue(0.5), descriptor);
   }
 
   {
@@ -175,7 +175,7 @@ AmclNode::AmclNode(const rclcpp::NodeOptions& options) : rclcpp_lifecycle::Lifec
     descriptor.floating_point_range[0].from_value = 0;
     descriptor.floating_point_range[0].to_value = std::numeric_limits<double>::max();
     descriptor.floating_point_range[0].step = 0;
-    declare_parameter("spatial_resolution_y", rclcpp::ParameterValue(0.1), descriptor);
+    declare_parameter("spatial_resolution_y", rclcpp::ParameterValue(0.5), descriptor);
   }
 
   {
@@ -187,7 +187,7 @@ AmclNode::AmclNode(const rclcpp::NodeOptions& options) : rclcpp_lifecycle::Lifec
     descriptor.floating_point_range[0].to_value = 2 * Sophus::Constants<double>::pi();
     descriptor.floating_point_range[0].step = 0;
     declare_parameter(
-        "spatial_resolution_theta", rclcpp::ParameterValue(Sophus::Constants<double>::pi() / 4), descriptor);
+        "spatial_resolution_theta", rclcpp::ParameterValue(10 * Sophus::Constants<double>::pi() / 180), descriptor);
   }
 
   {
@@ -380,7 +380,7 @@ AmclNode::AmclNode(const rclcpp::NodeOptions& options) : rclcpp_lifecycle::Lifec
     descriptor.floating_point_range[0].from_value = 0;
     descriptor.floating_point_range[0].to_value = 1;
     descriptor.floating_point_range[0].step = 0;
-    declare_parameter("z_max", rclcpp::ParameterValue(0.5), descriptor);
+    declare_parameter("z_max", rclcpp::ParameterValue(0.05), descriptor);
   }
 
   {
@@ -390,7 +390,7 @@ AmclNode::AmclNode(const rclcpp::NodeOptions& options) : rclcpp_lifecycle::Lifec
     descriptor.floating_point_range[0].from_value = 0;
     descriptor.floating_point_range[0].to_value = 1;
     descriptor.floating_point_range[0].step = 0;
-    declare_parameter("z_short", rclcpp::ParameterValue(0.5), descriptor);
+    declare_parameter("z_short", rclcpp::ParameterValue(0.05), descriptor);
   }
 
   {
@@ -454,21 +454,19 @@ AmclNode::AmclNode(const rclcpp::NodeOptions& options) : rclcpp_lifecycle::Lifec
   {
     auto descriptor = rcl_interfaces::msg::ParameterDescriptor();
     descriptor.description = "Initial pose x axis covariance.";
-    declare_parameter("initial_pose.covariance_x", 0.5 * 0.5, descriptor);
+    declare_parameter("initial_pose.covariance_x", 0.0, descriptor);
   }
 
   {
     auto descriptor = rcl_interfaces::msg::ParameterDescriptor();
     descriptor.description = "Initial pose y axis covariance.";
-    declare_parameter("initial_pose.covariance_y", 0.5 * 0.5, descriptor);
+    declare_parameter("initial_pose.covariance_y", 0.0, descriptor);
   }
 
   {
     auto descriptor = rcl_interfaces::msg::ParameterDescriptor();
     descriptor.description = "Initial pose yaw covariance.";
-    declare_parameter(
-        "initial_pose.covariance_yaw", Sophus::Constants<double>::pi() / 12. * Sophus::Constants<double>::pi() / 12.,
-        descriptor);
+    declare_parameter("initial_pose.covariance_yaw", 0.0, descriptor);
   }
 
   {

--- a/beluga_amcl/test/test_amcl_node.cpp
+++ b/beluga_amcl/test/test_amcl_node.cpp
@@ -707,6 +707,7 @@ TEST_F(TestNode, InitialPoseAfterInitialize) {
 }
 
 TEST_F(TestNode, InitialPoseWithWrongFrame) {
+  amcl_node_->set_parameter(rclcpp::Parameter{"set_initial_pose", false});
   amcl_node_->configure();
   amcl_node_->activate();
   tester_node_->publish_map();
@@ -728,6 +729,7 @@ TEST_F(TestNode, IsPublishingParticleCloud) {
 }
 
 TEST_F(TestNode, LaserScanWithNoOdomToBase) {
+  amcl_node_->set_parameter(rclcpp::Parameter{"set_initial_pose", true});
   amcl_node_->configure();
   amcl_node_->activate();
   tester_node_->publish_map();

--- a/beluga_amcl/test/test_amcl_node.cpp
+++ b/beluga_amcl/test/test_amcl_node.cpp
@@ -86,7 +86,7 @@ class TesterNode : public rclcpp::Node {
     map_publisher_ = create_publisher<nav_msgs::msg::OccupancyGrid>("map", rclcpp::SystemDefaultsQoS());
 
     initial_pose_publisher_ =
-        create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("initial_pose", rclcpp::SystemDefaultsQoS());
+        create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("initialpose", rclcpp::SystemDefaultsQoS());
 
     laser_scan_publisher_ = create_publisher<sensor_msgs::msg::LaserScan>("scan", rclcpp::SystemDefaultsQoS());
 
@@ -694,6 +694,7 @@ TEST_F(TestNode, InitialPoseBeforeInitialize) {
 }
 
 TEST_F(TestNode, InitialPoseAfterInitialize) {
+  amcl_node_->set_parameter(rclcpp::Parameter{"set_initial_pose", false});
   amcl_node_->configure();
   amcl_node_->activate();
   tester_node_->publish_map();

--- a/beluga_amcl/test/test_amcl_nodelet.cpp
+++ b/beluga_amcl/test/test_amcl_nodelet.cpp
@@ -328,7 +328,6 @@ class TestFixture : public BaseTestFixture<::testing::Test> {};
 TEST_F(TestFixture, MapWithWrongFrame) {
   beluga_amcl::AmclConfig config;
   ASSERT_TRUE(amcl_nodelet_->default_config(config));
-  config.use_map_topic = true;
   ASSERT_TRUE(amcl_nodelet_->set(config));
   tester_->publish_map_with_wrong_frame();
   ASSERT_TRUE(wait_for_initialization());
@@ -354,7 +353,6 @@ TEST_F(MapFromServiceFixture, MapFromService) {
 TEST_F(TestFixture, SetInitialPose) {
   beluga_amcl::AmclConfig config;
   ASSERT_TRUE(amcl_nodelet_->default_config(config));
-  config.use_map_topic = true;
   config.set_initial_pose = true;
   config.initial_pose_x = 34.0;
   config.initial_pose_y = 2.0;
@@ -378,7 +376,6 @@ TEST_F(TestFixture, SetInitialPose) {
 TEST_F(TestFixture, SetMapAndInitialPose) {
   beluga_amcl::AmclConfig config;
   ASSERT_TRUE(amcl_nodelet_->default_config(config));
-  config.use_map_topic = true;
   config.set_initial_pose = true;
   config.initial_pose_x = -1.0;
   config.initial_pose_y = 1.0;
@@ -479,7 +476,6 @@ TEST_F(TestFixture, NoBroadcastWhenInitialPoseInvalid) {
 TEST_F(TestFixture, FirstMapOnly) {
   beluga_amcl::AmclConfig config;
   ASSERT_TRUE(amcl_nodelet_->default_config(config));
-  config.use_map_topic = true;
   config.set_initial_pose = true;
   config.always_reset_initial_pose = true;
 
@@ -546,7 +542,6 @@ TEST_F(TestFixture, FirstMapOnly) {
 TEST_F(TestFixture, KeepCurrentEstimate) {
   beluga_amcl::AmclConfig config;
   ASSERT_TRUE(amcl_nodelet_->default_config(config));
-  config.use_map_topic = true;
   config.set_initial_pose = true;
   config.always_reset_initial_pose = false;
   config.first_map_only = false;
@@ -648,6 +643,7 @@ TEST_F(TestFixture, InitialPoseAfterInitialize) {
 TEST_F(TestFixture, InitialPoseWithWrongFrame) {
   beluga_amcl::AmclConfig config;
   ASSERT_TRUE(amcl_nodelet_->default_config(config));
+  config.set_initial_pose = false;
   ASSERT_TRUE(amcl_nodelet_->set(config));
   tester_->publish_map();
   ASSERT_TRUE(wait_for_initialization());
@@ -672,6 +668,7 @@ TEST_F(TestFixture, IsPublishingParticleCloud) {
 TEST_F(TestFixture, LaserScanWithNoOdomToBase) {
   beluga_amcl::AmclConfig config;
   ASSERT_TRUE(amcl_nodelet_->default_config(config));
+  config.set_initial_pose = true;
   ASSERT_TRUE(amcl_nodelet_->set(config));
   tester_->publish_map();
   ASSERT_TRUE(wait_for_initialization());

--- a/beluga_amcl/test/test_amcl_nodelet.cpp
+++ b/beluga_amcl/test/test_amcl_nodelet.cpp
@@ -175,12 +175,12 @@ class Tester {
     auto transform_base = geometry_msgs::TransformStamped{};
     transform_base.header.stamp = timestamp;
     transform_base.header.frame_id = "odom";
-    transform_base.child_frame_id = "base_footprint";
+    transform_base.child_frame_id = "base_link";
     transform_base.transform.rotation.w = 1.;
 
     auto transform_laser = geometry_msgs::TransformStamped{};
     transform_laser.header.stamp = timestamp;
-    transform_laser.header.frame_id = "base_footprint";
+    transform_laser.header.frame_id = "base_link";
     transform_laser.child_frame_id = "laser";
     transform_laser.transform.rotation.w = 1.;
 
@@ -328,6 +328,7 @@ class TestFixture : public BaseTestFixture<::testing::Test> {};
 TEST_F(TestFixture, MapWithWrongFrame) {
   beluga_amcl::AmclConfig config;
   ASSERT_TRUE(amcl_nodelet_->default_config(config));
+  config.use_map_topic = true;
   ASSERT_TRUE(amcl_nodelet_->set(config));
   tester_->publish_map_with_wrong_frame();
   ASSERT_TRUE(wait_for_initialization());
@@ -353,6 +354,7 @@ TEST_F(MapFromServiceFixture, MapFromService) {
 TEST_F(TestFixture, SetInitialPose) {
   beluga_amcl::AmclConfig config;
   ASSERT_TRUE(amcl_nodelet_->default_config(config));
+  config.use_map_topic = true;
   config.set_initial_pose = true;
   config.initial_pose_x = 34.0;
   config.initial_pose_y = 2.0;
@@ -376,6 +378,7 @@ TEST_F(TestFixture, SetInitialPose) {
 TEST_F(TestFixture, SetMapAndInitialPose) {
   beluga_amcl::AmclConfig config;
   ASSERT_TRUE(amcl_nodelet_->default_config(config));
+  config.use_map_topic = true;
   config.set_initial_pose = true;
   config.initial_pose_x = -1.0;
   config.initial_pose_y = 1.0;
@@ -476,6 +479,7 @@ TEST_F(TestFixture, NoBroadcastWhenInitialPoseInvalid) {
 TEST_F(TestFixture, FirstMapOnly) {
   beluga_amcl::AmclConfig config;
   ASSERT_TRUE(amcl_nodelet_->default_config(config));
+  config.use_map_topic = true;
   config.set_initial_pose = true;
   config.always_reset_initial_pose = true;
 
@@ -542,6 +546,7 @@ TEST_F(TestFixture, FirstMapOnly) {
 TEST_F(TestFixture, KeepCurrentEstimate) {
   beluga_amcl::AmclConfig config;
   ASSERT_TRUE(amcl_nodelet_->default_config(config));
+  config.use_map_topic = true;
   config.set_initial_pose = true;
   config.always_reset_initial_pose = false;
   config.first_map_only = false;
@@ -628,6 +633,7 @@ TEST_F(TestFixture, InitialPoseBeforeInitialize) {
 TEST_F(TestFixture, InitialPoseAfterInitialize) {
   beluga_amcl::AmclConfig config;
   ASSERT_TRUE(amcl_nodelet_->default_config(config));
+  config.set_initial_pose = false;
   ASSERT_TRUE(amcl_nodelet_->set(config));
   tester_->publish_map();
   ASSERT_TRUE(wait_for_initialization());


### PR DESCRIPTION
### Proposed changes

This is a minor patch to make default params match the navigation AMCL values in ROS 1 and ROS 2. This is convenient for users migrating from the AMCL node provided by the navigation stack, if they define a parameter file that does not mention all parameters, they can expect the behavior to match that of the navigation AMCL node.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)
