### PR TITLE
Fix missing control to force a filter update on pose updates

### DIFF
--- a/beluga_amcl/README.md
+++ b/beluga_amcl/README.md
@@ -61,6 +61,7 @@ Defaults are `map`, `odom` and `base`.
 | Topic                              | Type             | Description                                                                   |
 |------------------------------------|------------------|-------------------------------------------------------------------------------|
 | `reinitialize_global_localization` | `std_srvs/Empty` | Request to reinitialize global localization without an initial pose estimate. |
+| `request_nomotion_update`          | `std_srvs/Empty` | Trigger a forced update of the filter estimates.                              |
 
 ## ROS 1 Interface
 
@@ -103,9 +104,8 @@ Defaults are `map`, `odom` and `base`.
 | Topic                              | Type              | Description                                                                   |
 |------------------------------------|-------------------|-------------------------------------------------------------------------------|
 | `global_localization`              | `std_srvs/Empty`  | Request to reinitialize global localization without an initial pose estimate. |
+| `request_nomotion_update`          | `std_srvs/Empty`  | Trigger a forced update of the filter estimates.                              |
 | `set_map`                          | `nav_msgs/SetMap` | Set a new map and initial pose estimate.                                      |
-
-Note no `request_nomotion_update` service is available, as Beluga AMCL continually updates its estimate.
 
 ### Called Services
 

--- a/beluga_amcl/include/beluga_amcl/private/amcl_node.hpp
+++ b/beluga_amcl/include/beluga_amcl/private/amcl_node.hpp
@@ -62,6 +62,11 @@ class AmclNode : public rclcpp_lifecycle::LifecycleNode {
       std::shared_ptr<rmw_request_id_t> request_header,
       std::shared_ptr<std_srvs::srv::Empty::Request> request,
       std::shared_ptr<std_srvs::srv::Empty::Response> response);
+  void nomotion_update_callback(
+      std::shared_ptr<rmw_request_id_t> request_header,
+      std::shared_ptr<std_srvs::srv::Empty::Request> req,
+      std::shared_ptr<std_srvs::srv::Empty::Response> res);
+
   void reinitialize_with_pose(const Sophus::SE2d& pose, const Eigen::Matrix3d& covariance);
 
   std::unique_ptr<LaserLocalizationInterface2d> particle_filter_;
@@ -75,6 +80,7 @@ class AmclNode : public rclcpp_lifecycle::LifecycleNode {
   rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr initial_pose_sub_;
   rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr map_sub_;
   rclcpp::Service<std_srvs::srv::Empty>::SharedPtr global_localization_server_;
+  rclcpp::Service<std_srvs::srv::Empty>::SharedPtr nomotion_update_server_;
 
   std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
   std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
@@ -88,6 +94,7 @@ class AmclNode : public rclcpp_lifecycle::LifecycleNode {
   std::optional<Sophus::SE2d> latest_map_to_odom_transform_;
 
   bool enable_tf_broadcast_{false};
+  bool force_filter_update_{false};
 };
 
 }  // namespace beluga_amcl

--- a/beluga_amcl/include/beluga_amcl/private/amcl_nodelet.hpp
+++ b/beluga_amcl/include/beluga_amcl/private/amcl_nodelet.hpp
@@ -76,9 +76,11 @@ class AmclNodelet : public nodelet::Nodelet {
 
   bool global_localization_callback(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response);
 
+  bool nomotion_update_callback(std_srvs::Empty::Request& request, std_srvs::Empty::Response& response);
+
   void save_pose_timer_callback(const ros::TimerEvent& ev);
 
-  void initialize_with_pose(const Sophus::SE2d& pose, const Eigen::Matrix3d& covariance);
+  void reinitialize_with_pose(const Sophus::SE2d& pose, const Eigen::Matrix3d& covariance);
 
   void update_covariance_diagnostics(diagnostic_updater::DiagnosticStatusWrapper& status);
 
@@ -96,6 +98,7 @@ class AmclNodelet : public nodelet::Nodelet {
   ros::ServiceServer set_map_server_;
   ros::ServiceClient get_map_client_;
   ros::ServiceServer global_localization_server_;
+  ros::ServiceServer nomotion_update_server_;
 
   bool configured_{false};
   beluga_amcl::AmclConfig config_;
@@ -118,6 +121,8 @@ class AmclNodelet : public nodelet::Nodelet {
 
   std::optional<std::pair<Sophus::SE2d, Eigen::Matrix3d>> last_known_estimate_;
   std::optional<Sophus::SE2d> latest_map_to_odom_transform_;
+
+  bool force_filter_update_{false};
 };
 
 }  // namespace beluga_amcl

--- a/beluga_system_tests/test/test_system.cpp
+++ b/beluga_system_tests/test/test_system.cpp
@@ -120,7 +120,8 @@ TEST_P(BelugaSystemTest, testEstimatedPath) {
       }));
   for (const auto [iteration, data_point] : ranges::views::enumerate(test_data.data_points)) {
     auto scan_copy = data_point.scan;
-    const auto updated_pose = pf.update_filter(data_point.odom, std::move(scan_copy));
+    constexpr bool kForceUpdate = true;
+    const auto updated_pose = pf.update_filter(data_point.odom, std::move(scan_copy), !kForceUpdate);
     if (updated_pose) {
       auto estimation = pf.estimate();
       auto error = data_point.ground_truth.inverse() * estimation.first;

--- a/docker/images/noetic/Dockerfile
+++ b/docker/images/noetic/Dockerfile
@@ -115,6 +115,8 @@ RUN sudo apt-get update \
 
 COPY --from=cacher --chown=$USER:$GROUP /ws/ $USER_WS/
 
+RUN /bin/sh -c 'echo "export PATH=/usr/lib/ccache:\$PATH" >> ~/.bashrc'
+
 ENV WITHIN_DEV 1
 
 ENV SHELL /bin/bash


### PR DESCRIPTION
### Proposed changes

Major changes:
- Fixes lack of pose/transform update when setting a new initial pose.
- Add `request_nomotion_update` service (address #184)

Minor changes:
- Fix that ccache was not being used when building ROS 1.
- Rename `initialize_with_pose()` in `amcl_nodelet.xpp` to `reinitialize_with_pose()`, which is the name of the same function in `amcl_node.xpp`. The old name also overloaded the name of a different function.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)


### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)

