### PR TITLE
Add option to compare_results.py to save data to csv instead of plotting

### DIFF
--- a/beluga_benchmark/beluga_benchmark/compare_results.py
+++ b/beluga_benchmark/beluga_benchmark/compare_results.py
@@ -287,5 +287,4 @@ def main():
         )
         ax.set_ylim(new_limits)
 
-
     plt.show()

--- a/beluga_benchmark/beluga_benchmark/compare_results.py
+++ b/beluga_benchmark/beluga_benchmark/compare_results.py
@@ -109,6 +109,7 @@ def create_parameterized_series(results_path: Path):
     cpu_usage = []
     ape_rmse = []
     ape_mean = []
+    ape_std = []
     ape_median = []
     ape_max = []
     latency_min = []
@@ -137,6 +138,7 @@ def create_parameterized_series(results_path: Path):
         ape_rmse.append(stats["rmse"])
         ape_max.append(stats["max"])
         ape_mean.append(stats["mean"])
+        ape_std.append(stats["std"])
         ape_median.append(stats["median"])
         terminal_output_path = dir / TERMINAL_OUTPUT_LOG_FILE_NAME
         latency_stats = parse_latency_data(terminal_output_path)
@@ -153,6 +155,7 @@ def create_parameterized_series(results_path: Path):
                 'cpu_usage': cpu_usage,
                 'ape_rmse': ape_rmse,
                 'ape_mean': ape_mean,
+                'ape_std': ape_std,
                 'ape_median': ape_median,
                 'ape_max': ape_max,
                 'latency_min': latency_min,
@@ -203,16 +206,16 @@ def main():
         help='List of plots to generate. Default: ' + ', '.join(default_plots),
     )
 
+    arg_parser.add_argument(
+        '--save-csv',
+        type=str,
+        action='store',
+        help='Instead of plotting, save all the results to a csv file',
+    )
+
     args = arg_parser.parse_args()
 
     assert len(args.series) == len(args.label), 'Number of series and labels must match'
-
-    series = [
-        create_parameterized_series(series)
-        .filter(items=args.plot_names)
-        .add_prefix(label + '_')
-        for label, series in zip(args.label, args.series)
-    ]
 
     color_gen = cycle(
         [
@@ -225,6 +228,31 @@ def main():
             'orange',
         ]
     )
+
+    if args.save_csv:
+        # create list of dataframes with no filtered columns
+        series = [
+            create_parameterized_series(series).add_prefix(label + '_')
+            for label, series in zip(args.label, args.series)
+        ]
+        # leave only the index
+        full_table = series[0].filter(items=[])
+        # concatenate data in a single table
+        for s in series:
+            full_table = pd.concat([full_table, s], axis=1)
+        print('Saving to CSV file: ', args.save_csv)
+        full_table.to_csv(args.save_csv)
+        return 0
+
+    series = [
+        create_parameterized_series(series)
+        .filter(items=args.plot_names)
+        .add_prefix(label + '_')
+        for label, series in zip(args.label, args.series)
+    ]
+
+    print('Plotting data...')
+
     marker_gen = cycle('o^sDvP*')
 
     ax = series[0].plot(
@@ -258,4 +286,7 @@ def main():
             max(0.0, current_ylimits[1]),  # include zero above
         )
         ax.set_ylim(new_limits)
+
+    print(series)
+
     plt.show()

--- a/beluga_benchmark/beluga_benchmark/compare_results.py
+++ b/beluga_benchmark/beluga_benchmark/compare_results.py
@@ -287,6 +287,5 @@ def main():
         )
         ax.set_ylim(new_limits)
 
-    print(series)
 
     plt.show()

--- a/beluga_benchmark/docs/BENCHMARKING.md
+++ b/beluga_benchmark/docs/BENCHMARKING.md
@@ -77,6 +77,28 @@ The script will plot the following metrics vs the number of particles:
 - APE max
 - APE rmse
 
+## Saving benchmarking results to a CSV file
+
+The following command allows to save the results of different benchmarking runs to a CSV file, assuming that
+beam data has been stored in the `beam_beluga_seq` and `beam_nav2_amcl` directories, and
+likelihood data has been stored in the `likelihood_beluga_seq` and `likelihood_nav2_amcl` directories.
+
+```bash
+ros2 run beluga_benchmark compare_results \
+    -s beam_beluga_seq -l beluga          \
+    -s beam_nav2_amcl  -l nav2            \
+    --save-csv beam_model_data.csv
+
+ros2 run beluga_benchmark compare_results \
+    -s likelihood_beluga_seq -l beluga    \
+    -s likelihood_nav2_amcl  -l nav2      \
+    --save-csv likelihood_model_data.csv
+```
+
+The files `beam_model_data.csv` and `likelihood_model_data.csv` will be created in the current directory,
+containing all of the data captured in the benchmark runs, where columns will have been prefixed with the
+corresponding label passed to `compare_results` (e.g. `beluga_rss`, `nav2_rss`, etc).
+
 ## References
 
 - https://github.com/NERSC/timemory


### PR DESCRIPTION
### Proposed changes

Add small code snippet to enable saving benchmark scripts data to a csv file instead of plotting.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [x] 📚 Documentation (change which fixes or extends documentation)

💥 **Breaking change!** _Explain why a non-backwards compatible change is necessary or remove this line entirely if not applicable._

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

_Anything worth mentioning to the reviewers._
