### PR TITLE
Fix differential drive motion model

### DIFF
--- a/beluga/include/beluga/motion/differential_drive_model.hpp
+++ b/beluga/include/beluga/motion/differential_drive_model.hpp
@@ -155,8 +155,8 @@ class DifferentialDriveModel : public Mixin {
 
   static double rotation_variance(const Sophus::SO2d& rotation) {
     // Treat backward and forward motion symmetrically for the noise models.
-    static const auto flipping_rotation = Sophus::SO2d{Sophus::Constants<double>::pi()};
-    const auto flipped_rotation = rotation * flipping_rotation;
+    static const auto kFlippingRotation = Sophus::SO2d{Sophus::Constants<double>::pi()};
+    const auto flipped_rotation = rotation * kFlippingRotation;
     const auto delta = std::min(std::abs(rotation.log()), std::abs(flipped_rotation.log()));
     return delta * delta;
   }

--- a/beluga/include/beluga/motion/differential_drive_model.hpp
+++ b/beluga/include/beluga/motion/differential_drive_model.hpp
@@ -123,7 +123,6 @@ class DifferentialDriveModel : public Mixin {
               ? Sophus::SO2d{std::atan2(translation.y(), translation.x())} * previous_orientation.inverse()
               : Sophus::SO2d{0.0};
       const auto second_rotation = current_orientation * previous_orientation.inverse() * first_rotation.inverse();
-      const auto combined_rotation = first_rotation * second_rotation;
 
       {
         first_rotation_params_ = DistributionParam{
@@ -133,7 +132,8 @@ class DifferentialDriveModel : public Mixin {
         translation_params_ = DistributionParam{
             distance, std::sqrt(
                           params_.translation_noise_from_translation * distance_variance +
-                          params_.translation_noise_from_rotation * rotation_variance(combined_rotation))};
+                          params_.translation_noise_from_rotation *
+                              (rotation_variance(first_rotation) + rotation_variance(second_rotation)))};
         second_rotation_params_ = DistributionParam{
             second_rotation.log(), std::sqrt(
                                        params_.rotation_noise_from_rotation * rotation_variance(second_rotation) +

--- a/beluga/include/beluga/motion/differential_drive_model.hpp
+++ b/beluga/include/beluga/motion/differential_drive_model.hpp
@@ -121,7 +121,7 @@ class DifferentialDriveModel : public Mixin {
       const auto first_rotation =
           distance > params_.distance_threshold
               ? Sophus::SO2d{std::atan2(translation.y(), translation.x())} * previous_orientation.inverse()
-              : Sophus::SO2d{0.0};
+              : Sophus::SO2d{};
       const auto second_rotation = current_orientation * previous_orientation.inverse() * first_rotation.inverse();
 
       {
@@ -155,7 +155,8 @@ class DifferentialDriveModel : public Mixin {
 
   static double rotation_variance(const Sophus::SO2d& rotation) {
     // Treat backward and forward motion symmetrically for the noise models.
-    const auto flipped_rotation = rotation * Sophus::SO2d{Sophus::Constants<double>::pi()};
+    static const auto flipping_rotation = Sophus::SO2d{Sophus::Constants<double>::pi()};
+    const auto flipped_rotation = rotation * flipping_rotation;
     const auto delta = std::min(std::abs(rotation.log()), std::abs(flipped_rotation.log()));
     return delta * delta;
   }


### PR DESCRIPTION
### Proposed changes

Going over the math a few times, it doesn't seem to me that the rotation variance computation distributes over rotation composition. Not with those nonlinear max, min, abs operations in between.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

Not sure how to write a test for this. Would a formal proof (that `rotation_variance(a) * rotation_variance(b) != rotation_variance(a * b)`) do?