### PR TITLE
Add new discrete landmark and bearing sensor models to the beluga library

### DIFF
--- a/beluga/include/beluga/interfaces/bearing_sensor_model_interface.hpp
+++ b/beluga/include/beluga/interfaces/bearing_sensor_model_interface.hpp
@@ -1,0 +1,69 @@
+// Copyright 2022-2023 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BELUGA_INTERFACES_BEARING_SENSOR_MODEL_INTERFACE_HPP
+#define BELUGA_INTERFACES_BEARING_SENSOR_MODEL_INTERFACE_HPP
+
+// standard library
+#include <cstdint>
+#include <vector>
+
+// project
+#include <beluga/types/landmark_detection_types.hpp>
+
+/**
+ * \file
+ * \brief Includes the interface for bearing sensor models.
+ */
+
+namespace beluga {
+
+/// Pure abstract class representing the bearing sensor model interface.
+/**
+ * \tparam Map Bearing landmarks representation type.
+ */
+template <class Map>
+struct BearingSensorModelInterface {
+  /// Measurement type of the sensor: vector of landmark detections
+  using measurement_type = std::vector<LandmarkBearingDetection>;
+
+  /// Virtual destructor.
+  virtual ~BearingSensorModelInterface() = default;
+
+  /// Update the sensor model with the measured points.
+  /**
+   * This method updates the sensor model with the information
+   * it needs to compute the weight of each particle.
+   * The weight of each particle is calculated by subsequent calls to
+   * the `importance_weight()` method provided by the same mixin
+   * component.
+   *
+   * \param points The discrete sensor detections.
+   */
+  virtual void update_sensor(measurement_type&& points) = 0;
+
+  /// Update the sensor model with a new map.
+  /**
+   * This method updates the sensor model with a new map,
+   * i.e. a representation of the environment, that it needs
+   * to compute the weight of each particle.
+   *
+   * \param map The range finder map.
+   */
+  virtual void update_map(Map&& map) = 0;
+};
+
+}  // namespace beluga
+
+#endif

--- a/beluga/include/beluga/interfaces/landmark_sensor_model_interface.hpp
+++ b/beluga/include/beluga/interfaces/landmark_sensor_model_interface.hpp
@@ -1,0 +1,69 @@
+// Copyright 2022-2023 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BELUGA_INTERFACES_LANDMARK_SENSOR_MODEL_INTERFACE_HPP
+#define BELUGA_INTERFACES_LANDMARK_SENSOR_MODEL_INTERFACE_HPP
+
+// standard library
+#include <cstdint>
+#include <vector>
+
+// project
+#include <beluga/types/landmark_detection_types.hpp>
+
+/**
+ * \file
+ * \brief Includes the interface for generic landmark sensor models.
+ */
+
+namespace beluga {
+
+/// Pure abstract class representing a generic landmark sensor model.
+/**
+ * \tparam Landmark information representation type.
+ */
+template <class Map>
+struct LandmarkSensorModelInterface {
+  /// Measurement type of the sensor, detection position in robot frame
+  using measurement_type = std::vector<LandmarkPositionDetection>;
+
+  /// Virtual destructor.
+  virtual ~LandmarkSensorModelInterface() = default;
+
+  /// Update the sensor model with the measured points.
+  /**
+   * This method updates the sensor model with the information
+   * it needs to compute the weight of each particle.
+   * The weight of each particle is calculated by subsequent calls to
+   * the `importance_weight()` method provided by the same mixin
+   * component.
+   *
+   * \param points The discrete sensor detections in the reference frame of the particle.
+   */
+  virtual void update_sensor(measurement_type&& points) = 0;
+
+  /// Update the sensor model with a new map.
+  /**
+   * This method updates the sensor model with a new map,
+   * i.e. a representation of the environment, that it needs
+   * to compute the weight of each particle.
+   *
+   * \param map The range finder map.
+   */
+  virtual void update_map(Map&& map) = 0;
+};
+
+}  // namespace beluga
+
+#endif

--- a/beluga/include/beluga/interfaces/laser_sensor_model_interface_2d.hpp
+++ b/beluga/include/beluga/interfaces/laser_sensor_model_interface_2d.hpp
@@ -1,0 +1,64 @@
+// Copyright 2022-2023 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BELUGA_INTERFACES_LASER_SENSOR_MODEL_INTERFACE_2D_HPP
+#define BELUGA_INTERFACES_LASER_SENSOR_MODEL_INTERFACE_2D_HPP
+
+#include <vector>
+
+/**
+ * \file
+ * \brief Includes the interface for laser sensor models.
+ */
+
+namespace beluga {
+
+/// Pure abstract class representing the laser sensor model interface.
+/**
+ * \tparam Map Environment representation type.
+ */
+template <class Map>
+struct LaserSensorModelInterface2d {
+  /// Measurement type of the sensor: a point cloud for the range finder.
+  using measurement_type = std::vector<std::pair<double, double>>;
+
+  /// Virtual destructor.
+  virtual ~LaserSensorModelInterface2d() = default;
+
+  /// Update the sensor model with the measured points.
+  /**
+   * This method updates the sensor model with the information
+   * it needs to compute the weight of each particle.
+   * The weight of each particle is calculated by subsequent calls to
+   * the `importance_weight()` method provided by the same mixin
+   * component.
+   *
+   * \param points The range finder points in the reference frame of the particle.
+   */
+  virtual void update_sensor(measurement_type&& points) = 0;
+
+  /// Update the sensor model with a new map.
+  /**
+   * This method updates the sensor model with a new map,
+   * i.e. a representation of the environment, that it needs
+   * to compute the weight of each particle.
+   *
+   * \param map The range finder map.
+   */
+  virtual void update_map(Map&& map) = 0;
+};
+
+}  // namespace beluga
+
+#endif

--- a/beluga/include/beluga/sensor.hpp
+++ b/beluga/include/beluga/sensor.hpp
@@ -15,12 +15,9 @@
 #ifndef BELUGA_SENSOR_HPP
 #define BELUGA_SENSOR_HPP
 
-#include <beluga/sensor/beam_model.hpp>
-#include <beluga/sensor/likelihood_field_model.hpp>
-
 /**
  * \file
- * \brief Includes all Beluga sensor models.
+ * \brief Includes all Beluga sensor models and their interfaces.
  */
 
 /**
@@ -49,45 +46,19 @@
  * \section SensorModelLinks See also
  * - beluga::LikelihoodFieldModel
  * - beluga::BeamSensorModel
+ * - beluga::LandmarkSensorModel2d
+ * - beluga::BearingSensorModel2d
  */
 
-namespace beluga {
+// interfaces
+#include <beluga/interfaces/bearing_sensor_model_interface.hpp>
+#include <beluga/interfaces/landmark_sensor_model_interface.hpp>
+#include <beluga/interfaces/laser_sensor_model_interface_2d.hpp>
 
-/// Pure abstract class representing the laser sensor model interface.
-/**
- * \tparam Map Environment representation type.
- */
-template <class Map>
-struct LaserSensorModelInterface2d {
-  /// Measurement type of the sensor: a point cloud for the range finder.
-  using measurement_type = std::vector<std::pair<double, double>>;
-
-  /// Virtual destructor.
-  virtual ~LaserSensorModelInterface2d() = default;
-
-  /// Update the sensor model with the measured points.
-  /**
-   * This method updates the sensor model with the information
-   * it needs to compute the weight of each particle.
-   * The weight of each particle is calculated by subsequent calls to
-   * the `importance_weight()` method provided by the same mixin
-   * component.
-   *
-   * \param points The range finder points in the reference frame of the particle.
-   */
-  virtual void update_sensor(measurement_type&& points) = 0;
-
-  /// Update the sensor model with a new map.
-  /**
-   * This method updates the sensor model with a new map,
-   * i.e. a representation of the environment, that it needs
-   * to compute the weight of each particle.
-   *
-   * \param map The range finder map.
-   */
-  virtual void update_map(Map&& map) = 0;
-};
-
-}  // namespace beluga
+// implementations
+#include <beluga/sensor/beam_model.hpp>
+#include <beluga/sensor/bearing_sensor_model.hpp>
+#include <beluga/sensor/landmark_sensor_model.hpp>
+#include <beluga/sensor/likelihood_field_model.hpp>
 
 #endif

--- a/beluga/include/beluga/sensor/bearing_sensor_model.hpp
+++ b/beluga/include/beluga/sensor/bearing_sensor_model.hpp
@@ -1,0 +1,203 @@
+// Copyright 2023 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BELUGA_SENSOR_BEARING_SENSOR_MODEL_HPP
+#define BELUGA_SENSOR_BEARING_SENSOR_MODEL_HPP
+
+// external
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view/all.hpp>
+#include <range/v3/view/transform.hpp>
+#include <sophus/se2.hpp>
+#include <sophus/se3.hpp>
+
+// standard library
+#include <cmath>
+#include <random>
+#include <utility>
+#include <vector>
+
+// project
+#include <beluga/types/landmark_detection_types.hpp>
+
+/**
+ * \file
+ * \brief Implementation of a discrete landmark bearing sensor model.
+ */
+
+namespace beluga {
+
+/// Parameters used to construct a BearingSensorModel instance.
+struct BearingModelParam {
+  double sigma_bearing{1.0};            ///< Standard deviation of the bearing error.
+  Sophus::SE3d sensor_pose_in_robot{};  ///< Pose of the sensor in the robot reference frame.
+};
+
+/// Generic bearing sensor model, for both 2D and 3D state types.
+/**
+ * This class implements the BearingSensorModelInterface interface
+ * and satisfies \ref SensorModelPage.
+ * \tparam Mixin The mixed-in type with no particular requirements.
+ * \tparam LandmarkMap class managing the list of known landmarks.
+ * \tparam StateType type of the state of the particle.
+ */
+template <class Mixin, class LandmarkMap, class StateType>
+class BearingSensorModel : public Mixin {
+ public:
+  /// State type of a particle.
+  using state_type = StateType;
+  /// Weight type of the particle.
+  using weight_type = double;
+  /// Measurement type of the sensor: vector of landmark detections
+  using measurement_type = std::vector<LandmarkBearingDetection>;
+  /// Parameter type that the constructor uses to configure the bearing sensor model.
+  using param_type = BearingModelParam;
+
+  /// Constructs a BearingSensorModel instance.
+  /**
+   * \tparam ...Args Arguments types for the remaining mixin constructors.
+   * \param params Parameters to configure this instance. See beluga::BearingModelParam for details.
+   * \param landmark_map Map of landmarks to be used by this sensor model.
+   * \param ...rest Arguments that are not used by this part of the mixin, but
+   * by others.
+   */
+  template <class... Args>
+  explicit BearingSensorModel(param_type params, LandmarkMap landmark_map, Args&&... rest)
+      : Mixin(std::forward<Args>(rest)...), params_{std::move(params)}, landmark_map_{std::move(landmark_map)} {}
+
+  /**
+   * The generated state is an unoccupied cell of the grid, any free cell is
+   * sampled uniformly. The rotation is sampled uniformly as well.
+   *
+   * \tparam Generator  A random number generator that must satisfy the
+   *  [UniformRandomBitGenerator](https://en.cppreference.com/w/cpp/named_req/UniformRandomBitGenerator)
+   *  requirements.
+   * \param gen An uniform random bit generator object.
+   * \return The generated random state.
+   */
+  template <class Generator>
+  [[nodiscard]] state_type make_random_state(Generator& gen) const {
+    const auto map_boundaries = landmark_map_.map_limits();
+
+    if constexpr (std::is_same_v<state_type, Sophus::SE3d>) {
+      auto x_distribution = std::uniform_real_distribution<double>{map_boundaries.x_min, map_boundaries.x_max};
+      auto y_distribution = std::uniform_real_distribution<double>{map_boundaries.y_min, map_boundaries.y_max};
+      auto z_distribution = std::uniform_real_distribution<double>{map_boundaries.z_min, map_boundaries.z_max};
+      return Sophus::SE3d{
+          Sophus::SO3d::sampleUniform(gen),
+          Eigen::Vector3d{x_distribution(gen), y_distribution(gen), z_distribution(gen)}};
+    } else {
+      auto x_distribution = std::uniform_real_distribution<double>{map_boundaries.x_min, map_boundaries.x_max};
+      auto y_distribution = std::uniform_real_distribution<double>{map_boundaries.y_min, map_boundaries.y_max};
+      return Sophus::SE2d{Sophus::SO2d::sampleUniform(gen), Eigen::Vector2d{x_distribution(gen), y_distribution(gen)}};
+    }
+  }
+
+  /// Gets the importance weight for a particle with the provided state.
+  /**
+   * \param state State of the particle to calculate its importance weight.
+   * \return Calculated importance weight.
+   */
+  [[nodiscard]] weight_type importance_weight(const state_type& state) const {
+    Sophus::SE3d robot_pose_in_world;
+
+    if constexpr (std::is_same_v<state_type, Sophus::SE3d>) {
+      // The robot pose state is already given in 3D,
+      robot_pose_in_world = state;
+    } else {
+      // The robot pose state is given in 2D. Notice that in this case
+      // the 2D pose of the robot is assumed to be that of the robot footprint (projection of the robot
+      // on the z=0 plane of the 3D world frame). This is so that we can tie the sensor reference frame
+      // to the world frame where the landmarks are given without additional structural information.
+      robot_pose_in_world = Sophus::SE3d{
+          Sophus::SO3d::rotZ(state.so2().log()),
+          Eigen::Vector3d{state.translation().x(), state.translation().y(), 0.0}};
+    }
+
+    // precalculate the sensor pose in the world frame
+    const auto sensor_pose_in_world = robot_pose_in_world * params_.sensor_pose_in_robot;
+
+    const auto detection_weight = [this, &sensor_pose_in_world](const auto& detection) {
+      // find the landmark the most closely matches the sample bearing vector
+      const auto opt_landmark_bearing_in_sensor = landmark_map_.find_closest_bearing_landmark(
+          detection.detection_bearing_in_sensor, detection.category, sensor_pose_in_world);
+
+      // if we did not find a matching landmark, return 0.0
+      if (!opt_landmark_bearing_in_sensor) {
+        return 0.0;
+      }
+
+      // recover sample bearing vector
+      const auto detection_bearing_in_sensor = detection.detection_bearing_in_sensor.normalized();
+
+      // recover landmark bearing vector
+      const auto& landmark_bearing_in_sensor = *opt_landmark_bearing_in_sensor;
+
+      // calculate the aperture angle between the detection and the landmark
+      const auto cos_aperture = detection_bearing_in_sensor.dot(landmark_bearing_in_sensor);
+      const auto sin_aperture = detection_bearing_in_sensor.cross(landmark_bearing_in_sensor).norm();
+
+      // calculate the angle between the sample and the landmark
+      const auto bearing_error = std::atan2(sin_aperture, cos_aperture);
+
+      // model the probability of the landmark being detected as depending on the bearing error
+      const auto bearing_error_prob =
+          std::exp(-bearing_error * bearing_error / (2. * params_.sigma_bearing * params_.sigma_bearing));
+
+      // We'll assume the probability of identification error to be zero
+      const auto prob = bearing_error_prob;
+
+      // TODO(unknown): We continue to use the sum-of-cubes formula that nav2 uses
+      // See https://github.com/Ekumen-OS/beluga/issues/153
+      return prob * prob * prob;
+    };
+
+    return std::transform_reduce(points_.cbegin(), points_.cend(), 1.0, std::plus{}, detection_weight);
+  }
+
+  /// \copydoc BearingSensorModelInterface::update_sensor(measurement_type&&points)
+  void update_sensor(measurement_type&& points) final { points_ = std::move(points); }
+
+  /// \copydoc BearingSensorModelInterface::update_map(Map&& map)
+  void update_map(LandmarkMap&& map) final { landmark_map_ = std::move(map); }
+
+ private:
+  param_type params_;
+  LandmarkMap landmark_map_;
+  measurement_type points_;
+};
+
+/// Sensor model based on discrete landmarks bearing detection for 2D state types.
+/**
+ * This class implements the BearingSensorModelInterface interface
+ * and satisfies \ref SensorModelPage.
+ * \tparam Mixin The mixed-in type with no particular requirements.
+ * \tparam LandmarkMap class managing the list of known landmarks.
+ */
+template <class Mixin, class LandmarkMap>
+using BearingSensorModel2d = BearingSensorModel<Mixin, LandmarkMap, Sophus::SE2d>;
+
+/// Sensor model based on discrete landmarks bearing detection for 3D state types.
+/**
+ * This class implements the BearingSensorModelInterface interface
+ * and satisfies \ref SensorModelPage.
+ * \tparam Mixin The mixed-in type with no particular requirements.
+ * \tparam LandmarkMap class managing the list of known landmarks.
+ */
+template <class Mixin, class LandmarkMap>
+using BearingSensorModel3d = BearingSensorModel<Mixin, LandmarkMap, Sophus::SE3d>;
+
+}  // namespace beluga
+
+#endif

--- a/beluga/include/beluga/sensor/data/landmark_map.hpp
+++ b/beluga/include/beluga/sensor/data/landmark_map.hpp
@@ -1,0 +1,149 @@
+// Copyright 2023 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BELUGA_SENSOR_DATA_LANDMARK_MAP_HPP
+#define BELUGA_SENSOR_DATA_LANDMARK_MAP_HPP
+
+// external
+#include <range/v3/view/filter.hpp>
+#include <sophus/se3.hpp>
+
+// standard library
+#include <algorithm>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+// project
+#include <beluga/types/landmark_detection_types.hpp>
+
+/**
+ * \file
+ * \brief Landmark map datatype.
+ */
+
+namespace beluga {
+
+/// Basic 3D landmark map datatype
+class LandmarkMap {
+ public:
+  /// Vector of landmarks
+  using landmarks_set_position_data = std::vector<LandmarkPositionDetection>;
+  /// Type used to represent poses in the world frame
+  using world_pose_type = Sophus::SE3d;
+
+  /// @brief Constructor.
+  /// @param boundaries Limits of the map.
+  /// @param landmarks List of landmarks that can be expected to be detected.
+  LandmarkMap(const LandmarkMapBoundaries& boundaries, landmarks_set_position_data landmarks)
+      : landmarks_(std::move(landmarks)), map_boundaries_(std::move(boundaries)) {}
+
+  /// @brief Returns the map boundaries.
+  /// @return The map boundaries.
+  [[nodiscard]] LandmarkMapBoundaries map_limits() const { return map_boundaries_; }
+
+  /// @brief Finds the nearest landmark to a given detection and returns it's data.
+  /// @param detection_position_in_world The detection data.
+  /// @param detection_category The category of the detection.
+  /// @return The landmark data. nullopt if no landmark was found.
+  [[nodiscard]] std::optional<LandmarkPosition3> find_nearest_landmark(
+      const LandmarkPosition3& detection_position_in_world,
+      const LandmarkCategory& detection_category) const {
+    // only consider those that have the same id
+    auto same_category_landmarks_view =
+        landmarks_ | ranges::views::filter([detection_category = detection_category](const auto& l) {
+          return detection_category == l.category;
+        });
+
+    // find the landmark that minimizes the distance to the detection position
+    // This is O(n). A spatial data structure should be used instead.
+    auto min = std::min_element(
+        same_category_landmarks_view.begin(), same_category_landmarks_view.end(),
+        [&detection_position_in_world](const auto& a, const auto& b) {
+          const auto& landmark_a_position_in_world = a.detection_position_in_robot;
+          const auto& landmark_b_position_in_world = b.detection_position_in_robot;
+
+          const auto landmark_b_squared_in_world_squared =
+              (landmark_a_position_in_world - detection_position_in_world).squaredNorm();
+          const auto landmark_b_distance_in_world_squared =
+              (landmark_b_position_in_world - detection_position_in_world).squaredNorm();
+          return landmark_b_squared_in_world_squared < landmark_b_distance_in_world_squared;
+        });
+
+    if (min == same_category_landmarks_view.end()) {
+      return std::nullopt;
+    }
+
+    return min->detection_position_in_robot;
+  }
+
+  /// @brief Finds the landmark that minimizes the bearing error to a given detection and returns its data.
+  /// @param detection_bearing_in_sensor The detection data.
+  /// @param detection_category The category of the detection.
+  /// @param sensor_pose_in_world The pose of the sensor in the world frame.
+  /// @return The landmark data. nullopt if no landmark was found.
+  [[nodiscard]] std::optional<LandmarkBearing3> find_closest_bearing_landmark(
+      const LandmarkBearing3& detection_bearing_in_sensor,
+      const LandmarkCategory& detection_category,
+      const world_pose_type& sensor_pose_in_world) const {
+    // only consider those that have the same detection id (category)
+    auto same_category_landmarks_view =
+        landmarks_ | ranges::views::filter([detection_category = detection_category](const auto& l) {
+          return detection_category == l.category;
+        });
+
+    // find the landmark that minimizes the bearing error
+    const auto world_in_sensor_transform = sensor_pose_in_world.inverse();
+
+    // This whole search thing is very expensive, with objects getting created, normalized and
+    // destroyed multiple times and the same transformations being calculated over and over again.
+    // This will only work as a proof-of-concept, but it needs to be optimized for large numbers of
+    // landmarks.
+    const auto minimization_function = [&detection_bearing_in_sensor, &world_in_sensor_transform](
+                                           const auto& a, const auto& b) {
+      const auto& landmark_a_position_in_world = a.detection_position_in_robot;
+      const auto& landmark_b_position_in_world = b.detection_position_in_robot;
+
+      // convert the landmark locations relative to the sensor frame
+      const auto landmark_a_bearing_in_sensor = (world_in_sensor_transform * landmark_a_position_in_world).normalized();
+      const auto landmark_b_bearing_in_sensor = (world_in_sensor_transform * landmark_b_position_in_world).normalized();
+
+      // find the landmark that minimizes the bearing error by maximizing the dot product against the
+      // detection bearing vector
+      const auto dot_product_a = landmark_a_bearing_in_sensor.dot(detection_bearing_in_sensor);
+      const auto dot_product_b = landmark_b_bearing_in_sensor.dot(detection_bearing_in_sensor);
+
+      return dot_product_a > dot_product_b;
+    };
+
+    auto min = std::min_element(
+        same_category_landmarks_view.begin(), same_category_landmarks_view.end(), minimization_function);
+
+    if (min == same_category_landmarks_view.end()) {
+      return std::nullopt;
+    }
+
+    // find the normalized bearing vector to the landmark, relative to the sensor frame
+    const auto landmark_position_in_sensor = world_in_sensor_transform * min->detection_position_in_robot;
+    return landmark_position_in_sensor.normalized();
+  }
+
+ private:
+  landmarks_set_position_data landmarks_;
+  LandmarkMapBoundaries map_boundaries_;
+};
+
+}  // namespace beluga
+
+#endif

--- a/beluga/include/beluga/sensor/landmark_sensor_model.hpp
+++ b/beluga/include/beluga/sensor/landmark_sensor_model.hpp
@@ -1,0 +1,221 @@
+// Copyright 2023 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BELUGA_SENSOR_LANDMARK_SENSOR_MODEL_HPP
+#define BELUGA_SENSOR_LANDMARK_SENSOR_MODEL_HPP
+
+// external
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view/all.hpp>
+#include <range/v3/view/transform.hpp>
+#include <sophus/se2.hpp>
+#include <sophus/so2.hpp>
+
+// standard library
+#include <cmath>
+#include <random>
+#include <vector>
+
+// project
+#include <beluga/types/landmark_detection_types.hpp>
+
+/**
+ * \file
+ * \brief Implementation of a discrete landmark sensor model.
+ */
+
+namespace beluga {
+
+/// Parameters used to construct a LandmarkSensorModel instance (both 2D and 3D).
+/**
+ * See Probabilistic Robotics \cite thrun2005probabilistic section 6.6
+ */
+struct LandmarkModelParam {
+  double sigma_range{1.0};    ///< Standard deviation of the range error.
+  double sigma_bearing{1.0};  ///< Standard deviation of the bearing error.
+};
+
+/// Generic landmark model for discrete detection sensors (both 2D and 3D).
+/**
+ * This class implements the LandmarkSensorModelInterface interface
+ * and satisfies \ref SensorModelPage.
+ *
+ * This sensor model is a generalization of the model described in Probabilistic
+ * Robotics \cite thrun2005probabilistic Chapter 6.6 .
+ *
+ * \tparam Mixin The mixed-in type with no particular requirements.
+ * \tparam LandmarkMap class managing the list of known landmarks.
+ * \tparam StateType type of the state of the particle.
+ */
+template <class Mixin, class LandmarkMap, class StateType>
+class LandmarkSensorModel : public Mixin {
+ public:
+  /// State type of a particle.
+  using state_type = StateType;
+  /// Weight type of the particle.
+  using weight_type = double;
+  /// Measurement type of the sensor, detection position in robot frame
+  using measurement_type = std::vector<LandmarkPositionDetection>;
+  /// Parameter type that the constructor uses to configure the beam sensor model.
+  using param_type = LandmarkModelParam;
+
+  /// Constructs a LandmarkSensorModel instance.
+  /**
+   * \tparam ...Args Arguments types for the remaining mixin constructors.
+   * \param params Parameters to configure this instance.
+   *  See beluga::BeamModelParams for details.
+   * \param landmark_map Map of landmarks to be used by this sensor model.
+   * \param ...rest Arguments that are not used by this part of the mixin, but by others.
+   */
+  template <class... Args>
+  explicit LandmarkSensorModel(param_type params, LandmarkMap landmark_map, Args&&... rest)
+      : Mixin(std::forward<Args>(rest)...), params_{std::move(params)}, landmark_map_{std::move(landmark_map)} {}
+
+  /**
+   * The generated state is an unoccupied cell of the grid, any free cell is
+   * sampled uniformly. The rotation is as well sampled uniformly.
+   *
+   * \tparam Generator  A random number generator that must satisfy the
+   *  [UniformRandomBitGenerator](https://en.cppreference.com/w/cpp/named_req/UniformRandomBitGenerator)
+   *  requirements.
+   * \param gen An uniform random bit generator object.
+   * \return The generated random state.
+   */
+  template <class Generator>
+  [[nodiscard]] state_type make_random_state(Generator& gen) const {
+    const auto map_boundaries = landmark_map_.map_limits();
+
+    if constexpr (std::is_same_v<state_type, Sophus::SE3d>) {
+      auto x_distribution = std::uniform_real_distribution<double>{map_boundaries.x_min, map_boundaries.x_max};
+      auto y_distribution = std::uniform_real_distribution<double>{map_boundaries.y_min, map_boundaries.y_max};
+      auto z_distribution = std::uniform_real_distribution<double>{map_boundaries.z_min, map_boundaries.z_max};
+      return Sophus::SE3d{
+          Sophus::SO3d::sampleUniform(gen),
+          Eigen::Vector3d{x_distribution(gen), y_distribution(gen), z_distribution(gen)}};
+    } else {
+      auto x_distribution = std::uniform_real_distribution<double>{map_boundaries.x_min, map_boundaries.x_max};
+      auto y_distribution = std::uniform_real_distribution<double>{map_boundaries.y_min, map_boundaries.y_max};
+      return Sophus::SE2d{Sophus::SO2d::sampleUniform(gen), Eigen::Vector2d{x_distribution(gen), y_distribution(gen)}};
+    }
+  }
+
+  /// Gets the importance weight for a particle with the provided state.
+  /**
+   * \param state State of the particle to calculate its importance weight.
+   * \return Calculated importance weight.
+   */
+  [[nodiscard]] weight_type importance_weight(const state_type& state) const {
+    Sophus::SE3d robot_pose_in_world;
+
+    if constexpr (std::is_same_v<state_type, Sophus::SE3d>) {
+      // The robot pose state is already given in 3D,
+      robot_pose_in_world = state;
+    } else {
+      // The robot pose state is given in 2D. Notice that in this case
+      // the 2D pose of the robot is assumed to be that of the robot footprint (projection of the robot
+      // on the z=0 plane of the 3D world frame). This is so that we can tie the sensor reference frame
+      // to the world frame where the landmarks are given without additional structural information.
+      robot_pose_in_world = Sophus::SE3d{
+          Sophus::SO3d::rotZ(state.so2().log()),
+          Eigen::Vector3d{state.translation().x(), state.translation().y(), 0.0}};
+    }
+
+    const auto detection_weight = [this, &robot_pose_in_world](const auto& detection) {
+      // calculate range and detection_bearing_in_robot to the detection from the robot
+      // the detection is already in robot frame
+      const auto& detection_category = detection.category;
+      const auto& detection_position_in_robot = detection.detection_position_in_robot;
+
+      const auto detection_range_in_robot = detection_position_in_robot.norm();
+      const auto detection_bearing_in_robot = detection_position_in_robot.normalized();
+
+      // convert the detection to the world frame to query the map
+      const auto detection_position_in_world = robot_pose_in_world * detection_position_in_robot;
+
+      // find the closest matching landmark in the world map
+      const auto opt_landmark_position_in_world =
+          landmark_map_.find_nearest_landmark(detection_position_in_world, detection_category);
+
+      // if we did not find a matching landmark, return 0.0
+      if (!opt_landmark_position_in_world) {
+        return 0.0;
+      }
+
+      // convert landmark pose to world frame
+      // ignore height, because we are modelling the detection in 2D
+      const auto& landmark_position_in_world = *opt_landmark_position_in_world;
+      const auto landmark_in_robot_position = robot_pose_in_world.inverse() * landmark_position_in_world;
+
+      const auto landmark_range_in_robot = landmark_in_robot_position.norm();
+      const auto landmark_bearing_in_robot = landmark_in_robot_position.normalized();
+
+      // calculate the aperture angle between the detection and the landmark
+      const auto cos_aperture = landmark_bearing_in_robot.dot(detection_bearing_in_robot);
+      const auto sin_aperture = landmark_bearing_in_robot.cross(detection_bearing_in_robot).norm();
+      const auto bearing_error = std::atan2(sin_aperture, cos_aperture);
+
+      const auto range_error = detection_range_in_robot - landmark_range_in_robot;
+
+      // apply the error model from Probabilistic Robotics
+      const auto range_error_prob =
+          std::exp(-range_error * range_error / (2. * params_.sigma_range * params_.sigma_range));
+      const auto bearing_error_prob =
+          std::exp(-bearing_error * bearing_error / (2. * params_.sigma_bearing * params_.sigma_bearing));
+
+      // We'll assume the probability of identification error to be zero
+      const auto prob = range_error_prob * bearing_error_prob;
+
+      // TODO(unknown): We continue to use the sum-of-cubes formula that nav2 uses
+      // See https://github.com/Ekumen-OS/beluga/issues/153
+      return prob * prob * prob;
+    };
+
+    return std::transform_reduce(points_.cbegin(), points_.cend(), 1.0, std::plus{}, detection_weight);
+  }
+
+  /// \copydoc LandmarkSensorModelInterface::update_sensor(measurement_type&&points)
+  void update_sensor(measurement_type&& points) final { points_ = std::move(points); }
+
+  /// \copydoc LandmarkSensorModelInterface::update_map(Map&& map)
+  void update_map(LandmarkMap&& map) final { landmark_map_ = std::move(map); }
+
+ private:
+  param_type params_;
+  LandmarkMap landmark_map_;
+  measurement_type points_;
+};
+
+/// Sensor model based on discrete landmarks for 2D state types.
+/**
+ * This class implements the BearingSensorModelInterface interface
+ * and satisfies \ref SensorModelPage.
+ * \tparam Mixin The mixed-in type with no particular requirements.
+ * \tparam LandmarkMap class managing the list of known landmarks.
+ */
+template <class Mixin, class LandmarkMap>
+using LandmarkSensorModel2d = LandmarkSensorModel<Mixin, LandmarkMap, Sophus::SE2d>;
+
+/// Sensor model based on discrete landmarks for 3D state types.
+/**
+ * This class implements the BearingSensorModelInterface interface
+ * and satisfies \ref SensorModelPage.
+ * \tparam Mixin The mixed-in type with no particular requirements.
+ * \tparam LandmarkMap class managing the list of known landmarks.
+ */
+template <class Mixin, class LandmarkMap>
+using LandmarkSensorModel3d = LandmarkSensorModel<Mixin, LandmarkMap, Sophus::SE3d>;
+
+}  // namespace beluga
+
+#endif

--- a/beluga/include/beluga/types/landmark_detection_types.hpp
+++ b/beluga/include/beluga/types/landmark_detection_types.hpp
@@ -1,0 +1,59 @@
+// Copyright 2023 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BELUGA_TYPES_LANDMARK_DETECTION_TYPES_HPP
+#define BELUGA_TYPES_LANDMARK_DETECTION_TYPES_HPP
+
+// external
+#include <eigen3/Eigen/Core>
+
+// standard library
+#include <cstdint>
+
+/**
+ * \file
+ * \brief Auxiliar types for landmark models.
+ */
+
+namespace beluga {
+
+using LandmarkCategory = uint32_t;          ///< Type used to represent landmark categories.
+using LandmarkPosition3 = Eigen::Vector3d;  ///< Position of a landmark in the world reference frame.
+using LandmarkBearing3 = Eigen::Vector3d;   ///< Bearing of a landmark in the sensor reference frame.
+
+/// Landmark bearing detection data
+struct LandmarkMapBoundaries {
+  double x_min;  ///< Minimum x coordinate of the map.
+  double x_max;  ///< Maximum x coordinate of the map.
+  double y_min;  ///< Minimum y coordinate of the map.
+  double y_max;  ///< Maximum y coordinate of the map.
+  double z_min;  ///< Minimum z coordinate of the map.
+  double z_max;  ///< Maximum z coordinate of the map.
+};
+
+/// Landmark bearing detection data
+struct LandmarkPositionDetection {
+  LandmarkPosition3 detection_position_in_robot;  ///< Detection pose in the robot reference frame.
+  LandmarkCategory category;                      ///< Category of the landmark detection (i.e. landmark type).
+};
+
+/// Landmark bearing detection data
+struct LandmarkBearingDetection {
+  LandmarkBearing3 detection_bearing_in_sensor;  ///< Bearing vector of the detection in the sensor reference frame.
+  LandmarkCategory category;                     ///< Category of the landmark detection (i.e. landmark type).
+};
+
+}  // namespace beluga
+
+#endif

--- a/beluga/test/beluga/CMakeLists.txt
+++ b/beluga/test/beluga/CMakeLists.txt
@@ -27,10 +27,13 @@ add_executable(
   motion/test_omnidirectional_drive_model.cpp
   random/test_multivariate_normal_distribution.cpp
   sensor/data/test_dense_grid.cpp
+  sensor/data/test_landmark_map.cpp
   sensor/data/test_linear_grid.cpp
   sensor/data/test_occupancy_grid.cpp
   sensor/data/test_regular_grid.cpp
   sensor/test_beam_model.cpp
+  sensor/test_bearing_sensor_model.cpp
+  sensor/test_landmark_sensor_model.cpp
   sensor/test_likelihood_field_model.cpp
   test_mixin.cpp
   test_spatial_hash.cpp

--- a/beluga/test/beluga/sensor/data/test_landmark_map.cpp
+++ b/beluga/test/beluga/sensor/data/test_landmark_map.cpp
@@ -1,0 +1,125 @@
+// Copyright 2023 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+// standard library
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+// project
+#include <beluga/sensor/data/landmark_map.hpp>
+
+namespace {
+
+struct LandmarkMapCartesianTest : public ::testing::Test {
+  beluga::LandmarkMapBoundaries default_map_boundaries{0.0, 10.0, 1.0, 11.0, 2.0, 12.0};
+};
+
+TEST_F(LandmarkMapCartesianTest, SmokeTest) {
+  ASSERT_NO_THROW(beluga::LandmarkMap(default_map_boundaries, beluga::LandmarkMap::landmarks_set_position_data{}));
+}
+
+TEST_F(LandmarkMapCartesianTest, SimpleMapLoading) {
+  const auto landmark_10 = beluga::LandmarkPosition3{+1.0, +2.0, +3.0};
+  const auto landmark_11 = beluga::LandmarkPosition3{+1.0, +2.0, +3.0};
+  const auto landmark_20 = beluga::LandmarkPosition3{+5.0, +6.0, +7.0};
+
+  auto uut = beluga::LandmarkMap(default_map_boundaries, {{landmark_10, 0}, {landmark_11, 0}, {landmark_20, 1}});
+
+  {
+    const auto nearest = uut.find_nearest_landmark({1.0, 2.0, 3.0}, 0);
+    ASSERT_TRUE(nearest.has_value());
+    EXPECT_NEAR(0.0, (landmark_10 - *nearest).norm(), 1e-6);
+  }
+
+  {
+    const auto nearest = uut.find_nearest_landmark({1.0, 2.0, 3.0}, 1);
+    ASSERT_TRUE(nearest.has_value());
+    EXPECT_NEAR(0.0, (landmark_20 - *nearest).norm(), 1e-6);
+  }
+
+  {
+    const auto nearest = uut.find_nearest_landmark({1.0, 2.0, 3.0}, 99);
+    ASSERT_FALSE(nearest.has_value());
+  }
+}
+
+TEST_F(LandmarkMapCartesianTest, EmptyMap) {
+  auto uut = beluga::LandmarkMap(default_map_boundaries, beluga::LandmarkMap::landmarks_set_position_data{});
+  const auto nearest = uut.find_nearest_landmark({1.0, 2.0, 3.0}, 0);
+  ASSERT_FALSE(nearest.has_value());
+}
+
+struct LandmarkMapBearingTest : public ::testing::Test {
+  beluga::LandmarkMapBoundaries default_map_boundaries{0.0, 10.0, 1.0, 11.0, 2.0, 12.0};
+
+  beluga::LandmarkMap uut{
+      default_map_boundaries,
+      {
+          // category 0
+          {{+9.0, +0.0, +1.0}, 0},
+          {{+0.0, +9.0, +1.0}, 0},
+          {{+0.0, +0.0, +9.0}, 0},
+          // category 1
+          {{-9.0, +0.0, +1.0}, 1},
+          {{+0.0, -9.0, +1.0}, 1},
+          {{+0.0, +0.0, -9.0}, 1},
+          // category 2
+          {{+0.0, +0.0, -9.0}, 2},
+      }};
+
+  Sophus::SE3d sensor_pose_in_world{Sophus::SO3d{}, Eigen::Vector3d{0.0, 0.0, 1.0}};
+};
+
+TEST_F(LandmarkMapBearingTest, MapLimits) {
+  ASSERT_DOUBLE_EQ(uut.map_limits().x_min, 0.0);
+  ASSERT_DOUBLE_EQ(uut.map_limits().x_max, 10.0);
+  ASSERT_DOUBLE_EQ(uut.map_limits().y_min, 1.0);
+  ASSERT_DOUBLE_EQ(uut.map_limits().y_max, 11.0);
+  ASSERT_DOUBLE_EQ(uut.map_limits().z_min, 2.0);
+  ASSERT_DOUBLE_EQ(uut.map_limits().z_max, 12.0);
+}
+
+TEST_F(LandmarkMapBearingTest, TrivialQuery1) {
+  const auto expected_bearing = beluga::LandmarkBearing3{1.0, 0.0, 0.0};
+  const auto nearest = uut.find_closest_bearing_landmark(expected_bearing, 0, sensor_pose_in_world);
+  ASSERT_TRUE(nearest.has_value());
+  EXPECT_NEAR(0.0, (*nearest - expected_bearing).norm(), 1e-6);
+}
+
+TEST_F(LandmarkMapBearingTest, TrivialQuery2) {
+  const auto expected_bearing = beluga::LandmarkBearing3{-1.0, 0.0, 0.0};
+  const auto nearest = uut.find_closest_bearing_landmark(expected_bearing, 1, sensor_pose_in_world);
+  ASSERT_TRUE(nearest.has_value());
+  EXPECT_NEAR(0.0, (*nearest - expected_bearing).norm(), 1e-6);
+}
+
+TEST_F(LandmarkMapBearingTest, FeatureInTotallyDifferentDirection) {
+  const auto detection_bearing = beluga::LandmarkBearing3{1.0, 0.0, 0.0};
+  const auto expected_bearing = beluga::LandmarkBearing3{0.0, 0.0, -1.0};
+  const auto nearest = uut.find_closest_bearing_landmark(detection_bearing, 2, sensor_pose_in_world);
+  ASSERT_TRUE(nearest.has_value());
+  EXPECT_NEAR(0.0, (*nearest - expected_bearing).norm(), 1e-6);
+}
+
+TEST_F(LandmarkMapBearingTest, NoSuchFeature) {
+  const auto nearest =
+      uut.find_closest_bearing_landmark(beluga::LandmarkBearing3{1.0, 0.0, 0.0}, 99, sensor_pose_in_world);
+  ASSERT_FALSE(nearest.has_value());
+}
+
+}  // namespace

--- a/beluga/test/beluga/sensor/test_beam_model.cpp
+++ b/beluga/test/beluga/sensor/test_beam_model.cpp
@@ -16,7 +16,6 @@
 
 #include "beluga/algorithm/raycasting.hpp"
 #include "beluga/sensor.hpp"
-#include "beluga/sensor/beam_model.hpp"
 
 #include "beluga/test/static_occupancy_grid.hpp"
 

--- a/beluga/test/beluga/sensor/test_bearing_sensor_model.cpp
+++ b/beluga/test/beluga/sensor/test_bearing_sensor_model.cpp
@@ -1,0 +1,207 @@
+// Copyright 2023 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+// external
+#include <ciabatta/ciabatta.hpp>
+
+// standard library
+#include <algorithm>
+#include <random>
+#include <vector>
+
+// project
+#include <beluga/sensor.hpp>
+#include <beluga/sensor/data/landmark_map.hpp>
+
+namespace beluga {
+
+using Sensor2D = ciabatta::mixin<
+    ciabatta::curry<beluga::BearingSensorModel2d, LandmarkMap>::mixin,
+    ciabatta::provides<beluga::BearingSensorModelInterface<LandmarkMap>>::mixin>;
+
+using Sensor3D = ciabatta::mixin<
+    ciabatta::curry<beluga::BearingSensorModel3d, LandmarkMap>::mixin,
+    ciabatta::provides<beluga::BearingSensorModelInterface<LandmarkMap>>::mixin>;
+
+LandmarkMapBoundaries default_map_boundaries{-10.0, -10.0, 10.0, 10.0, 0.0, 0.0};
+
+double expected_aggregate_probability(std::vector<double> landmark_probs) {
+  // nav2_amcl formula, $1.0 + \sum_{i=1}^n p_i^3$
+  return std::transform_reduce(
+      landmark_probs.cbegin(), landmark_probs.cend(), 1.0, std::plus{}, [](const double v) { return v * v * v; });
+}
+
+BearingModelParam get_default_model_params() {
+  BearingModelParam ret;
+  ret.sigma_bearing = Sophus::Constants<double>::pi() / 4.0;  // 45 degrees
+  ret.sensor_pose_in_robot = Sophus::SE3d{Sophus::SO3d{}, Eigen::Vector3d{0.0, 0.0, 1.0}};
+  return ret;
+}
+
+auto make_sensor_data(std::vector<std::tuple<double, double, double, uint32_t>> detections) {
+  const auto conversion_function = [](const auto& t) {
+    const auto [x, y, z, category] = t;
+    return LandmarkBearingDetection{Eigen::Vector3d{x, y, z}, category};
+  };
+  return detections | ranges::views::transform(conversion_function) | ranges::to<std::vector>;
+}
+
+template <typename T>
+T get_robot_pose_in_world();
+
+template <>
+Sophus::SE2d get_robot_pose_in_world<Sophus::SE2d>() {
+  return Sophus::SE2d{Sophus::SO2d{-Sophus::Constants<double>::pi() / 2.0}, Eigen::Vector2d{1.0, -1.0}};
+}
+
+template <>
+Sophus::SE3d get_robot_pose_in_world<Sophus::SE3d>() {
+  return Sophus::SE3d{Sophus::SO3d::rotZ(-Sophus::Constants<double>::pi() / 2.0), Eigen::Vector3d{1.0, -1.0, 0.0}};
+}
+
+template <typename T>
+struct BearingSensorModelTests : public ::testing::Test {};
+
+using BearingSensorModelTestsTypes = ::testing::Types<Sensor2D, Sensor3D>;
+
+TYPED_TEST_SUITE(BearingSensorModelTests, BearingSensorModelTestsTypes);
+
+TYPED_TEST(BearingSensorModelTests, SmokeTest) {
+  auto uut = std::make_unique<TypeParam>(
+      get_default_model_params(), LandmarkMap(default_map_boundaries, {{{1.0, -1.0, 1.0}, 0}}));
+}
+
+TYPED_TEST(BearingSensorModelTests, BullsEyeDetection) {
+  // test case where the landmark is exactly where we expected it
+  auto uut = std::make_unique<TypeParam>(
+      get_default_model_params(), LandmarkMap(default_map_boundaries, {{{1.0, -2.0, 1.0}, 0}}));
+  ASSERT_NO_THROW(uut->update_sensor({{{1.0, 0.0, 0.0}, 0}}));
+  EXPECT_NEAR(
+      expected_aggregate_probability({1.0}),
+      uut->importance_weight(get_robot_pose_in_world<typename TypeParam::state_type>()), 1e-02);
+}
+
+TYPED_TEST(BearingSensorModelTests, MapUpdate) {
+  // test calls to the update_map function
+  auto map_1 = LandmarkMap(default_map_boundaries, {});
+  auto map_2 = LandmarkMap(default_map_boundaries, {{{1.0, -2.0, 1.0}, 0}});
+  auto uut = std::make_unique<TypeParam>(get_default_model_params(), std::move(map_1));
+  ASSERT_NO_THROW(uut->update_sensor({{{1.0, 0.0, 0.0}, 0}}));
+  EXPECT_NEAR(
+      expected_aggregate_probability({0.0}),
+      uut->importance_weight(get_robot_pose_in_world<typename TypeParam::state_type>()), 1e-02);
+  ASSERT_NO_THROW(uut->update_map(std::move(map_2)));
+  EXPECT_NEAR(
+      expected_aggregate_probability({1.0}),
+      uut->importance_weight(get_robot_pose_in_world<typename TypeParam::state_type>()), 1e-02);
+}
+
+TYPED_TEST(BearingSensorModelTests, MultipleBullsEyeDetections) {
+  // Test multiple detections of with different ids, all perfectly matching
+  auto uut = std::make_unique<TypeParam>(
+      get_default_model_params(),  //
+      LandmarkMap(                 //
+          default_map_boundaries,  //
+          {
+              {{1.0, -2.0, 0.0}, 0},  // landmark 0
+              {{1.0, -2.0, 1.0}, 1},  // landmark 1
+              {{1.0, -2.0, 2.0}, 2},  // landmark 2
+          }));
+
+  ASSERT_NO_THROW(uut->update_sensor({
+      {{+1.0, +0.0, -1.0}, 0},  // landmark 0 detection
+      {{+1.0, +0.0, +0.0}, 1},  // landmark 1 detection
+      {{+1.0, +0.0, +1.0}, 2},  // landmark 2 detection
+  }));
+
+  EXPECT_NEAR(
+      expected_aggregate_probability({1.0, 1.0, 1.0}),
+      uut->importance_weight(get_robot_pose_in_world<typename TypeParam::state_type>()), 1e-02);
+}
+
+TYPED_TEST(BearingSensorModelTests, OneStdInBearing) {
+  // test case where the landmark is 1 std offset from the expected bearing
+  auto uut = std::make_unique<TypeParam>(
+      get_default_model_params(), LandmarkMap(default_map_boundaries, {{{1.0, -2.0, 1.0}, 0}}));
+  // baseline
+  ASSERT_NO_THROW(uut->update_sensor({{{1.0, 0.0, 0.0}, 0}}));
+  EXPECT_NEAR(
+      expected_aggregate_probability({1.0}),
+      uut->importance_weight(get_robot_pose_in_world<typename TypeParam::state_type>()), 1e-02);
+  // 1 std left
+  ASSERT_NO_THROW(uut->update_sensor({{{1.0, 1.0, 0.0}, 0}}));
+  EXPECT_NEAR(
+      expected_aggregate_probability({0.6}),
+      uut->importance_weight(get_robot_pose_in_world<typename TypeParam::state_type>()), 1e-02);
+  // 1 std right
+  ASSERT_NO_THROW(uut->update_sensor({{{1.0, -1.0, 0.0}, 0}}));
+  EXPECT_NEAR(
+      expected_aggregate_probability({0.6}),
+      uut->importance_weight(get_robot_pose_in_world<typename TypeParam::state_type>()), 1e-02);
+  // 1 std up
+  ASSERT_NO_THROW(uut->update_sensor({{{1.0, 0.0, 1.0}, 0}}));
+  EXPECT_NEAR(
+      expected_aggregate_probability({0.6}),
+      uut->importance_weight(get_robot_pose_in_world<typename TypeParam::state_type>()), 1e-02);
+  // 1 std down
+  ASSERT_NO_THROW(uut->update_sensor({{{1.0, 0.0, -1.0}, 0}}));
+  EXPECT_NEAR(
+      expected_aggregate_probability({0.6}),
+      uut->importance_weight(get_robot_pose_in_world<typename TypeParam::state_type>()), 1e-02);
+}
+
+TYPED_TEST(BearingSensorModelTests, NoSuchLandmark) {
+  // perfect bearing measurement
+  auto uut = std::make_unique<TypeParam>(
+      get_default_model_params(), LandmarkMap(default_map_boundaries, {{{1.0, -1.0, 1.0}, 0}}));
+  ASSERT_NO_THROW(uut->update_sensor({{{1.0, 0.0, 0.0}, 99}}));
+  EXPECT_NEAR(
+      expected_aggregate_probability({0.0}),
+      uut->importance_weight(get_robot_pose_in_world<typename TypeParam::state_type>()), 1e-02);
+}
+
+TYPED_TEST(BearingSensorModelTests, SampleGeneration) {
+  // check that if I draw 1000 samples, I get a distribution that matches the expected one
+  auto uut = std::make_unique<TypeParam>(
+      get_default_model_params(),  //
+      LandmarkMap(                 //
+          default_map_boundaries,  //
+          {}));
+
+  // create a random generator engine
+  std::default_random_engine rd{42};
+
+  // get the limits of the map
+  const auto [xmin, xmax, ymin, ymax, zmin, zmax] = default_map_boundaries;
+
+  // generate 1000 samples, checking each of them to be within the map limits
+  std::vector<typename TypeParam::state_type> samples;
+  for (int i = 0; i < 1000; ++i) {
+    const auto sample = uut->make_random_state(rd);
+
+    EXPECT_GE(sample.translation().x(), xmin);
+    EXPECT_LE(sample.translation().x(), xmax);
+    EXPECT_GE(sample.translation().y(), ymin);
+    EXPECT_LE(sample.translation().y(), ymax);
+
+    if constexpr (std::is_same_v<typename TypeParam::state_type, Sophus::SE3d>) {
+      EXPECT_GE(sample.translation().z(), zmin);
+      EXPECT_LE(sample.translation().z(), zmax);
+    }
+  }
+}
+
+}  // namespace beluga

--- a/beluga/test/beluga/sensor/test_landmark_sensor_model.cpp
+++ b/beluga/test/beluga/sensor/test_landmark_sensor_model.cpp
@@ -1,0 +1,213 @@
+// Copyright 2023 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+// external
+#include <ciabatta/ciabatta.hpp>
+#include <sophus/se2.hpp>
+#include <sophus/so2.hpp>
+
+// standard library
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+// project
+#include <beluga/sensor.hpp>
+#include <beluga/sensor/data/landmark_map.hpp>
+
+namespace beluga {
+
+namespace {
+
+using Sensor2D = ciabatta::mixin<
+    ciabatta::curry<beluga::LandmarkSensorModel2d, LandmarkMap>::mixin,
+    ciabatta::provides<beluga::LandmarkSensorModelInterface<LandmarkMap>>::mixin>;
+
+using Sensor3D = ciabatta::mixin<
+    ciabatta::curry<beluga::LandmarkSensorModel3d, LandmarkMap>::mixin,
+    ciabatta::provides<beluga::LandmarkSensorModelInterface<LandmarkMap>>::mixin>;
+
+double expected_aggregate_probability(std::vector<double> landmark_probs) {
+  // nav2_amcl formula, $1.0 + \sum_{i=1}^n p_i^3$
+  return std::transform_reduce(
+      landmark_probs.cbegin(), landmark_probs.cend(), 1.0, std::plus{}, [](const double v) { return v * v * v; });
+}
+
+LandmarkModelParam get_default_model_params() {
+  LandmarkModelParam ret;
+  ret.sigma_range = 1.0;
+  ret.sigma_bearing = Sophus::Constants<double>::pi() / 2.0;  // 90 degrees
+  return ret;
+}
+
+template <typename T>
+T get_robot_pose_in_world();
+
+template <>
+Sophus::SE2d get_robot_pose_in_world<Sophus::SE2d>() {
+  return Sophus::SE2d{Sophus::SO2d{-Sophus::Constants<double>::pi() / 2.0}, Eigen::Vector2d{1.0, -1.0}};
+}
+
+template <>
+Sophus::SE3d get_robot_pose_in_world<Sophus::SE3d>() {
+  return Sophus::SE3d{Sophus::SO3d::rotZ(-Sophus::Constants<double>::pi() / 2.0), Eigen::Vector3d{1.0, -1.0, 0.0}};
+}
+
+LandmarkMapBoundaries default_map_boundaries{-10.0, -10.0, 10.0, 10.0, 0.0, 0.0};
+
+template <typename T>
+struct LandmarkSensorModelTests : public ::testing::Test {};
+
+using LandmarkSensorModelTestsTypes = ::testing::Types<Sensor2D, Sensor3D>;
+
+TYPED_TEST_SUITE(LandmarkSensorModelTests, LandmarkSensorModelTestsTypes);
+
+TYPED_TEST(LandmarkSensorModelTests, BullsEyeDetection) {
+  // test case where the landmark is exactly where we expected it
+  auto uut = std::make_unique<TypeParam>(
+      get_default_model_params(), LandmarkMap(default_map_boundaries, {{{3.0, -2.0, 0.0}, 0}}));
+  ASSERT_NO_THROW(uut->update_sensor({{{1.0, 2.0, 0.0}, 0}}));
+  EXPECT_NEAR(
+      expected_aggregate_probability({1.0}),
+      uut->importance_weight(get_robot_pose_in_world<typename TypeParam::state_type>()), 1e-02);
+}
+
+TYPED_TEST(LandmarkSensorModelTests, MapUpdate) {
+  // test calls to the update_map function
+  auto map_1 = LandmarkMap(default_map_boundaries, {});
+  auto map_2 = LandmarkMap(default_map_boundaries, {{{3.0, -2.0, 0.0}, 0}});
+  auto uut = std::make_unique<TypeParam>(get_default_model_params(), std::move(map_1));
+  ASSERT_NO_THROW(uut->update_sensor({{{1.0, 2.0, 0.0}, 0}}));
+  EXPECT_NEAR(
+      expected_aggregate_probability({0.0}),
+      uut->importance_weight(get_robot_pose_in_world<typename TypeParam::state_type>()), 1e-02);
+  ASSERT_NO_THROW(uut->update_map(std::move(map_2)));
+  EXPECT_NEAR(
+      expected_aggregate_probability({1.0}),
+      uut->importance_weight(get_robot_pose_in_world<typename TypeParam::state_type>()), 1e-02);
+}
+
+TYPED_TEST(LandmarkSensorModelTests, MultipleBullsEyeDetections) {
+  // Test multiple detections of with different ids, all perfectly matching
+  auto uut = std::make_unique<TypeParam>(
+      get_default_model_params(),  //
+      LandmarkMap(                 //
+          default_map_boundaries,  //
+          {
+              {{1.0, -2.0, 0.0}, 0},  // landmark 0
+              {{1.0, -0.0, 0.0}, 1},  // landmark 1
+              {{2.0, -1.0, 0.0}, 2},  // landmark 2
+              {{0.0, -1.0, 0.0}, 3},  // landmark 3
+          }));
+
+  ASSERT_NO_THROW(uut->update_sensor({
+      {{+1.0, +0.0, 0.0}, 0},  // landmark 0 detection
+      {{-1.0, +0.0, 0.0}, 1},  // landmark 1 detection
+      {{+0.0, +1.0, 0.0}, 2},  // landmark 2 detection
+      {{+0.0, -1.0, 0.0}, 3},  // landmark 3 detection
+  }));
+
+  EXPECT_NEAR(
+      expected_aggregate_probability({1.0, 1.0, 1.0, 1.0}),
+      uut->importance_weight(get_robot_pose_in_world<typename TypeParam::state_type>()), 1e-02);
+}
+
+TYPED_TEST(LandmarkSensorModelTests, OneStdInRange) {
+  // test case where the landmark is 1 std offset from the expected range
+  auto uut = std::make_unique<TypeParam>(
+      get_default_model_params(), LandmarkMap(default_map_boundaries, {{{1.0, -11.0, 0.0}, 0}}));
+  // baseline
+  ASSERT_NO_THROW(uut->update_sensor({{{10.0, 0.0, 0.0}, 0}}));
+  EXPECT_NEAR(
+      expected_aggregate_probability({1.0}),
+      uut->importance_weight(get_robot_pose_in_world<typename TypeParam::state_type>()), 1e-02);
+  // 1 std default
+  ASSERT_NO_THROW(uut->update_sensor({{{9.0, 0.0, 0.0}, 0}}));
+  EXPECT_NEAR(
+      expected_aggregate_probability({0.6}),
+      uut->importance_weight(get_robot_pose_in_world<typename TypeParam::state_type>()), 1e-02);
+  // 1 std excess
+  ASSERT_NO_THROW(uut->update_sensor({{{11.0, 0.0, 0.0}, 0}}));
+  EXPECT_NEAR(
+      expected_aggregate_probability({0.6}),
+      uut->importance_weight(get_robot_pose_in_world<typename TypeParam::state_type>()), 1e-02);
+}
+
+TYPED_TEST(LandmarkSensorModelTests, OneStdInBearing) {
+  // test case where the landmark is 1 std offset from the expected bearing
+  auto uut = std::make_unique<TypeParam>(
+      get_default_model_params(), LandmarkMap(default_map_boundaries, {{{1.0, -11.0, 0.0}, 0}}));
+  // baseline
+  ASSERT_NO_THROW(uut->update_sensor({{{10.0, 0.0, 0.0}, 0}}));
+  EXPECT_NEAR(
+      expected_aggregate_probability({1.0}),
+      uut->importance_weight(get_robot_pose_in_world<typename TypeParam::state_type>()), 1e-02);
+  // 1 std default
+  ASSERT_NO_THROW(uut->update_sensor({{{0.0, 10.0, 0.0}, 0}}));
+  EXPECT_NEAR(
+      expected_aggregate_probability({0.6}),
+      uut->importance_weight(get_robot_pose_in_world<typename TypeParam::state_type>()), 1e-02);
+  // 1 std excess
+  ASSERT_NO_THROW(uut->update_sensor({{{0.0, -10.0, 0.0}, 0}}));
+  EXPECT_NEAR(
+      expected_aggregate_probability({0.6}),
+      uut->importance_weight(get_robot_pose_in_world<typename TypeParam::state_type>()), 1e-02);
+}
+
+TYPED_TEST(LandmarkSensorModelTests, NoSuchLandmark) {
+  // test case where there is not landmark in the map of the detected id
+  auto uut = std::make_unique<TypeParam>(
+      get_default_model_params(), LandmarkMap(default_map_boundaries, {{{0.0, 1.0, 0.0}, 99}}));
+  ASSERT_NO_THROW(uut->update_sensor({{{0.0, 2.0, 0.0}, 88}}));
+  EXPECT_NEAR(
+      expected_aggregate_probability({0.0}),
+      uut->importance_weight(get_robot_pose_in_world<typename TypeParam::state_type>()), 1e-02);
+}
+
+TYPED_TEST(LandmarkSensorModelTests, SampleGeneration) {
+  // check that if I draw 1000 samples, I get a distribution that matches the expected one
+  auto uut = std::make_unique<TypeParam>(
+      get_default_model_params(),  //
+      LandmarkMap(                 //
+          default_map_boundaries,  //
+          {}));
+
+  // create a random generator engine
+  std::default_random_engine rd{42};
+
+  // get the limits of the map
+  const auto [xmin, xmax, ymin, ymax, zmin, zmax] = default_map_boundaries;
+
+  // generate 1000 samples, checking each of them to be within the map limits
+  std::vector<typename TypeParam::state_type> samples;
+  for (int i = 0; i < 1000; ++i) {
+    const auto sample = uut->make_random_state(rd);
+
+    EXPECT_GE(sample.translation().x(), xmin);
+    EXPECT_LE(sample.translation().x(), xmax);
+    EXPECT_GE(sample.translation().y(), ymin);
+    EXPECT_LE(sample.translation().y(), ymax);
+
+    if constexpr (std::is_same_v<typename TypeParam::state_type, Sophus::SE3d>) {
+      EXPECT_GE(sample.translation().z(), zmin);
+      EXPECT_LE(sample.translation().z(), zmax);
+    }
+  }
+}
+
+}  // namespace
+
+}  // namespace beluga

--- a/beluga/test/beluga/sensor/test_likelihood_field_model.cpp
+++ b/beluga/test/beluga/sensor/test_likelihood_field_model.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "beluga/sensor.hpp"
-#include "beluga/sensor/likelihood_field_model.hpp"
 #include "beluga/test/static_occupancy_grid.hpp"
 
 #include "ciabatta/ciabatta.hpp"

--- a/beluga_amcl/include/beluga_amcl/particle_filtering.hpp
+++ b/beluga_amcl/include/beluga_amcl/particle_filtering.hpp
@@ -22,7 +22,7 @@
 
 #include <beluga/mixin.hpp>
 #include <beluga/motion/differential_drive_model.hpp>
-#include <beluga/sensor/likelihood_field_model.hpp>
+#include <beluga/sensor.hpp>
 #include <beluga_amcl/filter_update_control/filter_update_control_mixin.hpp>
 #include <beluga_amcl/filter_update_control/resample_interval_policy.hpp>
 #include <beluga_amcl/filter_update_control/selective_resampling_policy.hpp>

--- a/beluga_amcl/src/amcl_node.cpp
+++ b/beluga_amcl/src/amcl_node.cpp
@@ -31,7 +31,6 @@
 #include <beluga/mixin.hpp>
 #include <beluga/motion/differential_drive_model.hpp>
 #include <beluga/random/multivariate_normal_distribution.hpp>
-#include <beluga/sensor/likelihood_field_model.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <lifecycle_msgs/msg/state.hpp>
 #include <range/v3/algorithm/transform.hpp>

--- a/beluga_system_tests/test/test_system.cpp
+++ b/beluga_system_tests/test/test_system.cpp
@@ -26,7 +26,6 @@
 #include <beluga/localization.hpp>
 #include <beluga/motion/differential_drive_model.hpp>
 #include <beluga/random/multivariate_normal_distribution.hpp>
-#include <beluga/sensor/likelihood_field_model.hpp>
 #include <beluga_amcl/amcl_node_utils.hpp>
 #include <beluga_amcl/filter_update_control/filter_update_control_mixin.hpp>
 #include <beluga_amcl/filter_update_control/resample_interval_policy.hpp>


### PR DESCRIPTION
### Proposed changes

 - Adds a slightly polished version of the landmark and bearing sensor models created during last week's hackaton.
 - Both have been extended to both 2D and 3D particle states (since it was trivial).
 - Tests have been improved.
 - A residual bug in the bearing model was found and fixed.
 - Minor refactoring to avoid crowding the `sensors.hpp` file with interfaces.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 **Breaking change!** _Explain why a non-backwards compatible change is necessary or remove this line entirely if not applicable._

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

_Anything worth mentioning to the reviewers._
