### PR TITLE
Improve spatial_hash function to avoid spatial periodicity in the hash function

### DIFF
--- a/beluga/test/beluga/test_spatial_hash.cpp
+++ b/beluga/test/beluga/test_spatial_hash.cpp
@@ -98,4 +98,51 @@ TEST(SpatialHash, Array) {
   EXPECT_EQ(hash1, hash2);
 }
 
+TEST(SpatialHash, NonPeriodicityCheck1) {
+  using Array = std::array<double, 8>;
+  constexpr std::array kClusteringResolution{1., 1., 1., 1., 1., 1., 1., 1.};
+
+  auto uut = beluga::spatial_hash<Array>{kClusteringResolution};
+
+  auto hash0 = uut({0., 0., 0., 0., 0., 0., 0., 0.});
+  auto hash1 = uut({64., 0., 0., 0., 0., 0., 0., 0.});
+  auto hash2 = uut({128., 0., 0., 0., 0., 0., 0., 0.});
+  auto hash3 = uut({192., 0., 0., 0., 0., 0., 0., 0.});
+  auto hash4 = uut({256., 0., 0., 0., 0., 0., 0., 0.});
+
+  EXPECT_NE(hash0, hash1);
+  EXPECT_NE(hash0, hash2);
+  EXPECT_NE(hash0, hash3);
+  EXPECT_NE(hash0, hash4);
+}
+
+TEST(SpatialHash, NonPeriodicityCheck2) {
+  using Array = std::array<double, 8>;
+  constexpr std::array kClusteringResolution{1., 1., 1., 1., 1., 1., 1., 1.};
+  constexpr double kStep = 2.0;
+
+  auto uut = beluga::spatial_hash<Array>{kClusteringResolution};
+
+  auto ref_hash = uut({0., 0., 0., 0., 0., 0., 0., 0.});
+
+  for (double n = kStep; n < 1024.; n += kStep) {
+    auto hash0 = uut({n, 0., 0., 0., 0., 0., 0., 0.});
+    auto hash1 = uut({0., n, 0., 0., 0., 0., 0., 0.});
+    auto hash2 = uut({0., 0., n, 0., 0., 0., 0., 0.});
+    auto hash3 = uut({0., 0., 0., n, 0., 0., 0., 0.});
+    auto hash4 = uut({0., 0., 0., 0., n, 0., 0., 0.});
+    auto hash5 = uut({0., 0., 0., 0., 0., n, 0., 0.});
+    auto hash6 = uut({0., 0., 0., 0., 0., 0., n, 0.});
+    auto hash7 = uut({0., 0., 0., 0., 0., 0., 0., n});
+    EXPECT_NE(ref_hash, hash0);
+    EXPECT_NE(ref_hash, hash1);
+    EXPECT_NE(ref_hash, hash2);
+    EXPECT_NE(ref_hash, hash3);
+    EXPECT_NE(ref_hash, hash4);
+    EXPECT_NE(ref_hash, hash5);
+    EXPECT_NE(ref_hash, hash6);
+    EXPECT_NE(ref_hash, hash7);
+  }
+}
+
 }  // namespace


### PR DESCRIPTION
### Proposed changes

Adds two commits:

- The first one adds periodicity checks that the existing hash function does not pass.
- The second one updates the hash function to pass old and new tests.

Based on:

- https://en.wikipedia.org/wiki/Hash_function#Fibonacci_hashing
- https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 **Breaking change!** _Explain why a non-backwards compatible change is necessary or remove this line entirely if not applicable._

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

_Anything worth mentioning to the reviewers._
