### PR TITLE
Add cluster based estimator

### DIFF
--- a/beluga/include/beluga/algorithm.hpp
+++ b/beluga/include/beluga/algorithm.hpp
@@ -20,6 +20,7 @@
  * \brief Includes all beluga algorithms.
  */
 
+#include <beluga/algorithm/cluster_based_estimation.hpp>
 #include <beluga/algorithm/distance_map.hpp>
 #include <beluga/algorithm/effective_sample_size.hpp>
 #include <beluga/algorithm/estimation.hpp>

--- a/beluga/include/beluga/algorithm/cluster_based_estimation.hpp
+++ b/beluga/include/beluga/algorithm/cluster_based_estimation.hpp
@@ -24,7 +24,6 @@
 #include <vector>
 
 // external
-#include <range/v3/action/sort.hpp>
 #include <range/v3/algorithm/max_element.hpp>
 #include <range/v3/numeric/accumulate.hpp>
 #include <range/v3/range/conversion.hpp>
@@ -94,8 +93,10 @@ template <class Map, class Proj>
  */
 template <class Range>
 [[nodiscard]] auto calculate_percentile_threshold(Range&& range, double percentile) {
-  auto values = range | ranges::to<std::vector> | ranges::actions::sort;
-  return values[static_cast<std::size_t>(static_cast<double>(values.size()) * percentile)];
+  auto values = range | ranges::to<std::vector>;
+  const auto n = static_cast<std::size_t>(static_cast<double>(values.size()) * percentile);
+  std::nth_element(values.begin(), values.begin() + n, values.end());
+  return values[n];
 }
 
 /// Implementation utilities for a particle clusterizer algorithm.

--- a/beluga/include/beluga/algorithm/cluster_based_estimation.hpp
+++ b/beluga/include/beluga/algorithm/cluster_based_estimation.hpp
@@ -1,0 +1,421 @@
+// Copyright 2023-2024 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BELUGA_ALGORITHM_CLUSTER_BASED_ESTIMATION_HPP
+#define BELUGA_ALGORITHM_CLUSTER_BASED_ESTIMATION_HPP
+
+// standard library
+#include <functional>
+#include <optional>
+#include <queue>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+// external
+#include <range/v3/action/sort.hpp>
+#include <range/v3/algorithm/max_element.hpp>
+#include <range/v3/numeric/accumulate.hpp>
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view/cache1.hpp>
+#include <range/v3/view/filter.hpp>
+#include <range/v3/view/map.hpp>
+#include <range/v3/view/zip.hpp>
+#include <sophus/se2.hpp>
+#include <sophus/types.hpp>
+
+// project
+#include <beluga/algorithm/estimation.hpp>
+#include <beluga/algorithm/spatial_hash.hpp>
+#include <beluga/views.hpp>
+
+/**
+ * \file
+ * \brief Implementation of a cluster-based estimation algorithm.
+ */
+
+namespace beluga {
+
+/// Create a priority queue from a map using a specified projection.
+/**
+ * This function template constructs a priority queue where the elements are
+ * ordered by a priority value derived from the map's values.
+ * The elements in the queue will contain a key that belongs to the map and the
+ * corresponding priority.
+ *
+ * \tparam Map The type of the associative container.
+ * \tparam Proj The type of the projection invocable.
+ * \param map The map containing the data to be inserted into the priority queue.
+ * \param proj The projection function used to compute the priority of each element.
+ * \return A priority queue where elements are ordered by the priority computed
+ *         from the map's values using the projection function.
+ */
+template <class Map, class Proj>
+[[nodiscard]] auto make_priority_queue(const Map& map, Proj&& proj) {
+  struct KeyWithPriority {
+    double priority;  // priority value used to order the queue (higher value first).
+    std::size_t key;  // hash of the cell in the grid cell data map.
+
+    bool operator<(const KeyWithPriority& other) const {
+      return priority < other.priority;  // sort in decreasing priority order
+    }
+  };
+
+  const auto make_from_pair = [proj = std::forward<Proj>(proj)](const auto& pair) {
+    return KeyWithPriority{std::invoke(proj, pair.second), pair.first};
+  };
+
+  const auto range = map |                                       //
+                     ranges::views::transform(make_from_pair) |  //
+                     ranges::views::common;
+
+  return std::priority_queue<KeyWithPriority>(range.begin(), range.end());
+}
+
+/// Calculates the threshold value at a specified percentile from a range.
+/**
+ * Find the value that is greater than the given percentage of the numbers in a range.
+ *
+ * \tparam Range The type of the input range containing the values.
+ * \param range The input range of values from which to calculate the percentile threshold.
+ * \param percentile The percentile (between 0 and 1) to calculate the threshold for.
+ * \return The value at the specified percentile in the sorted range.
+ */
+template <class Range>
+[[nodiscard]] auto calculate_percentile_threshold(Range&& range, double percentile) {
+  auto values = range | ranges::to<std::vector> | ranges::actions::sort;
+  return values[static_cast<std::size_t>(static_cast<double>(values.size()) * percentile)];
+}
+
+/// Implementation utilities for a particle clusterizer algorithm.
+struct ParticleClusterizerImpl {
+  /// A struct that holds the data of a single cell for the clusterization algorithm.
+  template <class State>
+  struct Cell {
+    State representative_state;             ///< state of a particle that is within the cell
+    double weight{0.0};                     ///< average weight of the cell
+    std::size_t num_particles{0};           ///< number of particles in the cell
+    std::optional<std::size_t> cluster_id;  ///< cluster id of the cell
+  };
+
+  /// A map that holds the sparse data about the particles grouped in cells.
+  template <class State>
+  using Map = std::unordered_map<std::size_t, Cell<State>>;
+
+  /// Create a cluster map from a range of particles and their corresponding spatial hashes.
+  /**
+   * This method will populate all the relevant fields in the map except for the cluster ID,
+   * which has to be computed with a separate call to `assign_clusters`.
+   *
+   * \tparam States The range type for particle states.
+   * \tparam Weights The range type for particle weights.
+   * \tparam Hashes The range type for particle spatial hashes.
+   * \param states A range of particle states.
+   * \param weights A range of particle weights.
+   * \param hashes A range of particle spatial hashes.
+   * \return A map where each unique hash corresponds to a cell with accumulated weight, particle count, and
+   * representative state.
+   */
+  template <class States, class Weights, class Hashes>
+  [[nodiscard]] static auto make_cluster_map(States&& states, Weights&& weights, Hashes&& hashes) {
+    using State = ranges::range_value_t<States>;
+    Map<State> map;
+
+    // Preallocate memory with a very rough estimation of the number of cells we might end up with.
+    map.reserve(states.size() / 5);
+
+    // Calculate the accumulated cell weight and save a single representative state for each cell.
+    for (const auto& [state, weight, hash] : ranges::views::zip(states, weights, hashes)) {
+      auto [it, inserted] = map.try_emplace(hash, Cell<State>{});
+      auto& [_, entry] = *it;
+      entry.weight += weight;
+      entry.num_particles++;
+      if (inserted) {
+        entry.representative_state = state;
+      }
+    }
+
+    return map;
+  }
+
+  /// Normalize weights and cap them to a given percentile.
+  /**
+   * Given a valid cluster map, normalize the accumulated weight by the number of particles
+   * in each cell to avoid biasing the clustering algorithm towards cells that randomly end up
+   * with more particles than others.
+   *
+   * Then cap the values to a given percentile to flatten the top of the approximated
+   * density function and make the clustering algorithm more robust to estimation noise,
+   * by fusing together any adjacent peaks whose weight is above the threshold.
+   *
+   * \tparam State The state type of the cells in the map.
+   * \param map A reference to the map where cells are stored.
+   * \param percentile The percentile threshold for capping the weights.
+   */
+  template <class State>
+  static void normalize_and_cap_weights(Map<State>& map, double percentile) {
+    auto entries = ranges::views::values(map);
+
+    for (auto& entry : entries) {
+      assert(entry.num_particles > 0);
+      entry.weight /= static_cast<double>(entry.num_particles);
+    }
+
+    const double max_weight =
+        calculate_percentile_threshold(ranges::views::transform(entries, &Cell<State>::weight), percentile);
+
+    for (auto& entry : entries) {
+      entry.weight = std::min(entry.weight, max_weight);
+    }
+  }
+
+  /// Assign cluster ids to an existing cluster map.
+  /**
+   * This function implements a clustering algorithm that assigns cluster IDs to cells in a map
+   * based on their spatial relationships.
+   *
+   * Notice that with this algorithm each cell will go through the priority queue at most twice.
+   *
+   * \tparam State The state type of the cells in the map.
+   * \tparam NeighborsFunction A callable object that, given a state, returns a range of neighboring cell hashes.
+   * \param map A reference to the map where cells are stored.
+   * \param neighbors_function A function that returns neighboring cell hashes for a given state.
+   */
+  template <class State, class NeighborsFunction>
+  static void assign_clusters(Map<State>& map, NeighborsFunction&& neighbors_function) {
+    auto queue = make_priority_queue(map, &Cell<State>::weight);
+    const auto max_priority = queue.top().priority;
+
+    std::size_t next_cluster_id = 0;
+
+    // Process cells in order of descending weight.
+    while (!queue.empty()) {
+      const auto hash = queue.top().key;
+      queue.pop();
+
+      // The hash is guaranteed to exist in the map.
+      auto& cell = map[hash];
+
+      // If there's no cluster id assigned to the cell, assign a new one.
+      if (!cell.cluster_id.has_value()) {
+        cell.cluster_id = next_cluster_id++;
+      }
+
+      // Process the neighbors of the cell; if they don't have a cluster id already assigned
+      // then assign them one and add them to the queue with an inflated priority
+      // to ensure they get processed ASAP before moving on to other local peaks.
+      // Notice that with this algorithm each cell will go through the priority queue at most twice.
+
+      // Define a lambda to check if a neighboring cell is valid for clustering.
+      const auto is_valid_neighbor = [&](const auto& neighbor_hash) {
+        auto it = map.find(neighbor_hash);
+        return (
+            (it != map.end()) &&                     // is within the map
+            (!it->second.cluster_id.has_value()) &&  // AND not yet mapped to a cluster
+            (it->second.weight <= cell.weight));     // AND has lower weight than the current cell
+      };
+
+      // Process the neighbors of the current cell.
+      for (const std::size_t neighbor_hash : neighbors_function(cell.representative_state) |  //
+                                                 ranges::views::cache1 |                      //
+                                                 ranges::views::filter(is_valid_neighbor)) {
+        auto& neighbor = map[neighbor_hash];
+        neighbor.cluster_id = cell.cluster_id;
+        queue.push({max_priority + neighbor.weight, neighbor_hash});  // reintroduce with inflated priority
+      }
+    }
+  }
+};
+
+/// Parameters used to construct a ParticleClusterizer instance.
+struct ParticleClusterizerParam {
+  double spatial_hash_resolution = 0.20;   ///< clustering algorithm spatial resolution
+  double angular_hash_resolution = 0.524;  ///< clustering algorithm angular resolution
+
+  /// Cluster weight cap threshold.
+  /**
+   * This parameters is the upper percentile threshold used to cap the accumulated
+   * weight of the cells in the grid to flatten the top of the approximated
+   * density function and make the clustering algorithm more robust to estimation noise,
+   * by fusing together any adjacent peaks whose weight is above the threshold.
+   * The range of this parameter is 0.0 to 1.0. The 0.9 default places the
+   * threshold at approximately 0.5 standard deviation from the mean, which is
+   * halfway to the inflection of the normal distribution.
+   * */
+  double weight_cap_percentile = 0.90;
+};
+
+/// Particle clusterizer implementation.
+class ParticleClusterizer {
+ public:
+  /// Constructor that initializes the ParticleClusterizer with given parameters.
+  explicit ParticleClusterizer(const ParticleClusterizerParam& parameters) : parameters_{parameters} {}
+
+  /// Computes the neighboring cells for a given pose using the spatial hash function.
+  /**
+   * \param pose The pose for which neighboring cells are computed.
+   * \return A range of spatial hashes corresponding to the neighboring cells.
+   */
+  [[nodiscard]] auto neighbors(const Sophus::SE2d& pose) const {
+    return adjacent_grid_cells_ |  //
+           ranges::views::transform([&pose](const Sophus::SE2d& neighbor_pose) { return pose * neighbor_pose; }) |
+           ranges::views::transform(spatial_hash_function_);
+  }
+
+  /// Clusters the given particles based on their states and weights.
+  /**
+   * \tparam Particles The type of the particles range.
+   * \param particles A range of particles to be clustered.
+   * \return A vector of cluster IDs corresponding to the input particles.
+   */
+  template <class Particles>
+  [[nodiscard]] auto operator()(Particles&& particles) {
+    auto states = beluga::views::states(particles);
+    auto weights = beluga::views::weights(particles);
+    auto hashes = states | ranges::views::transform(spatial_hash_function_) | ranges::to<std::vector>;
+
+    auto map = ParticleClusterizerImpl::make_cluster_map(states, weights, hashes);
+    ParticleClusterizerImpl::normalize_and_cap_weights(map, parameters_.weight_cap_percentile);
+    ParticleClusterizerImpl::assign_clusters(map, [this](const auto& state) { return neighbors(state); });
+
+    return hashes |  //
+           ranges::views::transform([&map](std::size_t hash) { return map[hash].cluster_id.value(); }) |
+           ranges::to<std::vector>;
+  }
+
+ private:
+  ParticleClusterizerParam parameters_;  ///< Parameters for the particle clusterizer.
+
+  beluga::spatial_hash<Sophus::SE2d> spatial_hash_function_{
+      parameters_.spatial_hash_resolution,  // x
+      parameters_.spatial_hash_resolution,  // y
+      parameters_.angular_hash_resolution   // theta
+  };
+
+  std::array<Sophus::SE2d, 6> adjacent_grid_cells_ = {
+      ///< Adjacent grid cells for neighbor calculation.
+      Sophus::SE2d{Sophus::SO2d{0.0}, Sophus::Vector2d{+parameters_.spatial_hash_resolution, 0.0}},
+      Sophus::SE2d{Sophus::SO2d{0.0}, Sophus::Vector2d{-parameters_.spatial_hash_resolution, 0.0}},
+      Sophus::SE2d{Sophus::SO2d{0.0}, Sophus::Vector2d{0.0, +parameters_.spatial_hash_resolution}},
+      Sophus::SE2d{Sophus::SO2d{0.0}, Sophus::Vector2d{0.0, -parameters_.spatial_hash_resolution}},
+      Sophus::SE2d{Sophus::SO2d{+parameters_.angular_hash_resolution}, Sophus::Vector2d{0.0, 0.0}},
+      Sophus::SE2d{Sophus::SO2d{-parameters_.angular_hash_resolution}, Sophus::Vector2d{0.0, 0.0}},
+  };
+};
+
+/// For each cluster, estimate the mean and covariance of the states that belong to it.
+/**
+ * \tparam States Range type of the states.
+ * \tparam Weights Range type of the weights.
+ * \tparam Hashes Range type of the hashes.
+ * \param states Range containing the states of the particles.
+ * \param weights Range containing the weights of the particles.
+ * \param clusters Cluster ids of the particles.
+ * \return A vector of elements, containing the weight, mean and covariance of each cluster, in no particular order.
+ */
+template <class States, class Weights, class Clusters>
+[[nodiscard]] auto estimate_clusters(States&& states, Weights&& weights, Clusters&& clusters) {
+  using State = typename ranges::range_value_t<States>;
+  using Weight = typename ranges::range_value_t<Weights>;
+  using Cluster = typename ranges::range_value_t<Clusters>;
+
+  using EstimateState = std::decay_t<decltype(std::get<0>(beluga::estimate(states, weights)))>;
+  using EstimateCovariance = std::decay_t<decltype(std::get<1>(beluga::estimate(states, weights)))>;
+
+  static_assert(std::is_same_v<State, EstimateState>);
+
+  struct Particle {
+    State state;
+    Weight weight;
+    Cluster cluster;
+
+    /// Convenient factory method to pass to `zip_with`.
+    static constexpr auto construct(const State& s, Weight w, Cluster c) { return Particle{s, w, c}; }
+  };
+
+  struct Estimate {
+    Weight weight;
+    EstimateState mean;
+    EstimateCovariance covariance;
+
+    /// Constructor used with `emplace_back`.
+    constexpr Estimate(Weight w, EstimateState m, EstimateCovariance c)
+        : weight{w}, mean{std::move(m)}, covariance{std::move(c)} {}
+
+    constexpr bool operator<(const Estimate& other) const { return weight < other.weight; }
+    constexpr bool operator<=(const Estimate& other) const { return weight <= other.weight; }
+    constexpr bool operator>(const Estimate& other) const { return weight > other.weight; }
+    constexpr bool operator>=(const Estimate& other) const { return weight >= other.weight; }
+    constexpr bool operator==(const Estimate& other) const { return weight == other.weight; }
+    constexpr bool operator!=(const Estimate& other) const { return weight != other.weight; }
+  };
+
+  // For each cluster found, estimate the mean and covariance of the states that belong to it.
+  const auto unique_clusters = clusters | ranges::to<std::unordered_set>;
+  auto estimates = std::vector<Estimate>{};
+  estimates.reserve(unique_clusters.size());
+
+  for (const auto cluster : unique_clusters) {
+    auto particles = ranges::views::zip_with(&Particle::construct, states, weights, clusters) |          //
+                     ranges::views::cache1 |                                                             //
+                     ranges::views::filter([cluster](const auto& p) { return p.cluster == cluster; }) |  //
+                     ranges::to<std::vector>;
+
+    if (particles.size() < 2) {
+      // If there's only one sample in the cluster we can't estimate the covariance.
+      continue;
+    }
+
+    auto filtered_states = particles | ranges::views::transform(&Particle::state);
+    auto filtered_weights = particles | ranges::views::transform(&Particle::weight);
+    const auto [mean, covariance] = estimate(filtered_states, filtered_weights);
+    const auto total_weight = ranges::accumulate(filtered_weights, 0.0);
+    estimates.emplace_back(total_weight, std::move(mean), std::move(covariance));
+  }
+
+  return estimates;
+}
+
+/// Computes a cluster-based estimate from a particle set.
+/**
+ * Particles are grouped into clusters around local maxima. The state mean and covariance
+ * of the cluster with the highest total weight is returned. If no clusters are found,
+ * the overall mean and covariance of the particles are calculated and returned.
+ *
+ * \tparam Particles The type of the particles range.
+ * \param particles A range of particles to be clustered and estimated.
+ * \param parameters Parameters for the particle clusterizer (optional).
+ * \return A pair consisting of the state mean and covariance of the cluster with the highest total weight.
+ */
+template <class Particles>
+[[nodiscard]] auto cluster_based_estimate(Particles&& particles, ParticleClusterizerParam parameters = {}) {
+  const auto clusters = ParticleClusterizer{parameters}(particles);
+
+  auto per_cluster_estimates =
+      estimate_clusters(beluga::views::states(particles), beluga::views::weights(particles), clusters);
+
+  if (per_cluster_estimates.empty()) {
+    // hmmm... maybe the particles are too fragmented? calculate the overall mean and covariance.
+    return beluga::estimate(
+        beluga::views::states(particles),  // namespace beluga
+        beluga::views::weights(particles));
+  }
+
+  const auto [_, mean, covariance] = *ranges::max_element(per_cluster_estimates);
+  return std::make_pair(mean, covariance);
+}
+
+}  // namespace beluga
+
+#endif

--- a/beluga/include/beluga/algorithm/estimation.hpp
+++ b/beluga/include/beluga/algorithm/estimation.hpp
@@ -128,6 +128,7 @@ template <
     typename = std::enable_if_t<std::is_same_v<Pose, typename Sophus::SE2<Scalar>>>>
 std::pair<Sophus::SE2<Scalar>, Sophus::Matrix3<Scalar>> estimate(Poses&& poses, Weights&& weights) {
   auto translation_view = poses | ranges::views::transform([](const auto& pose) { return pose.translation(); });
+  auto poses_view = poses | ranges::views::common;
   auto weights_view = weights | ranges::views::common;
   const auto weights_sum = std::accumulate(weights_view.begin(), weights_view.end(), 0.0);
   auto normalized_weights_view =
@@ -144,8 +145,8 @@ std::pair<Sophus::SE2<Scalar>, Sophus::Matrix3<Scalar>> estimate(Poses&& poses, 
   // This is expected and the value will be renormalized after having used the non-normal result to estimate the
   // orientation autocovariance.
   const Sophus::Vector4<Scalar> mean_pose_vector = std::transform_reduce(
-      poses.begin(), poses.end(), normalized_weights_view.begin(), Sophus::Vector4<Scalar>::Zero().eval(), std::plus{},
-      pose_to_weighted_eigen_vector);
+      poses_view.begin(), poses_view.end(), normalized_weights_view.begin(), Sophus::Vector4<Scalar>::Zero().eval(),
+      std::plus{}, pose_to_weighted_eigen_vector);
 
   // Calculate the weighted pose estimation
   Sophus::SE2<Scalar> estimated_pose = Eigen::Map<const Sophus::SE2<Scalar>>{mean_pose_vector.data()};

--- a/beluga/test/beluga/CMakeLists.txt
+++ b/beluga/test/beluga/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
   actions/test_reweight.cpp
   algorithm/raycasting/test_bresenham.cpp
   algorithm/test_amcl_core.cpp
+  algorithm/test_cluster_based_estimation.cpp
   algorithm/test_distance_map.cpp
   algorithm/test_effective_sample_size.cpp
   algorithm/test_estimation.cpp

--- a/beluga/test/beluga/algorithm/test_cluster_based_estimation.cpp
+++ b/beluga/test/beluga/algorithm/test_cluster_based_estimation.cpp
@@ -1,0 +1,416 @@
+// Copyright 2023-2024 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <beluga/algorithm/cluster_based_estimation.hpp>
+#include <beluga/algorithm/spatial_hash.hpp>
+#include <range/v3/action/sort.hpp>
+#include <range/v3/action/unique.hpp>
+#include <range/v3/view/filter.hpp>
+#include <range/v3/view/unique.hpp>
+#include <sophus/se2.hpp>
+
+#include <beluga/testing/sophus_matchers.hpp>
+
+namespace beluga {
+namespace {
+
+using testing::SE2Near;
+using testing::Vector3Near;
+
+using Eigen::Vector2d;
+using Sophus::Matrix3d;
+using Sophus::SE2d;
+using Sophus::SO2d;
+
+template <class Range, class Hasher>
+[[nodiscard]] auto precalculate_particle_hashes(Range&& states, const Hasher& spatial_hash_function_) {
+  return states | ranges::views::transform(spatial_hash_function_) | ranges::to<std::vector<std::size_t>>();
+}
+
+struct ClusterBasedEstimationDetailTesting : public ::testing::Test {
+  double kSpatialHashResolution = 1.0;
+  double kAngularHashResolution = Sophus::Constants<double>::pi() / 2.0;  // 90 degrees
+  double kTolerance = 1e-6;
+
+  // spatial hash function used to group particles in cells
+  beluga::spatial_hash<Sophus::SE2d> spatial_hash_function{
+      kSpatialHashResolution,  // x
+      kSpatialHashResolution,  // y
+      kAngularHashResolution   // theta
+  };
+
+  [[nodiscard]] auto generate_test_grid_cell_data_map() const {
+    constexpr auto kUpperLimit = 30.0;
+
+    ParticleClusterizerImpl::Map<SE2d> map;
+    for (double x = 0.0; x < kUpperLimit; x += 1.0) {
+      const auto weight = x;
+      const auto state = SE2d{SO2d{0.}, Vector2d{x, x}};
+      map.emplace(spatial_hash_function(state), ParticleClusterizerImpl::Cell<SE2d>{state, weight, 0, std::nullopt});
+    }
+    return map;
+  }
+
+  [[nodiscard]] static auto
+  make_particle_multicluster_dataset(double xmin, double xmax, double ymin, double ymax, double step) {
+    std::vector<std::pair<SE2d, beluga::Weight>> particles;
+
+    const auto xwidth = xmax - xmin;
+    const auto ywidth = ymax - ymin;
+
+    // simulate particles in a grid with 4 (2x2) clusters with
+    // different peak heights. The highest on is the one located on the
+    // higher-right.
+
+    for (double x = step / 2.0; x <= xwidth; x += step) {
+      for (double y = step / 2.0; y <= ywidth; y += step) {
+        // adjust the height of each of the four peaks
+        const auto k = (2 * x < xwidth ? 0.0 : 1.0) + (2 * y < ywidth ? 0.0 : 2.0) + 1.0;
+        auto weight = std::abs(std::sin(2.0 * M_PI * x / xwidth)) *  //
+                      std::abs(std::sin(2.0 * M_PI * y / ywidth)) *  //
+                      k;
+        // add a field of zeros around the peaks to ease predicting the mean and
+        // covariance values of the highest peaks
+        weight = std::max(0.0, weight - k / 2.0);
+        particles.emplace_back(SE2d{SO2d{0.}, Vector2d{x + xmin, y + ymin}}, weight);
+      }
+    }
+
+    return particles;
+  }
+};
+
+TEST_F(ClusterBasedEstimationDetailTesting, ParticleHashesCalculationStep) {
+  const auto s00 = SE2d{SO2d{0.0}, Vector2d{0.25, 0.25}};
+  const auto s01 = SE2d{SO2d{0.0}, Vector2d{3.75, 0.75}};
+  const auto s10 = SE2d{SO2d{2.0}, Vector2d{0.00, 0.00}};
+  const auto s20 = SE2d{SO2d{2.0}, Vector2d{2.00, 0.00}};
+
+  const auto states = std::vector{s00, s01, s10, s20};
+
+  const auto hashes = precalculate_particle_hashes(states, spatial_hash_function);
+
+  const auto hash00 = spatial_hash_function(s00);
+  const auto hash01 = spatial_hash_function(s01);
+  const auto hash10 = spatial_hash_function(s10);
+  const auto hash20 = spatial_hash_function(s20);
+
+  ASSERT_EQ(hashes.size(), 4);
+  EXPECT_EQ(hashes[0], hash00);
+  EXPECT_EQ(hashes[1], hash01);
+  EXPECT_EQ(hashes[2], hash10);
+  EXPECT_EQ(hashes[3], hash20);
+}
+
+TEST_F(ClusterBasedEstimationDetailTesting, GridCellDataMapGenerationStep) {
+  const auto s00 = SE2d{SO2d{0.0}, Vector2d{0.25, 0.25}};  // bin 1
+  const auto s01 = SE2d{SO2d{0.0}, Vector2d{0.75, 0.75}};  // bin 1
+  const auto s10 = SE2d{SO2d{2.0}, Vector2d{0.00, 0.00}};  // bin 2
+  const auto s20 = SE2d{SO2d{2.0}, Vector2d{2.00, 0.00}};  // bin 3
+
+  const auto particles = std::vector<std::pair<SE2d, beluga::Weight>>{
+      std::make_pair(s00, 1.5),
+      std::make_pair(s01, 0.5),
+      std::make_pair(s10, 1.0),
+      std::make_pair(s20, 1.0),
+  };
+
+  auto states = beluga::views::states(particles);
+  auto weights = beluga::views::weights(particles);
+  auto hashes = states | ranges::views::transform(spatial_hash_function) | ranges::to<std::vector>;
+
+  auto test_data = ParticleClusterizerImpl::make_cluster_map(states, weights, hashes);
+
+  const auto hash00 = spatial_hash_function(s00);
+  const auto hash10 = spatial_hash_function(s10);
+  const auto hash20 = spatial_hash_function(s20);
+
+  ASSERT_EQ(test_data.size(), 3);
+  ASSERT_NE(test_data.find(hash00), test_data.end());
+  ASSERT_NE(test_data.find(hash10), test_data.end());
+  ASSERT_NE(test_data.find(hash20), test_data.end());
+
+  EXPECT_EQ(test_data[hash00].weight, 2.0);
+  EXPECT_EQ(test_data[hash10].weight, 1.0);
+  EXPECT_EQ(test_data[hash20].weight, 1.0);
+
+  ASSERT_THAT(test_data[hash00].representative_state, SE2Near(s00.so2(), s00.translation(), kTolerance));
+  ASSERT_THAT(test_data[hash10].representative_state, SE2Near(s10.so2(), s10.translation(), kTolerance));
+  ASSERT_THAT(test_data[hash20].representative_state, SE2Near(s20.so2(), s20.translation(), kTolerance));
+
+  ASSERT_FALSE(test_data[hash00].cluster_id.has_value());
+  ASSERT_FALSE(test_data[hash10].cluster_id.has_value());
+  ASSERT_FALSE(test_data[hash20].cluster_id.has_value());
+}
+
+TEST_F(ClusterBasedEstimationDetailTesting, MakePriorityQueue) {
+  // data preparation
+  auto data = generate_test_grid_cell_data_map();
+
+  // test proper
+  auto prio_queue = make_priority_queue(data, &ParticleClusterizerImpl::Cell<SE2d>::weight);
+  EXPECT_EQ(prio_queue.size(), data.size());
+
+  // from there on the weights should be strictly decreasing
+  auto prev_weight = prio_queue.top().priority;
+  while (!prio_queue.empty()) {
+    const auto top = prio_queue.top();
+    EXPECT_GE(prev_weight, top.priority);
+    prev_weight = top.priority;
+    prio_queue.pop();
+  }
+}
+
+TEST_F(ClusterBasedEstimationDetailTesting, MapGridCellsToClustersStep) {
+  const double k_field_side = 36.0;
+  const double k_half_field_side = 18.0;
+
+  // create a map with four independent peaks
+  std::vector<std::tuple<double, double, double>> coordinates;
+  for (double x = 0.0; x < k_field_side; x += 1.0) {
+    for (double y = 0.0; y < k_field_side; y += 1.0) {
+      const auto weight = std::abs(std::sin(10.0 * x * M_PI / 180.0)) * std::abs(std::sin(10.0 * y * M_PI / 180.0));
+      coordinates.emplace_back(x, y, weight);
+    }
+  }
+
+  ParticleClusterizerImpl::Map<SE2d> map;
+
+  for (const auto& [x, y, w] : coordinates) {
+    const auto state = SE2d{SO2d{0.}, Vector2d{x, y}};
+    map.emplace(spatial_hash_function(state), ParticleClusterizerImpl::Cell<SE2d>{state, w, 0, std::nullopt});
+  }
+
+  const auto neighbors = [&](const auto& state) {
+    static const auto kAdjacentGridCells = {
+        SE2d{SO2d{0.0}, Vector2d{+kSpatialHashResolution, 0.0}},
+        SE2d{SO2d{0.0}, Vector2d{-kSpatialHashResolution, 0.0}},
+        SE2d{SO2d{0.0}, Vector2d{0.0, +kSpatialHashResolution}},
+        SE2d{SO2d{0.0}, Vector2d{0.0, -kSpatialHashResolution}},
+    };
+
+    return kAdjacentGridCells |  //
+           ranges::views::transform([&state](const Sophus::SE2d& neighbor_pose) { return state * neighbor_pose; }) |
+           ranges::views::transform(spatial_hash_function);
+  };
+
+  // test proper
+
+  // only cells beyond the 10% weight percentile to avoid the messy border
+  // between clusters beneath that threshold
+  const auto ten_percent_threshold = calculate_percentile_threshold(
+      map | ranges::views::values | ranges::views::transform(&ParticleClusterizerImpl::Cell<SE2d>::weight), 0.15);
+
+  ParticleClusterizerImpl::assign_clusters(map, neighbors);
+
+  auto cells_above_minimum_threshold_view =
+      coordinates | ranges::views::filter([&](const auto& c) { return std::get<2>(c) >= ten_percent_threshold; });
+
+  const auto right_side_cell = [&](const auto& c) { return std::get<0>(c) >= k_half_field_side; };
+  const auto left_side_cell = [&](const auto& c) { return !right_side_cell(c); };
+  const auto top_side_cell = [&](const auto& c) { return std::get<1>(c) >= k_half_field_side; };
+  const auto bottom_side_cell = [&](const auto& c) { return !top_side_cell(c); };
+
+  auto quadrant_1_view = cells_above_minimum_threshold_view |     //
+                         ranges::views::filter(left_side_cell) |  //
+                         ranges::views::filter(bottom_side_cell);
+  auto quadrant_2_view = cells_above_minimum_threshold_view |      //
+                         ranges::views::filter(right_side_cell) |  //
+                         ranges::views::filter(bottom_side_cell);
+  auto quadrant_3_view = cells_above_minimum_threshold_view |     //
+                         ranges::views::filter(left_side_cell) |  //
+                         ranges::views::filter(top_side_cell);
+  auto quadrant_4_view = cells_above_minimum_threshold_view |      //
+                         ranges::views::filter(right_side_cell) |  //
+                         ranges::views::filter(top_side_cell);
+
+  const auto coord_to_hash = [&](const auto& coords) {
+    const auto& [x, y, w] = coords;
+    const auto state = SE2d{SO2d{0.}, Vector2d{x, y}};
+    return spatial_hash_function(state);
+  };
+
+  const auto hash_to_id = [&](const auto& hash) { return map[hash].cluster_id.value(); };
+
+  auto quadrant_1_unique_ids = quadrant_1_view |                          //
+                               ranges::views::transform(coord_to_hash) |  //
+                               ranges::views::transform(hash_to_id) |     //
+                               ranges::to<std::vector<std::size_t>>() |   //
+                               ranges::actions::sort |                    //
+                               ranges::actions::unique;                   //
+  auto quadrant_2_unique_ids = quadrant_2_view |                          //
+                               ranges::views::transform(coord_to_hash) |  //
+                               ranges::views::transform(hash_to_id) |     //
+                               ranges::to<std::vector<std::size_t>>() |   //
+                               ranges::actions::sort |                    //
+                               ranges::actions::unique;                   //
+  auto quadrant_3_unique_ids = quadrant_3_view |                          //
+                               ranges::views::transform(coord_to_hash) |  //
+                               ranges::views::transform(hash_to_id) |     //
+                               ranges::to<std::vector<std::size_t>>() |   //
+                               ranges::actions::sort |                    //
+                               ranges::actions::unique;                   //
+  auto quadrant_4_unique_ids = quadrant_4_view |                          //
+                               ranges::views::transform(coord_to_hash) |  //
+                               ranges::views::transform(hash_to_id) |     //
+                               ranges::to<std::vector<std::size_t>>() |   //
+                               ranges::actions::sort |                    //
+                               ranges::actions::unique;                   //
+
+  auto full_field_unique_ids = cells_above_minimum_threshold_view |       //
+                               ranges::views::transform(coord_to_hash) |  //
+                               ranges::views::transform(hash_to_id) |     //
+                               ranges::to<std::vector<std::size_t>>() |   //
+                               ranges::actions::sort |                    //
+                               ranges::actions::unique;                   //
+
+  // check that each quadrant receives its own cluster id, and that
+  // there are four clusters in total
+  EXPECT_EQ(quadrant_1_unique_ids.size(), 1);
+  EXPECT_EQ(quadrant_2_unique_ids.size(), 1);
+  EXPECT_EQ(quadrant_3_unique_ids.size(), 1);
+  EXPECT_EQ(quadrant_4_unique_ids.size(), 1);
+
+  EXPECT_EQ(full_field_unique_ids.size(), 4);
+}
+
+TEST_F(ClusterBasedEstimationDetailTesting, ClusterStateEstimationStep) {
+  const double k_field_side = 36.0;
+
+  // create a map with four independent peaks
+  auto particles = make_particle_multicluster_dataset(0.0, k_field_side, 0.0, k_field_side, 1.0);
+
+  const auto clusters =
+      ParticleClusterizer{ParticleClusterizerParam{kSpatialHashResolution, kAngularHashResolution, 0.9}}(particles);
+
+  auto per_cluster_estimates =
+      estimate_clusters(beluga::views::states(particles), beluga::views::weights(particles), clusters);
+
+  // check that the number of clusters is correct
+  ASSERT_EQ(per_cluster_estimates.size(), 4);
+
+  // order by decreasing weight
+  std::sort(per_cluster_estimates.begin(), per_cluster_estimates.end());
+
+  // check that the cluster means were found in the expected order
+  EXPECT_THAT(per_cluster_estimates[0].mean, SE2Near(SO2d{0.0}, Vector2d{9.0, 9.0}, kTolerance));
+  EXPECT_THAT(per_cluster_estimates[1].mean, SE2Near(SO2d{0.0}, Vector2d{27.0, 9.0}, kTolerance));
+  EXPECT_THAT(per_cluster_estimates[2].mean, SE2Near(SO2d{0.0}, Vector2d{9.0, 27.0}, kTolerance));
+  EXPECT_THAT(per_cluster_estimates[3].mean, SE2Near(SO2d{0.0}, Vector2d{27.0, 27.0}, kTolerance));
+}
+
+TEST_F(ClusterBasedEstimationDetailTesting, ClusterEstimation) {
+  // test the weights have effect by selecting a few states and ignoring others
+  const auto states = std::vector{
+      SE2d{SO2d{Sophus::Constants<double>::pi() / 6}, Vector2d{0.0, -3.0}},  //
+      SE2d{SO2d{Sophus::Constants<double>::pi() / 2}, Vector2d{1.0, -2.0}},  //
+      SE2d{SO2d{Sophus::Constants<double>::pi() / 3}, Vector2d{2.0, -1.0}},  //
+      SE2d{SO2d{Sophus::Constants<double>::pi() / 2}, Vector2d{1.0, -2.0}},  //
+      SE2d{SO2d{Sophus::Constants<double>::pi() / 6}, Vector2d{2.0, -3.0}},  //
+      SE2d{SO2d{Sophus::Constants<double>::pi() / 2}, Vector2d{3.0, -2.0}},  //
+      SE2d{SO2d{Sophus::Constants<double>::pi() / 3}, Vector2d{4.0, -2.0}},  //
+      SE2d{SO2d{Sophus::Constants<double>::pi() / 2}, Vector2d{0.0, -3.0}},  //
+  };
+
+  // cluster 0 has the max weight, except for cluster 3 which will be ignored because it has only a single particle
+  const auto weights = std::vector{0.5, 0.5, 0.2, 0.3, 0.3, 0.2, 0.2, 1.0};
+  const auto clusters = std::vector{0, 0, 1, 2, 2, 1, 1, 3};
+
+  const auto particles = ranges::views::zip(states, weights, clusters);
+
+  auto cluster_0_particles =
+      particles | ranges::views::cache1 | ranges::views::filter([](const auto& p) { return std::get<2>(p) == 0; });
+
+  auto cluster_0_states = cluster_0_particles | beluga::views::elements<0>;
+  auto cluster_0_weights = cluster_0_particles | beluga::views::elements<1>;
+
+  const auto [expected_pose, expected_covariance] = beluga::estimate(cluster_0_states, cluster_0_weights);
+  const auto per_cluster_estimates = beluga::estimate_clusters(states, weights, clusters);
+
+  ASSERT_EQ(per_cluster_estimates.size(), 3);  // cluster 3 should be ignored because it has only one particle
+
+  const auto [_, pose, covariance] = *ranges::max_element(per_cluster_estimates);
+
+  constexpr double kTolerance = 0.001;
+
+  ASSERT_THAT(pose, SE2Near(expected_pose.so2(), expected_pose.translation(), kTolerance));
+  ASSERT_THAT(covariance.col(0).eval(), Vector3Near(expected_covariance.col(0).eval(), kTolerance));
+  ASSERT_THAT(covariance.col(1).eval(), Vector3Near(expected_covariance.col(1).eval(), kTolerance));
+  ASSERT_THAT(covariance.col(2).eval(), Vector3Near(expected_covariance.col(2).eval(), kTolerance));
+}
+
+TEST_F(ClusterBasedEstimationDetailTesting, HeaviestClusterSelectionTest) {
+  const auto particles = make_particle_multicluster_dataset(-2.0, +2.0, -2.0, +2.0, 0.025);
+
+  // determine the expected values of the mean and covariance of the highest
+  // weight cluster
+  const auto max_peak_filter = [](const auto& s) { return s.translation().x() >= 0.0 && s.translation().y() >= 0.0; };
+  const auto mask_filter = [](const auto& sample) { return std::get<1>(sample); };
+
+  auto max_peak_mask = beluga::views::states(particles) | ranges::views::transform(max_peak_filter);
+  auto max_peak_masked_states = ranges::views::zip(beluga::views::states(particles), max_peak_mask) |
+                                ranges::views::filter(mask_filter) | beluga::views::elements<0>;
+  auto max_peak_masked_weights = ranges::views::zip(beluga::views::weights(particles), max_peak_mask) |
+                                 ranges::views::filter(mask_filter) | beluga::views::elements<0>;
+
+  const auto [expected_pose, expected_covariance] = beluga::estimate(max_peak_masked_states, max_peak_masked_weights);
+
+  const auto [pose, covariance] = beluga::cluster_based_estimate(particles);
+
+  ASSERT_THAT(pose, SE2Near(expected_pose.so2(), expected_pose.translation(), kTolerance));
+  ASSERT_NEAR(covariance(0, 0), expected_covariance(0, 0), 0.001);
+  ASSERT_NEAR(covariance(0, 1), expected_covariance(0, 1), 0.001);
+  ASSERT_NEAR(covariance(0, 2), expected_covariance(0, 2), 0.001);
+  ASSERT_NEAR(covariance(1, 0), expected_covariance(1, 0), 0.001);
+  ASSERT_NEAR(covariance(1, 1), expected_covariance(1, 1), 0.001);
+  ASSERT_NEAR(covariance(1, 2), expected_covariance(1, 2), 0.001);
+  ASSERT_NEAR(covariance(2, 0), expected_covariance(2, 0), 0.001);
+  ASSERT_NEAR(covariance(2, 1), expected_covariance(2, 1), 0.001);
+  ASSERT_NEAR(covariance(2, 2), expected_covariance(2, 2), 0.001);
+}
+
+TEST_F(ClusterBasedEstimationDetailTesting, NightmareDistributionTest) {
+  // particles so far away that they are isolated and will therefore form four separate single
+  // particle clusters
+  const auto states = std::vector{
+      SE2d{SO2d{0.0}, Vector2d{-10.0, -10.0}},  //
+      SE2d{SO2d{0.0}, Vector2d{-10.0, +10.0}},  //
+      SE2d{SO2d{0.0}, Vector2d{+10.0, -10.0}},  //
+      SE2d{SO2d{0.0}, Vector2d{+10.0, +10.0}}};
+  const auto weights = std::vector<beluga::Weight>{0.2, 0.2, 0.2, 0.2};
+
+  // in this case, the cluster algorithm will not be able to group the particles and will
+  // default to the set mean and covariance
+  const auto [expected_pose, expected_covariance] = beluga::estimate(states, weights);
+
+  auto particles = ranges::views::zip(states, weights) | ranges::to<std::vector>();
+  const auto [pose, covariance] = beluga::cluster_based_estimate(particles);
+
+  ASSERT_THAT(pose, SE2Near(expected_pose.so2(), expected_pose.translation(), kTolerance));
+  ASSERT_NEAR(covariance(0, 0), expected_covariance(0, 0), 0.001);
+  ASSERT_NEAR(covariance(0, 1), expected_covariance(0, 1), 0.001);
+  ASSERT_NEAR(covariance(0, 2), expected_covariance(0, 2), 0.001);
+  ASSERT_NEAR(covariance(1, 0), expected_covariance(1, 0), 0.001);
+  ASSERT_NEAR(covariance(1, 1), expected_covariance(1, 1), 0.001);
+  ASSERT_NEAR(covariance(1, 2), expected_covariance(1, 2), 0.001);
+  ASSERT_NEAR(covariance(2, 0), expected_covariance(2, 0), 0.001);
+  ASSERT_NEAR(covariance(2, 1), expected_covariance(2, 1), 0.001);
+  ASSERT_NEAR(covariance(2, 2), expected_covariance(2, 2), 0.001);
+}
+
+}  // namespace
+
+}  // namespace beluga


### PR DESCRIPTION
### Proposed changes

Addresses #258 and #172.

Add new cluster based estimator. 

- Splits the space in a grid and determines the accumulated weight in each cell.
- Starting from the weight peaks, it groups cells into clusters of ever decreasing weight. It creates as many clusters as needed to cover all the particle occupied space.
- Estimates mean and covariance for each.
- Returns the mean and covariance of the cluster with the highest cumulative weight.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)