### PR TITLE
Add take_while_kld view

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,6 +27,7 @@ Checks: >
   -readability-named-parameter,
   -readability-redundant-declaration,
   -readability-function-cognitive-complexity,
+  -readability-suspicious-call-argument,
   -bugprone-narrowing-conversions,
   -bugprone-easily-swappable-parameters,
   -bugprone-implicit-widening-of-multiplication-result

--- a/beluga/include/beluga/storage.hpp
+++ b/beluga/include/beluga/storage.hpp
@@ -154,19 +154,20 @@ class StoragePolicy : public Mixin {
    */
   template <class Range>
   void initialize_particles(Range&& input) {
-    static_assert(std::is_convertible_v<ranges::range_value_t<Range>, particle_type>, "Invalid value type");
+    static_assert(std::is_convertible_v<ranges::range_value_t<Range>, state_type>, "Invalid value type");
     const std::size_t size = this->self().max_samples();
+    auto particles = input |                                                             //
+                     ranges::views::transform(beluga::make_from_state<particle_type>) |  //
+                     ranges::views::take(size);
     particles_[1].resize(size);
     const auto first = std::begin(particles_[1]);
-    const auto last = ranges::copy(input | ranges::views::take(size), first).out;
+    const auto last = ranges::copy(particles, first).out;
     particles_[1].resize(static_cast<std::size_t>(std::distance(first, last)));
     std::swap(particles_[0], particles_[1]);
   }
 
   /// \copydoc StorageInterface::initialize_states()
-  void initialize_states(input_view_type input) final {
-    initialize_particles(input | ranges::views::transform(beluga::make_from_state<particle_type>));
-  }
+  void initialize_states(input_view_type input) final { initialize_particles(input); }
 
   /// \copydoc StorageInterface::particle_count()
   [[nodiscard]] std::size_t particle_count() const final { return particles_[0].size(); }

--- a/beluga/include/beluga/type_traits/particle_traits.hpp
+++ b/beluga/include/beluga/type_traits/particle_traits.hpp
@@ -50,9 +50,9 @@ using weight_t = typename particle_traits<T>::weigth_type;
  * \return The new particle, created from the given state.
  */
 template <class Particle, class T = state_t<Particle>>
-constexpr auto make_from_state(T&& value) {
+constexpr auto make_from_state(T value) {
   auto particle = Particle{};
-  beluga::state(particle) = std::forward<T>(value);
+  beluga::state(particle) = std::move(value);
   beluga::weight(particle) = 1.0;
   return particle;
 }

--- a/beluga/include/beluga/views/take_while_kld.hpp
+++ b/beluga/include/beluga/views/take_while_kld.hpp
@@ -1,0 +1,190 @@
+// Copyright 2023 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BELUGA_VIEWS_TAKE_WHILE_KLD_HPP
+#define BELUGA_VIEWS_TAKE_WHILE_KLD_HPP
+
+#include <unordered_set>
+
+#include <beluga/views/elements.hpp>
+
+#include <range/v3/view/take.hpp>
+#include <range/v3/view/take_while.hpp>
+#include <range/v3/view/zip.hpp>
+
+/**
+ * \file
+ * \brief Implementation of a take_while_kld range adaptor object.
+ */
+
+namespace beluga {
+
+namespace detail {
+
+/// Default upper standard normal quantile, P = 0.999
+constexpr double kDefaultKldZ = 3.;
+
+}  // namespace detail
+
+/// Returns a callable object that verifies if the KLD condition is being satisfied.
+/**
+ * The callable object will compute the minimum number of samples based on a Kullback-Leibler
+ * distance epsilon between the maximum likelihood estimate and the true distribution. \n
+ * Z is the upper standard normal quantile for P, where P is the probability
+ * that the error in the estimated distribution will be less than epsilon.
+ *
+ * Here are some examples:
+ * | P     | Z                |
+ * |-------|------------------|
+ * | 0.900 | 1.28155156327703 |
+ * | 0.950 | 1.64485362793663 |
+ * | 0.990 | 2.32634787735669 |
+ * | 0.999 | 3.09023224677087 |
+ *
+ * If the computed value is less than what the min argument specifies, then min will be returned.
+ *
+ * See KLD-Sampling: Adaptive Particle Filters \cite fox2001adaptivekldsampling.
+ *
+ * \param min Minimum number of particles that the callable object will return.
+ * \param epsilon Maximum distance epsilon between the maximum likelihood estimate and the true
+ *  distrubution.
+ * \param z Upper standard normal quantile for the probability that the error in the
+ *  estimated distribution is less than epsilon.
+ * \return A callable object with prototype `(std::size_t hash) -> bool`.
+ *  `hash` is the spatial hash of the particle being added. \n
+ *  The returned callable object is stateful, tracking the total number of particles and
+ *  the particle clusters based on the spatial hash. \n
+ *  The return value of the callable will be false when the number of particles is more than the minimum
+ *  and the KLD condition is satisfied, if not it will be true. \n
+ *  i.e. A return value of true means that you need to keep sampling to satisfy the condition.
+ */
+inline auto kld_condition(std::size_t min, double epsilon, double z = beluga::detail::kDefaultKldZ) {
+  auto target_size = [two_epsilon = 2 * epsilon, z](std::size_t k) {
+    if (k <= 2U) {
+      return std::numeric_limits<std::size_t>::max();
+    }
+    double common = 2. / static_cast<double>(9 * (k - 1));
+    double base = 1. - common + std::sqrt(common) * z;
+    double result = (static_cast<double>(k - 1) / two_epsilon) * base * base * base;
+    return static_cast<std::size_t>(std::ceil(result));
+  };
+
+  return [=, count = 0ULL, buckets = std::unordered_set<std::size_t>{}](std::size_t hash) mutable {
+    count++;
+    buckets.insert(hash);
+    return count <= min || count <= target_size(buckets.size());
+  };
+}
+
+namespace views {
+
+namespace detail {
+
+/// Implementation detail for a take_while_kld range adaptor object.
+struct take_while_kld_fn {
+  /// Overload that implements the take_while_kld algorithm.
+  /**
+   * \tparam States An [input range](https://en.cppreference.com/w/cpp/ranges/input_range) with particle states.
+   * \tparam Hashes An [input range](https://en.cppreference.com/w/cpp/ranges/input_range) with particle hashes.
+   * \param states Source range from where to take elements.
+   * \param hashes Source range containing hashes (or bucket ids) to compute the KLD condition.
+   * \param min Minimum samples to take.
+   * \param max Maximum samples to take.
+   * \param epsilon See beluga::kld_condition() for details.
+   * \param z See beluga::kld_condition() for details.
+   */
+  template <class States, class Hashes, std::enable_if_t<ranges::input_range<Hashes>, int> = 0>
+  constexpr auto operator()(
+      States&& states,
+      Hashes&& hashes,
+      std::size_t min,
+      std::size_t max,
+      double epsilon,
+      double z = beluga::detail::kDefaultKldZ) const {
+    static_assert(ranges::input_range<States>);
+    static_assert(ranges::input_range<Hashes>);
+    static_assert(std::is_convertible_v<ranges::range_value_t<Hashes>, std::size_t>);
+    const auto hash = [](const auto& p) { return std::get<1>(p); };
+    return ranges::views::zip(ranges::views::all(states), ranges::views::all(hashes)) |  //
+           ranges::views::take_while(beluga::kld_condition(min, epsilon, z), hash) |     //
+           ranges::views::take(max) |                                                    //
+           beluga::views::elements<0>;
+  }
+
+  /// Overload that implements the take_while_kld algorithm with an external hasher.
+  /**
+   * \tparam States An [input range](https://en.cppreference.com/w/cpp/ranges/input_range) with particle states.
+   * \tparam Hasher A callable object that can compute the spatial hash for a given state.
+   * \param states Source range from where to take elements.
+   * \param hasher Hasher instance used to compute the spatial hash for a given state.
+   * \param min Minimum samples to take.
+   * \param max Maximum samples to take.
+   * \param epsilon See beluga::kld_condition() for details.
+   * \param z See beluga::kld_condition() for details.
+   */
+  template <class States, class Hasher, std::enable_if_t<ranges::views::transformable_range<States, Hasher>, int> = 0>
+  constexpr auto operator()(
+      States&& states,
+      Hasher hasher,
+      std::size_t min,
+      std::size_t max,
+      double epsilon,
+      double z = beluga::detail::kDefaultKldZ) const {
+    return this->operator()(
+        ranges::views::all(states),                           //
+        ranges::views::transform(states, std::move(hasher)),  //
+        min,                                                  //
+        max,                                                  //
+        epsilon,                                              //
+        z);
+  }
+
+  /// Overload that returns a view closure to compose with other views.
+  /**
+   * \tparam Hasher A callable object that can compute the spatial hash for a given state.
+   * \param hasher Hasher instance used to compute the spatial hash for a given state.
+   * \param min Minimum samples to take.
+   * \param max Maximum samples to take.
+   * \param epsilon See beluga::kld_condition() for details.
+   * \param z See beluga::kld_condition() for details.
+   */
+  template <class Hasher>
+  constexpr auto operator()(
+      Hasher hasher,
+      std::size_t min,
+      std::size_t max,
+      double epsilon,
+      double z = beluga::detail::kDefaultKldZ) const {
+    return ranges::make_view_closure(ranges::bind_back(take_while_kld_fn{}, std::move(hasher), min, max, epsilon, z));
+  }
+};
+
+}  // namespace detail
+
+/// [Range adaptor object](https://en.cppreference.com/w/cpp/named_req/RangeAdaptorObject) that
+/// will take elements from a range while the KLD condition is statisfied.
+/**
+ * The input range should be randomly generated from an existing particle set.
+ * This adaptor will return elements until the minimum number of samples based on a Kullback-Leibler
+ * distance epsilon is satisfied.
+ *
+ * See KLD-Sampling: Adaptive Particle Filters \cite fox2001adaptivekldsampling.
+ */
+inline constexpr detail::take_while_kld_fn take_while_kld;
+
+}  // namespace views
+
+}  // namespace beluga
+
+#endif

--- a/beluga/test/beluga/CMakeLists.txt
+++ b/beluga/test/beluga/CMakeLists.txt
@@ -42,7 +42,8 @@ add_executable(
   test_storage.cpp
   test_tuple_vector.cpp
   type_traits/test_strongly_typed_numeric.cpp
-  views/test_take_evenly.cpp)
+  views/test_take_evenly.cpp
+  views/test_take_while_kld.cpp)
 
 target_link_libraries(
   test_beluga PRIVATE ${PROJECT_NAME} beluga_compile_options GTest::gmock_main)

--- a/beluga/test/beluga/algorithm/test_particle_filter.cpp
+++ b/beluga/test/beluga/algorithm/test_particle_filter.cpp
@@ -46,7 +46,9 @@ class MockMixin : public Mixin {
 
   template <class Range>
   void initialize_particles(Range&& input) {
-    particles_ = input | ranges::to<std::vector>;
+    particles_ = input |                                                                              //
+                 ranges::views::transform([](double state) { return std::make_pair(state, 1.0); }) |  //
+                 ranges::to<std::vector>;
   }
 
   template <class Generator>
@@ -60,10 +62,7 @@ class MockMixin : public Mixin {
     return particles_ | beluga::views::elements<0> | ranges::views::common;
   }
 
-  auto take_samples() const {
-    return ranges::views::transform([](double state) { return std::make_pair(state, 1.0); }) |
-           ranges::views::take_exactly(10);
-  }
+  auto take_samples() const { return ranges::views::take_exactly(10); }
 
   template <class Generator>
   double apply_motion(double state, Generator&) const {

--- a/beluga/test/beluga/algorithm/test_sampling.cpp
+++ b/beluga/test/beluga/algorithm/test_sampling.cpp
@@ -20,14 +20,11 @@
 #include <range/v3/range/conversion.hpp>
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/generate.hpp>
-#include <range/v3/view/intersperse.hpp>
 #include <range/v3/view/take_exactly.hpp>
-#include <range/v3/view/take_while.hpp>
 
 namespace {
 
 using testing::_;
-using testing::DoubleEq;
 using testing::Each;
 using testing::Return;
 using testing::ReturnRef;
@@ -70,53 +67,6 @@ TEST(RandomSample, Functional) {
                 ranges::views::take_exactly(samples);
   AssertWeights(output, values, weights);
 }
-
-class KldConditionWithParam : public ::testing::TestWithParam<std::tuple<double, std::size_t, std::size_t>> {};
-
-auto GenerateDistinctHashes(std::size_t count) {
-  return ranges::views::generate([count, hash = 0UL]() mutable {
-    if (hash < count) {
-      ++hash;
-    }
-    return hash;
-  });
-}
-
-TEST_P(KldConditionWithParam, Minimum) {
-  const std::size_t cluster_count = std::get<1>(GetParam());
-  auto output = GenerateDistinctHashes(cluster_count) |
-                ranges::views::take_while(beluga::kld_condition(1'000, 0.01, 0.95)) | ranges::to<std::vector>;
-  ASSERT_GE(output.size(), 1'000);
-}
-
-TEST_P(KldConditionWithParam, Limit) {
-  const double kld_k = std::get<0>(GetParam());
-  const std::size_t cluster_count = std::get<1>(GetParam());
-  const std::size_t min_samples = std::get<2>(GetParam());
-  auto output = GenerateDistinctHashes(cluster_count) |
-                ranges::views::take_while(beluga::kld_condition(0, 0.01, kld_k)) | ranges::to<std::vector>;
-  ASSERT_EQ(output.size(), min_samples);
-}
-
-constexpr double kPercentile90th = 1.28155156327703;
-constexpr double kPercentile99th = 2.32634787735669;
-
-INSTANTIATE_TEST_SUITE_P(
-    KldPairs,
-    KldConditionWithParam,
-    testing::Values(
-        std::make_tuple(kPercentile90th, 3, 228),
-        std::make_tuple(kPercentile90th, 4, 311),
-        std::make_tuple(kPercentile90th, 5, 388),
-        std::make_tuple(kPercentile90th, 6, 461),
-        std::make_tuple(kPercentile90th, 7, 531),
-        std::make_tuple(kPercentile90th, 100, 5871),
-        std::make_tuple(kPercentile99th, 3, 462),
-        std::make_tuple(kPercentile99th, 4, 569),
-        std::make_tuple(kPercentile99th, 5, 666),
-        std::make_tuple(kPercentile99th, 6, 756),
-        std::make_tuple(kPercentile99th, 7, 843),
-        std::make_tuple(kPercentile99th, 100, 6733)));
 
 template <class Mixin>
 class MockStorage : public Mixin {
@@ -212,69 +162,10 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(0.5, 0.1, 0.08),
         std::make_tuple(0.5, 0.0, 0.10)));
 
-TEST(FixedLimiter, TakeSamplesLeavesUnitWeight) {
-  auto instance = ciabatta::mixin<MockStorage, beluga::FixedLimiter>{beluga::FixedLimiterParam{1'200}};
-  auto output = ranges::views::generate([]() { return 1; }) | instance.take_samples() |
-                ranges::views::transform([](const auto& p) -> double { return std::get<1>(p); }) |
-                ranges::to<std::vector>;
-  ASSERT_THAT(output, Each(DoubleEq(1.0)));
-}
-
 TEST(FixedLimiter, TakeMaximum) {
   auto instance = ciabatta::mixin<MockStorage, beluga::FixedLimiter>{beluga::FixedLimiterParam{1'200}};
   auto output = ranges::views::generate([]() { return 1; }) | instance.take_samples() | ranges::to<std::vector>;
   ASSERT_EQ(output.size(), 1'200);
-}
-
-template <class Mixin>
-struct MockStorageWithCluster : public Mixin {
-  using state_type = std::pair<double, double>;
-  using particle_type = std::tuple<state_type, beluga::Weight, beluga::Cluster>;
-
-  template <class... Args>
-  explicit MockStorageWithCluster(Args&&... rest) : Mixin(std::forward<Args>(rest)...) {}
-};
-
-TEST(KldLimiter, TakeSamplesLeavesUnitWeight) {
-  auto instance = ciabatta::mixin<MockStorage, beluga::FixedLimiter>{beluga::FixedLimiterParam{1'200}};
-  auto output = ranges::views::generate([]() { return 1; }) | instance.take_samples() |
-                ranges::views::transform([](const auto& p) -> double { return std::get<1>(p); }) |
-                ranges::to<std::vector>;
-  ASSERT_THAT(output, Each(DoubleEq(1.0)));
-}
-
-using state = std::pair<double, double>;
-
-TEST(KldLimiter, TakeMaximum) {
-  constexpr std::array kClusteringResolution{1., 1.};
-  auto hasher = beluga::spatial_hash<state>{kClusteringResolution};
-  auto instance = ciabatta::mixin<MockStorageWithCluster, ciabatta::curry<beluga::KldLimiter, state>::mixin>{
-      beluga::KldLimiterParam<state>{200, 1'200, hasher, 0.05, 3.}};
-  auto output = ranges::views::generate([]() { return std::make_pair(1., 1.); }) | instance.take_samples() |
-                ranges::to<std::vector>;
-  ASSERT_EQ(output.size(), 1'200);
-}
-
-TEST(KldLimiter, TakeLimit) {
-  constexpr std::array kClusteringResolution{0.05, 0.05};
-  auto hasher = beluga::spatial_hash<state>{kClusteringResolution};
-  auto instance = ciabatta::mixin<MockStorageWithCluster, ciabatta::curry<beluga::KldLimiter, state>::mixin>{
-      beluga::KldLimiterParam<state>{0, 1'200, hasher, 0.05, 3.}};
-  auto output = ranges::views::generate([]() { return std::make_pair(1., 1.); }) |
-                ranges::views::intersperse(std::make_pair(2., 2.)) |
-                ranges::views::intersperse(std::make_pair(3., 3.)) | instance.take_samples() | ranges::to<std::vector>;
-  ASSERT_EQ(output.size(), 135);
-}
-
-TEST(KldLimiter, TakeMinimum) {
-  constexpr std::array kClusteringResolution{1., 1.};
-  auto hasher = beluga::spatial_hash<state>{kClusteringResolution};
-  auto instance = ciabatta::mixin<MockStorageWithCluster, ciabatta::curry<beluga::KldLimiter, state>::mixin>{
-      beluga::KldLimiterParam<state>{200, 1'200, hasher, 0.05, 3.}};
-  auto output = ranges::views::generate([]() { return std::make_pair(1., 1.); }) |
-                ranges::views::intersperse(std::make_pair(2., 2.)) |
-                ranges::views::intersperse(std::make_pair(3., 3.)) | instance.take_samples() | ranges::to<std::vector>;
-  ASSERT_EQ(output.size(), 200);
 }
 
 }  // namespace

--- a/beluga/test/beluga/test_storage.cpp
+++ b/beluga/test/beluga/test_storage.cpp
@@ -78,7 +78,7 @@ TYPED_TEST(StoragePolicyTest, ResampleParticles) {
   EXPECT_CALL(mixin, max_samples()).WillOnce(Return(5)).WillOnce(Return(5));
   mixin.initialize_states(states);
   ASSERT_EQ(mixin.particle_count(), 5);
-  mixin.initialize_particles(mixin.particles() | ranges::views::reverse);
+  mixin.initialize_particles(states | ranges::views::reverse);
   ASSERT_TRUE(ranges::equal(mixin.states(), states | ranges::views::reverse));
 }
 

--- a/beluga/test/beluga/views/test_take_while_kld.cpp
+++ b/beluga/test/beluga/views/test_take_while_kld.cpp
@@ -1,0 +1,126 @@
+// Copyright 2023 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include "beluga/views/take_while_kld.hpp"
+
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view/empty.hpp>
+#include <range/v3/view/generate.hpp>
+#include <range/v3/view/intersperse.hpp>
+
+namespace {
+
+class KldConditionWithParam : public ::testing::TestWithParam<std::tuple<double, std::size_t, std::size_t>> {};
+
+auto GenerateDistinctHashes(std::size_t count) {
+  return ranges::views::generate([count, hash = 0UL]() mutable {
+    if (hash < count) {
+      ++hash;
+    }
+    return hash;
+  });
+}
+
+TEST_P(KldConditionWithParam, Minimum) {
+  const std::size_t cluster_count = std::get<1>(GetParam());
+  const std::size_t min = 1'000;
+  const double epsilon = 0.01;
+  const double kld_k = 0.95;
+  auto output = GenerateDistinctHashes(cluster_count) |                                  //
+                ranges::views::take_while(beluga::kld_condition(min, epsilon, kld_k)) |  //
+                ranges::to<std::vector>;
+  ASSERT_GE(output.size(), 1'000);
+}
+
+TEST_P(KldConditionWithParam, Limit) {
+  const double kld_k = std::get<0>(GetParam());
+  const std::size_t cluster_count = std::get<1>(GetParam());
+  const std::size_t expected_count = std::get<2>(GetParam());
+  const std::size_t min = 0;
+  const double epsilon = 0.01;
+  auto output = GenerateDistinctHashes(cluster_count) |
+                ranges::views::take_while(beluga::kld_condition(min, epsilon, kld_k)) |  //
+                ranges::to<std::vector>;
+  ASSERT_EQ(output.size(), expected_count);
+}
+
+constexpr double kPercentile90th = 1.28155156327703;
+constexpr double kPercentile99th = 2.32634787735669;
+
+INSTANTIATE_TEST_SUITE_P(
+    KldPairs,
+    KldConditionWithParam,
+    testing::Values(
+        std::make_tuple(kPercentile90th, 3, 228),
+        std::make_tuple(kPercentile90th, 4, 311),
+        std::make_tuple(kPercentile90th, 5, 388),
+        std::make_tuple(kPercentile90th, 6, 461),
+        std::make_tuple(kPercentile90th, 7, 531),
+        std::make_tuple(kPercentile90th, 100, 5871),
+        std::make_tuple(kPercentile99th, 3, 462),
+        std::make_tuple(kPercentile99th, 4, 569),
+        std::make_tuple(kPercentile99th, 5, 666),
+        std::make_tuple(kPercentile99th, 6, 756),
+        std::make_tuple(kPercentile99th, 7, 843),
+        std::make_tuple(kPercentile99th, 100, 6733)));
+
+inline constexpr auto identity = [](auto&& t) noexcept { return std::forward<decltype(t)>(t); };
+
+TEST(TakeWhileKld, TakeZero) {
+  const std::size_t min = 2;
+  const std::size_t max = 3;
+  const double epsilon = 0.1;
+  const auto output = ranges::views::empty<std::size_t> |                           //
+                      beluga::views::take_while_kld(identity, min, max, epsilon) |  //
+                      ranges::to<std::vector>;
+  ASSERT_EQ(output.size(), 0);
+}
+
+TEST(TakeWhileKld, TakeMaximum) {
+  const std::size_t min = 200;
+  const std::size_t max = 1200;
+  const double epsilon = 0.05;
+  const auto output = ranges::views::generate([]() { return 1UL; }) |               //
+                      beluga::views::take_while_kld(identity, min, max, epsilon) |  //
+                      ranges::to<std::vector>;
+  ASSERT_EQ(output.size(), max);
+}
+
+TEST(TakeWhileKld, TakeLimit) {
+  const std::size_t min = 0;
+  const std::size_t max = 1200;
+  const double epsilon = 0.05;
+  const auto output = ranges::views::generate([]() { return 1UL; }) |               //
+                      ranges::views::intersperse(2UL) |                             //
+                      ranges::views::intersperse(3UL) |                             //
+                      beluga::views::take_while_kld(identity, min, max, epsilon) |  //
+                      ranges::to<std::vector>;
+  ASSERT_EQ(output.size(), 135);
+}
+
+TEST(TakeWhileKld, TakeMinimum) {
+  const std::size_t min = 200;
+  const std::size_t max = 1200;
+  const double epsilon = 0.05;
+  const auto output = ranges::views::generate([]() { return 1UL; }) |               //
+                      ranges::views::intersperse(2UL) |                             //
+                      ranges::views::intersperse(3UL) |                             //
+                      beluga::views::take_while_kld(identity, min, max, epsilon) |  //
+                      ranges::to<std::vector>;
+  ASSERT_EQ(output.size(), min);
+}
+
+}  // namespace


### PR DESCRIPTION
### Proposed changes

This patch adds a new particle filter view to take samples based on the KLD condition. This decouples the algorithm implementation from the specific mixin class that we currently use.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)
