### PR TITLE
Add zip view and fix tuple vector traits

### DIFF
--- a/beluga/include/beluga/views.hpp
+++ b/beluga/include/beluga/views.hpp
@@ -21,6 +21,7 @@
 #include <beluga/views/sample.hpp>
 #include <beluga/views/take_evenly.hpp>
 #include <beluga/views/take_while_kld.hpp>
+#include <beluga/views/zip.hpp>
 
 /**
  * \file

--- a/beluga/include/beluga/views/zip.hpp
+++ b/beluga/include/beluga/views/zip.hpp
@@ -1,0 +1,77 @@
+// Copyright 2024 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BELUGA_VIEWS_ZIP_HPP
+#define BELUGA_VIEWS_ZIP_HPP
+
+#include <tuple>
+
+#include <range/v3/view/zip.hpp>
+
+/**
+ * \file
+ * \brief Implementation of a zip range adaptor object.
+ */
+
+namespace beluga::views {
+
+namespace detail {
+
+/// Utility type to adapt the zip output.
+struct as_common_tuple_indirect_fn {
+  /// Reference overload.
+  template <class... Its>
+  constexpr auto operator()(const Its&... its) const  //
+      noexcept((noexcept(ranges::iter_reference_t<Its>(*its)) && ...)) {
+    return ranges::common_tuple<ranges::iter_reference_t<Its>...>{*its...};
+  }
+
+  /// Move overload.
+  template <class... Its>
+  constexpr auto operator()(ranges::move_tag, const Its&... its) const
+      noexcept((noexcept(ranges::iter_rvalue_reference_t<Its>(ranges::iter_move(its))) && ...)) {
+    return ranges::common_tuple<ranges::iter_rvalue_reference_t<Its>...>{ranges::iter_move(its)...};
+  }
+
+  /// Copy overload.
+  /**
+   * This is needed for `ranges_value_t` to return `std::tuple` when this object is passed to a `zip_with_view`.
+   */
+  template <class... Its>
+  constexpr auto operator()(ranges::copy_tag, Its...) const -> std::tuple<ranges::iter_value_t<Its>...> {
+    RANGES_EXPECT(false);
+  }
+};
+
+/// Implementation detail for a zip range adaptor object.
+struct zip_fn {
+  /// Overload that implements the zip_view algorithm.
+  template <class... Ranges>
+  constexpr auto operator()(Ranges&&... ranges) const {
+    return ranges::views::iter_zip_with(as_common_tuple_indirect_fn{}, std::forward<Ranges>(ranges)...);
+  }
+};
+
+}  // namespace detail
+
+/// Given N ranges, return a new range where the Mth element is a tuple of the Mth elements of all N ranges.
+/**
+ * Unlike `ranges::views::zip`, iterators always dereference into tuples, not pairs.
+ * Other than that, they are both equivalent views.
+ */
+inline constexpr detail::zip_fn zip;
+
+}  // namespace beluga::views
+
+#endif

--- a/beluga/test/beluga/test_tuple_vector.cpp
+++ b/beluga/test/beluga/test_tuple_vector.cpp
@@ -163,6 +163,30 @@ TEST(TupleVectorTest, ConceptChecks) {
   static_assert(!ranges::contiguous_range<decltype(container)>);
 }
 
+TEST(TupleVectorTest, TraitConsistency) {
+  using Container = beluga::TupleVector<std::tuple<float, int>>;
+  using Iterator = decltype(ranges::begin(std::declval<Container&>()));
+
+  // Expected types
+  static_assert(std::is_same_v<
+                ranges::range_value_t<Container>,  //
+                std::tuple<float, int>>);
+  static_assert(std::is_same_v<
+                ranges::range_reference_t<Container>,  //
+                ranges::common_tuple<float&, int&>>);
+  static_assert(std::is_same_v<
+                ranges::range_rvalue_reference_t<Container>,  //
+                ranges::common_tuple<float&&, int&&>>);
+
+  // Consistency
+  static_assert(std::is_same_v<
+                ranges::iter_value_t<Iterator>,  //
+                typename Container::value_type>);
+  static_assert(std::is_same_v<
+                ranges::iter_reference_t<Iterator>,  //
+                typename Container::reference_type>);
+}
+
 TEST(TupleVectorTest, ConstCorrectness) {
   auto container = beluga::TupleVector<std::tuple<float>>{std::make_tuple(1)};
   static_assert(std::is_same_v<decltype(*ranges::begin(container)), ranges::common_tuple<float&>>);


### PR DESCRIPTION
### Proposed changes

Fixes `ranges::range_value_t<beluga::TupleVector>` returning a `ranges::common_tuple` instead of `std::tuple`.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)