### PR TITLE
Add assign action

### DIFF
--- a/beluga/include/beluga/actions.hpp
+++ b/beluga/include/beluga/actions.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Ekumen, Inc.
+// Copyright 2024 Ekumen, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,23 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef BELUGA_BELUGA_HPP
-#define BELUGA_BELUGA_HPP
+#ifndef BELUGA_ACTIONS_HPP
+#define BELUGA_ACTIONS_HPP
+
+#include <beluga/actions/assign.hpp>
 
 /**
  * \file
- * \brief Includes all the Beluga API.
+ * \brief Implementation of useful range actions.
  */
-
-#include <beluga/actions.hpp>
-#include <beluga/algorithm.hpp>
-#include <beluga/mixin.hpp>
-#include <beluga/motion.hpp>
-#include <beluga/primitives.hpp>
-#include <beluga/random.hpp>
-#include <beluga/sensor.hpp>
-#include <beluga/tuple_vector.hpp>
-#include <beluga/type_traits.hpp>
-#include <beluga/views.hpp>
 
 #endif

--- a/beluga/include/beluga/actions/assign.hpp
+++ b/beluga/include/beluga/actions/assign.hpp
@@ -1,0 +1,116 @@
+// Copyright 2024 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BELUGA_ACTIONS_ASSIGN_HPP
+#define BELUGA_ACTIONS_ASSIGN_HPP
+
+#include <range/v3/action/action.hpp>
+#include <range/v3/functional/bind_back.hpp>
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view/view.hpp>
+
+namespace beluga::actions {
+
+/// \cond
+
+template <class T, class = void>
+struct is_range_closure : std::false_type {};
+
+template <class T>
+struct is_range_closure<ranges::actions::action_closure<T>> : std::true_type {};
+
+template <class T>
+struct is_range_closure<ranges::views::view_closure<T>> : std::true_type {};
+
+template <class T>
+inline constexpr bool is_range_closure_v = is_range_closure<T>::value;
+
+/// \endcond
+
+namespace detail {
+
+/// Implementation detail for an assign range adaptor object.
+struct assign_fn {
+  /// Overload that implements the assign algorithm.
+  template <
+      class Range,
+      class Fn,
+      std::enable_if_t<ranges::range<Range>, int> = 0,
+      std::enable_if_t<is_range_closure_v<Fn>, int> = 0>
+  constexpr auto operator()(Range& range, Fn fn) const -> Range& {
+    auto&& view = fn(range);
+    if constexpr (!std::is_same_v<Range, std::decay_t<decltype(view)>>) {
+      // If the result of invoking the closure is not the range itself,
+      // then we need to convert the view and assign it to the input range.
+      range = std::move(view) | ranges::to<Range>;
+    }
+    return range;
+  }
+
+  /// Hidden friend operator overload that enables action / view composition.
+  /**
+   * Enables the following expressions:
+   *   1) view_closure | assign
+   *   2) action_closure | view_closure | assign
+   *   3) action_closure | assign
+   *
+   * 1) Will create an action closure that can eagerly invoke `view_closure` and assign
+   *    the resulting range to the input range.
+   * 2) Will create a new action closure that can invoke `action_closure`, eagerly invoke
+   *    `view_closure`, and assign the resulting range to the input range.
+   * 3) Technically a no-op, it will just invoke the `action_closure`.
+   */
+  template <class Fn, std::enable_if_t<is_range_closure_v<Fn>, int> = 0>
+  friend constexpr auto operator|(Fn fn, assign_fn) {
+    return ranges::make_action_closure(ranges::bind_back(assign_fn{}, std::move(fn)));
+  }
+};
+
+}  // namespace detail
+
+/// [Range adaptor object](https://en.cppreference.com/w/cpp/named_req/RangeAdaptorObject) that
+/// can converts a view closure into an action closure.
+/**
+ * This can be appended to any view closure to evaluate it eagerly and assign the result
+ * to a given range, effectively converting any view into an action.
+ */
+inline constexpr detail::assign_fn assign;
+
+/// Operator overload that appends assign to any range closure.
+template <
+    class Range,
+    class Fn,
+    std::enable_if_t<ranges::range<Range>, int> = 0,
+    std::enable_if_t<is_range_closure_v<Fn>, int> = 0>
+constexpr auto operator<<=(Range& range, Fn fn) -> Range& {
+  return range |= std::move(fn) | beluga::actions::assign;
+}
+
+}  // namespace beluga::actions
+
+// Make the assign operator overload findable by ADL for existing range adaptor objects:
+
+namespace beluga::views {
+using beluga::actions::operator<<=;
+}
+
+namespace ranges::views {
+using beluga::actions::operator<<=;
+}
+
+namespace ranges::actions {
+using beluga::actions::operator<<=;
+}
+
+#endif

--- a/beluga/include/beluga/actions/assign.hpp
+++ b/beluga/include/beluga/actions/assign.hpp
@@ -93,30 +93,6 @@ struct assign_fn {
  */
 inline constexpr detail::assign_fn assign;
 
-/// Operator overload that appends assign to any range closure.
-template <
-    class Range,
-    class Fn,
-    std::enable_if_t<ranges::range<Range>, int> = 0,
-    std::enable_if_t<is_range_closure_v<Fn>, int> = 0>
-constexpr auto operator<<=(Range& range, Fn fn) -> Range& {
-  return range |= std::move(fn) | beluga::actions::assign;
-}
-
 }  // namespace beluga::actions
-
-// Make the assign operator overload findable by ADL for existing range adaptor objects:
-
-namespace beluga::views {
-using beluga::actions::operator<<=;
-}
-
-namespace ranges::views {
-using beluga::actions::operator<<=;
-}
-
-namespace ranges::actions {
-using beluga::actions::operator<<=;
-}
 
 #endif

--- a/beluga/include/beluga/actions/assign.hpp
+++ b/beluga/include/beluga/actions/assign.hpp
@@ -84,6 +84,12 @@ struct assign_fn {
 /**
  * This can be appended to any view closure to evaluate it eagerly and assign the result
  * to a given range, effectively converting any view into an action.
+ *
+ * The assignment of elements into the container may involve copy which can be less efficient than
+ * move because lvalue references are produced during the indirection call. Users can opt-in to use
+ * `ranges::views::move` to adapt the range in order for their elements to always produce an rvalue
+ * reference during the indirection call which implies move. In this case, make sure that the input
+ * views don't require accessing the elements in the adapted range more than once.
  */
 inline constexpr detail::assign_fn assign;
 

--- a/beluga/test/beluga/CMakeLists.txt
+++ b/beluga/test/beluga/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_executable(
   test_beluga
+  actions/test_assign.cpp
   algorithm/raycasting/test_bresenham.cpp
   algorithm/test_distance_map.cpp
   algorithm/test_estimation.cpp

--- a/beluga/test/beluga/actions/test_assign.cpp
+++ b/beluga/test/beluga/actions/test_assign.cpp
@@ -59,12 +59,6 @@ TEST(AssignAction, ViewToActionCall) {
   ASSERT_TRUE(ranges::equal(input, std::vector{3, 2, 1}));
 }
 
-TEST(AssignAction, ViewToActionOperator) {
-  auto input = std::vector{1, 2, 3};
-  input <<= ranges::views::reverse;
-  ASSERT_TRUE(ranges::equal(input, std::vector{3, 2, 1}));
-}
-
 TEST(AssignAction, ActionComposition) {
   auto input = std::vector{1, 2, 3};
   input |= ranges::actions::drop(1) | beluga::actions::assign;
@@ -90,7 +84,7 @@ TEST(AssignAction, ActionViewActionComposition) {
 
 TEST(AssignAction, List) {
   auto input = std::list{1, 2, 3};
-  input <<= ranges::actions::remove(2) | ranges::views::reverse;
+  input |= ranges::actions::remove(2) | ranges::views::reverse | beluga::actions::assign;
   ASSERT_TRUE(ranges::equal(input, std::list{3, 1}));
 }
 

--- a/beluga/test/beluga/actions/test_assign.cpp
+++ b/beluga/test/beluga/actions/test_assign.cpp
@@ -1,0 +1,84 @@
+// Copyright 2024 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <list>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <beluga/actions/assign.hpp>
+
+#include <range/v3/action/drop.hpp>
+#include <range/v3/action/remove.hpp>
+#include <range/v3/algorithm/equal.hpp>
+#include <range/v3/view/reverse.hpp>
+#include <range/v3/view/transform.hpp>
+
+namespace {
+
+TEST(AssignAction, ViewToAction) {
+  auto input = std::vector{1, 2, 3};
+  input |= ranges::views::reverse | beluga::actions::assign;
+  ASSERT_TRUE(ranges::equal(input, std::vector{3, 2, 1}));
+}
+
+TEST(AssignAction, ViewToActionComposition) {
+  auto reverse_and_assign = ranges::views::reverse | beluga::actions::assign;
+  auto input = std::vector{1, 2, 3};
+  input |= reverse_and_assign;
+  ASSERT_TRUE(ranges::equal(input, std::vector{3, 2, 1}));
+}
+
+TEST(AssignAction, ViewToActionCall) {
+  auto input = std::vector{1, 2, 3};
+  beluga::actions::assign(input, ranges::views::reverse);
+  ASSERT_TRUE(ranges::equal(input, std::vector{3, 2, 1}));
+}
+
+TEST(AssignAction, ViewToActionOperator) {
+  auto input = std::vector{1, 2, 3};
+  input <<= ranges::views::reverse;
+  ASSERT_TRUE(ranges::equal(input, std::vector{3, 2, 1}));
+}
+
+TEST(AssignAction, ActionComposition) {
+  auto input = std::vector{1, 2, 3};
+  input |= ranges::actions::drop(1) | beluga::actions::assign;
+  ASSERT_TRUE(ranges::equal(input, std::vector{2, 3}));
+}
+
+TEST(AssignAction, ActionViewComposition) {
+  auto input = std::vector{1, 2, 3};
+  input |= ranges::actions::drop(1) | ranges::views::reverse | beluga::actions::assign;
+  ASSERT_TRUE(ranges::equal(input, std::vector{3, 2}));
+}
+
+TEST(AssignAction, ActionViewActionComposition) {
+  auto input = std::vector{1, 2, 3};
+  input |= ranges::actions::drop(1) |                                      //
+           ranges::views::reverse |                                        //
+           beluga::actions::assign |                                       //
+           ranges::actions::drop(1) |                                      //
+           ranges::views::transform([](auto value) { return ++value; }) |  //
+           beluga::actions::assign;
+  ASSERT_TRUE(ranges::equal(input, std::vector{3}));
+}
+
+TEST(AssignAction, List) {
+  auto input = std::list{1, 2, 3};
+  input <<= ranges::actions::remove(2) | ranges::views::reverse;
+  ASSERT_TRUE(ranges::equal(input, std::list{3, 1}));
+}
+
+}  // namespace

--- a/beluga/test/beluga/actions/test_assign.cpp
+++ b/beluga/test/beluga/actions/test_assign.cpp
@@ -72,13 +72,13 @@ TEST(AssignAction, ActionViewComposition) {
 
 TEST(AssignAction, ActionViewActionComposition) {
   auto input = std::vector{1, 2, 3};
-  input |= ranges::actions::drop(1) |                                      //
-           ranges::views::reverse |                                        //
-           beluga::actions::assign |                                       //
-           ranges::actions::drop(1) |                                      //
-           ranges::views::transform([](auto value) { return ++value; }) |  //
+  input |= ranges::actions::drop(1) |                                         //
+           ranges::views::reverse |                                           //
+           beluga::actions::assign |                                          //
+           ranges::actions::drop(1) |                                         //
+           ranges::views::transform([](auto value) { return value + 10; }) |  //
            beluga::actions::assign;
-  ASSERT_TRUE(ranges::equal(input, std::vector{3}));
+  ASSERT_TRUE(ranges::equal(input, std::vector{12}));
 }
 
 TEST(AssignAction, List) {

--- a/beluga/test/beluga/actions/test_assign.cpp
+++ b/beluga/test/beluga/actions/test_assign.cpp
@@ -40,7 +40,7 @@ TEST(AssignAction, MoveOnlyRange) {
   input.emplace_back(std::make_unique<int>(1));
   input.emplace_back(std::make_unique<int>(2));
   input.emplace_back(std::make_unique<int>(3));
-  input |= ranges::views::move | ranges::views::reverse | beluga::actions::assign;
+  input |= ranges::views::reverse | ranges::views::move | beluga::actions::assign;
   ASSERT_EQ(*input.front(), 3);
   ASSERT_EQ(*input.back(), 1);
 }

--- a/beluga/test/beluga/actions/test_assign.cpp
+++ b/beluga/test/beluga/actions/test_assign.cpp
@@ -23,6 +23,7 @@
 #include <range/v3/action/drop.hpp>
 #include <range/v3/action/remove.hpp>
 #include <range/v3/algorithm/equal.hpp>
+#include <range/v3/view/indirect.hpp>
 #include <range/v3/view/move.hpp>
 #include <range/v3/view/reverse.hpp>
 #include <range/v3/view/transform.hpp>
@@ -41,8 +42,7 @@ TEST(AssignAction, MoveOnlyRange) {
   input.emplace_back(std::make_unique<int>(2));
   input.emplace_back(std::make_unique<int>(3));
   input |= ranges::views::reverse | ranges::views::move | beluga::actions::assign;
-  ASSERT_EQ(*input.front(), 3);
-  ASSERT_EQ(*input.back(), 1);
+  ASSERT_TRUE(ranges::equal(input | ranges::views::indirect, std::vector{3, 2, 1}));
 }
 
 TEST(AssignAction, ViewToActionComposition) {

--- a/beluga/test/beluga/actions/test_assign.cpp
+++ b/beluga/test/beluga/actions/test_assign.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <list>
+#include <memory>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -25,8 +26,6 @@
 #include <range/v3/view/move.hpp>
 #include <range/v3/view/reverse.hpp>
 #include <range/v3/view/transform.hpp>
-
-#include <memory>
 
 namespace {
 

--- a/beluga/test/beluga/actions/test_assign.cpp
+++ b/beluga/test/beluga/actions/test_assign.cpp
@@ -22,8 +22,11 @@
 #include <range/v3/action/drop.hpp>
 #include <range/v3/action/remove.hpp>
 #include <range/v3/algorithm/equal.hpp>
+#include <range/v3/view/move.hpp>
 #include <range/v3/view/reverse.hpp>
 #include <range/v3/view/transform.hpp>
+
+#include <memory>
 
 namespace {
 
@@ -31,6 +34,16 @@ TEST(AssignAction, ViewToAction) {
   auto input = std::vector{1, 2, 3};
   input |= ranges::views::reverse | beluga::actions::assign;
   ASSERT_TRUE(ranges::equal(input, std::vector{3, 2, 1}));
+}
+
+TEST(AssignAction, MoveOnlyRange) {
+  auto input = std::vector<std::unique_ptr<int>>{};
+  input.emplace_back(std::make_unique<int>(1));
+  input.emplace_back(std::make_unique<int>(2));
+  input.emplace_back(std::make_unique<int>(3));
+  input |= ranges::views::move | ranges::views::reverse | beluga::actions::assign;
+  ASSERT_EQ(*input.front(), 3);
+  ASSERT_EQ(*input.back(), 1);
 }
 
 TEST(AssignAction, ViewToActionComposition) {


### PR DESCRIPTION
### Proposed changes

View-action composition in the range library is limited. This patch implements a new range adaptor object that can be appended to any view closure to evaluate it eagerly and assign the result to a given range, effectively converting any view into an action.

Related to #279.

The simple particle filter pipeline example becomes:

```cpp
struct Particle {
  int state;
  double weight;
};

auto particles = std::vector<Particle>{};
auto motion_model = ...;
auto sensor_model = ...;

particles |= beluga::actions::propagate(motion_model) |
             beluga::actions::reweight(sensor_model) |
             beluga::views::sample |
             ranges::views::take_exactly(1000) |
             beluga::actions::assign;
```

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)