### PR TITLE
Extend sample view to sample from random distributions

### DIFF
--- a/beluga/test/beluga/views/test_sample.cpp
+++ b/beluga/test/beluga/views/test_sample.cpp
@@ -151,4 +151,16 @@ TEST(SampleView, DiscreteDistributionProbability) {
   ASSERT_NEAR(static_cast<double>(buckets[4]) / size, 0.2, 0.01);
 }
 
+TEST(SampleView, FromRandomDistributionFalse) {
+  auto distribution = std::bernoulli_distribution{0.0};
+  auto output = beluga::views::sample(distribution) | ranges::views::take_exactly(10);
+  ASSERT_EQ(ranges::count(output, false), 10);
+}
+
+TEST(SampleView, FromRandomDistributionTrue) {
+  auto distribution = std::bernoulli_distribution{1.0};
+  auto output = beluga::views::sample(distribution) | ranges::views::take_exactly(10);
+  ASSERT_EQ(ranges::count(output, true), 10);
+}
+
 }  // namespace

--- a/beluga_system_tests/test/test_system_new.cpp
+++ b/beluga_system_tests/test/test_system_new.cpp
@@ -126,7 +126,6 @@ auto particle_filter_test(
   auto hasher = beluga::spatial_hash<Sophus::SE2d>{0.1, 0.1, 0.1};
 
   // Use the initial distribution to initialize particles.
-  // TODO(nahuel): We should have a view to sample from an existing distribution.
   // TODO(nahuel): We should have a view to convert from Eigen to Sophus types.
   /**
    * auto particles = beluga::views::sample(initial_distribution) |
@@ -135,9 +134,8 @@ auto particle_filter_test(
    *                  ranges::views::take_exactly(params.max_particles) |
    *                  ranges::to<beluga::TupleVector>;
    */
-  auto particles = ranges::views::generate([initial_distribution]() mutable {
-                     static thread_local auto engine = std::mt19937{std::random_device()()};
-                     const auto sample = initial_distribution(engine);
+  auto particles = beluga::views::sample(initial_distribution) |  //
+                   ranges::views::transform([](const auto& sample) {
                      return Sophus::SE2d{Sophus::SO2d{sample.z()}, Eigen::Vector2d{sample.x(), sample.y()}};
                    }) |
                    ranges::views::transform(beluga::make_from_state<Particle>) |  //


### PR DESCRIPTION
### Proposed changes

This saves lines of code by extending the sample view implementation to convert any random distribution (a callable that takes a URNG as an input argument) into a range.

It also makes the implementation easier to follow by removing the use of default arguments (which play poorly with overloads).

Related to #279.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)
