### PR TITLE
Extend multivariate distribution to support different result types

### DIFF
--- a/beluga/docs/doxygen_cites.bib
+++ b/beluga/docs/doxygen_cites.bib
@@ -9,6 +9,16 @@
   publisher={MIT Press}
 }
 
+@book{gentle2009computationalstatistics,
+  title={Computational Statistics},
+  author={Gentle, J. E.},
+  isbn={9780387981437},
+  series={Statistics and Computing},
+  year={2009},
+  publisher={Springer},
+  doi={10.1007/978-0-387-98144-4}
+}
+
 @article{grisetti2007selectiveresampling,
   author={Grisetti, Giorgio and Stachniss, Cyrill and Burgard, Wolfram},
   journal={IEEE Transactions on Robotics},

--- a/beluga/include/beluga/random/multivariate_distribution_traits.hpp
+++ b/beluga/include/beluga/random/multivariate_distribution_traits.hpp
@@ -17,7 +17,6 @@
 
 #include <Eigen/Core>
 #include <sophus/se2.hpp>
-#include <sophus/se3.hpp>
 
 /**
  * \file
@@ -108,58 +107,6 @@ struct multivariate_distribution_traits<T, std::enable_if_t<std::is_base_of_v<So
   /// Convert from vector to result representation.
   [[nodiscard]] static constexpr result_type from_vector(const vector_type& v) {
     return {Sophus::SO2<scalar_type>::exp(v.z()), v.head(2)};
-  }
-};
-
-/// Specialization for types derived from Sophus::SO3Base.
-template <class T>
-struct multivariate_distribution_traits<T, std::enable_if_t<std::is_base_of_v<Sophus::SO3Base<T>, T>>> {
-  /// The scalar type.
-  using scalar_type = typename T::Scalar;
-
-  /// The result type representation.
-  using result_type = Sophus::SO3<scalar_type>;
-
-  /// The vector type.
-  using vector_type = typename Eigen::Matrix<scalar_type, 3, 1>;
-
-  /// The covariance matrix type.
-  using covariance_type = typename Eigen::Matrix<scalar_type, 3, 3>;
-
-  /// Convert from result to vector representation.
-  [[nodiscard]] static constexpr vector_type to_vector(const result_type& t) { return t.log(); }
-
-  /// Convert from vector to result representation.
-  [[nodiscard]] static constexpr result_type from_vector(const vector_type& v) {
-    return Sophus::SO3<scalar_type>::exp(v);
-  }
-};
-
-/// Specialization for types derived from Sophus::SE3Base.
-template <class T>
-struct multivariate_distribution_traits<T, std::enable_if_t<std::is_base_of_v<Sophus::SE3Base<T>, T>>> {
-  /// The scalar type.
-  using scalar_type = typename T::Scalar;
-
-  /// The result type representation.
-  using result_type = Sophus::SE3<scalar_type>;
-
-  /// The vector type.
-  using vector_type = typename Eigen::Matrix<scalar_type, 6, 1>;
-
-  /// The covariance matrix type.
-  using covariance_type = typename Eigen::Matrix<scalar_type, 6, 6>;
-
-  /// Convert from result to vector representation.
-  [[nodiscard]] static constexpr vector_type to_vector(const result_type& t) {
-    vector_type v;
-    v << t.translation(), t.so3().log();
-    return v;
-  }
-
-  /// Convert from vector to result representation.
-  [[nodiscard]] static constexpr result_type from_vector(const vector_type& v) {
-    return result_type{Sophus::SO3<scalar_type>::exp(v.tail(3)), v.head(3)};
   }
 };
 

--- a/beluga/include/beluga/random/multivariate_distribution_traits.hpp
+++ b/beluga/include/beluga/random/multivariate_distribution_traits.hpp
@@ -1,0 +1,168 @@
+// Copyright 2024 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BELUGA_RANDOM_MULTIVARIATE_DISTRIBUTION_TRAITS_HPP
+#define BELUGA_RANDOM_MULTIVARIATE_DISTRIBUTION_TRAITS_HPP
+
+#include <Eigen/Core>
+#include <sophus/se2.hpp>
+#include <sophus/se3.hpp>
+
+/**
+ * \file
+ * \brief Implementation of multivariate distribution traits.
+ */
+
+namespace beluga {
+
+/// Forward declaration of the multivariate_distribution_traits class template.
+template <class T, class Enable = void>
+struct multivariate_distribution_traits;
+
+/// Specialization for types derived from `Eigen::EigenBase`.
+template <class T>
+struct multivariate_distribution_traits<T, std::enable_if_t<std::is_base_of_v<Eigen::EigenBase<T>, T>>> {
+  static_assert(T::ColsAtCompileTime == 1 || T::RowsAtCompileTime == 1, "T should be a column or row vector");
+
+  /// Extract size information and types from the Eigen matrix type T.
+  static constexpr int matrix_size = T::ColsAtCompileTime > T::RowsAtCompileTime  //
+                                         ? T::ColsAtCompileTime
+                                         : T::RowsAtCompileTime;
+
+  /// The scalar type.
+  using scalar_type = typename T::Scalar;
+
+  /// The result type representation.
+  using result_type = typename T::PlainMatrix;
+
+  /// The vector type.
+  using vector_type = typename T::PlainMatrix;
+
+  /// The covariance matrix type.
+  using covariance_type = typename Eigen::Matrix<scalar_type, matrix_size, matrix_size>;
+
+  /// Convert from result to vector representation.
+  [[nodiscard]] static constexpr vector_type to_vector(const result_type& t) { return t; }
+
+  /// Convert from vector to result representation.
+  [[nodiscard]] static constexpr result_type from_vector(const vector_type& v) { return v; }
+};
+
+/// Specialization for types derived from Sophus::SO2Base.
+template <class T>
+struct multivariate_distribution_traits<T, std::enable_if_t<std::is_base_of_v<Sophus::SO2Base<T>, T>>> {
+  /// The scalar type.
+  using scalar_type = typename T::Scalar;
+
+  /// The result type representation.
+  using result_type = Sophus::SO2<scalar_type>;
+
+  /// The vector type.
+  using vector_type = typename Eigen::Matrix<scalar_type, 1, 1>;
+
+  /// The covariance matrix type.
+  using covariance_type = typename Eigen::Matrix<scalar_type, 1, 1>;
+
+  /// Convert from result to vector representation.
+  [[nodiscard]] static constexpr vector_type to_vector(const result_type& t) { return vector_type{t.log()}; }
+
+  /// Convert from vector to result representation.
+  [[nodiscard]] static constexpr result_type from_vector(const vector_type& v) {
+    return Sophus::SO2<scalar_type>::exp(v.x());
+  }
+};
+
+/// Specialization for types derived from Sophus::SE2Base.
+template <class T>
+struct multivariate_distribution_traits<T, std::enable_if_t<std::is_base_of_v<Sophus::SE2Base<T>, T>>> {
+  /// The scalar type.
+  using scalar_type = typename T::Scalar;
+
+  /// The result type representation.
+  using result_type = Sophus::SE2<scalar_type>;
+
+  /// The vector type.
+  using vector_type = typename Eigen::Matrix<scalar_type, 3, 1>;
+
+  /// The covariance matrix type.
+  using covariance_type = typename Eigen::Matrix<scalar_type, 3, 3>;
+
+  /// Convert from result to vector representation.
+  [[nodiscard]] static constexpr vector_type to_vector(const result_type& t) {
+    vector_type v;
+    v << t.translation(), t.so2().log();
+    return v;
+  }
+
+  /// Convert from vector to result representation.
+  [[nodiscard]] static constexpr result_type from_vector(const vector_type& v) {
+    return {Sophus::SO2<scalar_type>::exp(v.z()), v.head(2)};
+  }
+};
+
+/// Specialization for types derived from Sophus::SO3Base.
+template <class T>
+struct multivariate_distribution_traits<T, std::enable_if_t<std::is_base_of_v<Sophus::SO3Base<T>, T>>> {
+  /// The scalar type.
+  using scalar_type = typename T::Scalar;
+
+  /// The result type representation.
+  using result_type = Sophus::SO3<scalar_type>;
+
+  /// The vector type.
+  using vector_type = typename Eigen::Matrix<scalar_type, 3, 1>;
+
+  /// The covariance matrix type.
+  using covariance_type = typename Eigen::Matrix<scalar_type, 3, 3>;
+
+  /// Convert from result to vector representation.
+  [[nodiscard]] static constexpr vector_type to_vector(const result_type& t) { return t.log(); }
+
+  /// Convert from vector to result representation.
+  [[nodiscard]] static constexpr result_type from_vector(const vector_type& v) {
+    return Sophus::SO3<scalar_type>::exp(v);
+  }
+};
+
+/// Specialization for types derived from Sophus::SE3Base.
+template <class T>
+struct multivariate_distribution_traits<T, std::enable_if_t<std::is_base_of_v<Sophus::SE3Base<T>, T>>> {
+  /// The scalar type.
+  using scalar_type = typename T::Scalar;
+
+  /// The result type representation.
+  using result_type = Sophus::SE3<scalar_type>;
+
+  /// The vector type.
+  using vector_type = typename Eigen::Matrix<scalar_type, 6, 1>;
+
+  /// The covariance matrix type.
+  using covariance_type = typename Eigen::Matrix<scalar_type, 6, 6>;
+
+  /// Convert from result to vector representation.
+  [[nodiscard]] static constexpr vector_type to_vector(const result_type& t) {
+    vector_type v;
+    v << t.translation(), t.so3().log();
+    return v;
+  }
+
+  /// Convert from vector to result representation.
+  [[nodiscard]] static constexpr result_type from_vector(const vector_type& v) {
+    return result_type{Sophus::SO3<scalar_type>::exp(v.tail(3)), v.head(3)};
+  }
+};
+
+}  // namespace beluga
+
+#endif

--- a/beluga/include/beluga/random/multivariate_normal_distribution.hpp
+++ b/beluga/include/beluga/random/multivariate_normal_distribution.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Ekumen, Inc.
+// Copyright 2023-2024 Ekumen, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,10 +16,9 @@
 #define BELUGA_RANDOM_MULTIVARIATE_NORMAL_DISTRIBUTION_HPP
 
 #include <random>
-
-#include <Eigen/Core>
-#include <Eigen/Eigenvalues>
 #include <utility>
+
+#include <beluga/random/multivariate_distribution_traits.hpp>
 
 /**
  * \file
@@ -28,135 +27,201 @@
 
 namespace beluga {
 
-/// Multivariate normal distribution.
-/**
- * `MultivariateNormalDistribution<Matrix>` is an implementation of
- * \ref RandomStateDistributionPage that represents a multi-dimensional
- * normal distribution of real-valued random variables.
- *
- * \tparam Matrix The type of the covariance matrix; this is expected to be an instantiation
- * of the [Eigen::Matrix](https://eigen.tuxfamily.org/dox/classEigen_1_1Matrix.html) class
- * template.
- */
-template <class Matrix>
-class MultivariateNormalDistribution {
+/// Multivariate normal distribution parameter set class.
+template <class Vector, class Matrix>
+class MultivariateNormalDistributionParam {
  public:
-  /// Scalar type for matrices of type Matrix.
-  using Scalar = typename Matrix::Scalar;
+  static_assert(std::is_base_of_v<Eigen::EigenBase<Vector>, Vector>, "Vector should be an Eigen type");
+  static_assert(
+      Vector::ColsAtCompileTime == 1 || Vector::RowsAtCompileTime == 1,
+      "Vector should be a column or row vector");
 
-  /// The eigen column vector from Matrix.
-  using Vector = typename Eigen::Matrix<typename Matrix::Scalar, Matrix::RowsAtCompileTime, 1>;
+  /// The scalar type.
+  using scalar_type = typename Vector::Scalar;
 
-  /// Multivariate normal distribution parameter set class.
-  class Param {
-   public:
-    /// The type of distribution to which this parameter set class belongs.
-    using distribution_type = MultivariateNormalDistribution<Matrix>;
+  /// The vector type.
+  using vector_type = Vector;
 
-    /// Constructs a parameter set instance.
-    Param() = default;
+  /// The covariance matrix from Vector.
+  using matrix_type = Matrix;
 
-    /// Constructs a parameter set instance.
-    /**
-     * \tparam InputType The input type derived from `EigenBase`.
-     * \param covariance Real symmetric matrix that represents the covariance of the random variable.
-     *
-     * \throw std::runtime_error If the provided covariance is invalid.
-     */
-    template <typename InputType>
-    explicit Param(const Eigen::EigenBase<InputType>& covariance) : transform_{make_transform(covariance)} {}
+  /// Constructs a parameter set instance.
+  MultivariateNormalDistributionParam() = default;
 
-    /// Constructs a parameter set instance.
-    /**
-     * \tparam InputType The input type derived from `EigenBase`.
-     * \param mean A vector that represents the mean value of the random variable.
-     * \param covariance Real symmetric matrix that represents the covariance of the random variable.
-     *
-     * \throw std::runtime_error If the provided covariance is invalid.
-     */
-    template <typename InputType>
-    Param(Vector mean, const Eigen::EigenBase<InputType>& covariance)
-        : mean_{std::move(mean)}, transform_{make_transform(covariance)} {}
-
-    /// Compares this object with other parameter set object.
-    /**
-     * \param other Parameter set object to compare against.
-     * \return True if the objects are equal, false otherwise.
-     */
-    [[nodiscard]] bool operator==(const Param& other) const {
-      return mean_ == other.mean_ && transform_ == other.transform_;
-    }
-
-    /// Compares this object with other parameter set object.
-    /**
-     * \param other Parameter set object to compare against.
-     * \return True if the objects are not equal, false otherwise.
-     */
-    [[nodiscard]] bool operator!=(const Param& other) const { return !(*this == other); }
-
-   private:
-    friend class MultivariateNormalDistribution<Matrix>;
-
-    Vector mean_{Vector::Zero()};
-    Matrix transform_{make_transform(Vector::Ones().asDiagonal())};
-
-    [[nodiscard]] static Matrix make_transform(const Matrix& covariance) {
-      // For more information about the method used to generate correlated normal vectors
-      // from independent normal distributions, see:
-      // https://en.wikipedia.org/wiki/Multivariate_normal_distribution#Drawing_values_from_the_distribution
-      // Gentle, J. E. (2009). Computational Statistics. Statistics and Computing. New York: Springer. pp. 315–316.
-      // https://doi.org/10.1007%2F978-0-387-98144-4
-      if (!covariance.isApprox(covariance.transpose())) {
-        throw std::runtime_error("Invalid covariance matrix, it is not symmetric.");
-      }
-      const auto solver = Eigen::SelfAdjointEigenSolver<Matrix>{covariance};
-      if (solver.info() != Eigen::Success) {
-        throw std::runtime_error("Invalid covariance matrix, eigen solver failed.");
-      }
-      const auto& eigenvalues = solver.eigenvalues();
-      if ((eigenvalues.array() < 0.0).any()) {
-        throw std::runtime_error("Invalid covariance matrix, it has negative eigenvalues.");
-      }
-      return solver.eigenvectors() * eigenvalues.cwiseSqrt().asDiagonal();
-    }
-  };
-
-  /// The type of the parameter set.
-  using param_type = Param;
-
-  /// The result type generated by the generator.
-  using result_type = Vector;
-
-  /// Constructs a MultivariateNormalDistribution with zero mean and circularly symmetric unitary covariance.
-  MultivariateNormalDistribution() = default;
-
-  /// Constructs a MultivariateNormalDistribution using param as distribution parameters.
+  /// Constructs a parameter set instance.
   /**
-   * \param params The distribution parameter set.
-   */
-  explicit MultivariateNormalDistribution(const param_type& params) : params_{params} {}
-
-  /// Constructs a MultivariateNormalDistribution with zero mean and the given covariance.
-  /**
-   * \tparam InputType The input type derived from `EigenBase`.
    * \param covariance Real symmetric matrix that represents the covariance of the random variable.
    *
    * \throw std::runtime_error If the provided covariance is invalid.
    */
-  template <class InputType>
-  explicit MultivariateNormalDistribution(const Eigen::EigenBase<InputType>& covariance) : params_{covariance} {}
+  explicit MultivariateNormalDistributionParam(matrix_type covariance)
+      : transform_{make_transform(std::move(covariance))} {}
 
-  /// Constructs a MultivariateNormalDistribution with the given mean and covariance.
+  /// Constructs a parameter set instance.
   /**
-   * \tparam InputType The input type derived from `EigenBase`.
    * \param mean A vector that represents the mean value of the random variable.
    * \param covariance Real symmetric matrix that represents the covariance of the random variable.
    *
    * \throw std::runtime_error If the provided covariance is invalid.
    */
-  template <class InputType>
-  MultivariateNormalDistribution(const Vector& mean, const Eigen::EigenBase<InputType>& covariance)
-      : params_(mean, covariance) {}
+  MultivariateNormalDistributionParam(vector_type mean, matrix_type covariance)
+      : mean_{std::move(mean)}, transform_{make_transform(std::move(covariance))} {}
+
+  /// Compares this object with other parameter set object.
+  /**
+   * \param other Parameter set object to compare against.
+   * \return True if the objects are equal, false otherwise.
+   */
+  [[nodiscard]] bool operator==(const MultivariateNormalDistributionParam& other) const {
+    return mean_ == other.mean_ && transform_ == other.transform_;
+  }
+
+  /// Compares this object with other parameter set object.
+  /**
+   * \param other Parameter set object to compare against.
+   * \return True if the objects are not equal, false otherwise.
+   */
+  [[nodiscard]] bool operator!=(const MultivariateNormalDistributionParam& other) const { return !(*this == other); }
+
+  /// Generates a new random object from the distribution.
+  /**
+   * \tparam Generator The generator type that must meet the requirements of
+   * [UniformRandomBitGenerator](https://en.cppreference.com/w/cpp/named_req/UniformRandomBitGenerator).
+   * \param distribution A reference to a normal distribution instance.
+   * \param generator An uniform random bit generator object.
+   * \return The generated random object.
+   */
+  template <class Generator>
+  [[nodiscard]] auto operator()(std::normal_distribution<scalar_type>& distribution, Generator& generator) const {
+    const auto delta = vector_type{}.unaryExpr([&distribution, &generator](auto) { return distribution(generator); });
+    if constexpr (vector_type::ColsAtCompileTime == 1) {
+      return mean_ + transform_ * delta;
+    } else {
+      return mean_ + delta * transform_;
+    }
+  }
+
+ private:
+  vector_type mean_{vector_type::Zero()};
+  matrix_type transform_{make_transform(vector_type::Ones().asDiagonal())};
+
+  [[nodiscard]] static matrix_type make_transform(matrix_type covariance) {
+    // For more information about the method used to generate correlated normal vectors
+    // from independent normal distributions, see:
+    // https://en.wikipedia.org/wiki/Multivariate_normal_distribution#Drawing_values_from_the_distribution
+    // \cite gentle2009computationalstatistics.
+    if (!covariance.isApprox(covariance.transpose())) {
+      throw std::runtime_error("Invalid covariance matrix, it is not symmetric.");
+    }
+    const auto solver = Eigen::SelfAdjointEigenSolver<matrix_type>{covariance};
+    if (solver.info() != Eigen::Success) {
+      throw std::runtime_error("Invalid covariance matrix, eigen solver failed.");
+    }
+    const auto& eigenvalues = solver.eigenvalues();
+    if ((eigenvalues.array() < 0.0).any()) {
+      throw std::runtime_error("Invalid covariance matrix, it has negative eigenvalues.");
+    }
+    return solver.eigenvectors() * eigenvalues.cwiseSqrt().asDiagonal();
+  }
+};
+
+/// Multivariate normal distribution.
+/**
+ * `MultivariateNormalDistribution<T>` is an implementation of
+ * \ref RandomStateDistributionPage that represents a multi-dimensional
+ * normal distribution of real-valued random variables.
+ *
+ * \tparam T The result type for the distribution.
+ */
+template <class T>
+class MultivariateNormalDistribution {
+ public:
+  template <class U>
+  friend class MultivariateNormalDistribution;
+
+  /// The scalar type.
+  using scalar_type = typename multivariate_distribution_traits<T>::scalar_type;
+
+  /// The Eigen vector type corresponding to T.
+  using vector_type = typename multivariate_distribution_traits<T>::vector_type;
+
+  /// The covariance matrix from T.
+  using covariance_type = typename multivariate_distribution_traits<T>::covariance_type;
+
+  /// The result type from T.
+  using result_type = typename multivariate_distribution_traits<T>::result_type;
+
+  /// The type of the parameter set.
+  using param_type = MultivariateNormalDistributionParam<vector_type, covariance_type>;
+
+  /// Construct with zero mean and circularly symmetric unitary covariance.
+  MultivariateNormalDistribution() = default;
+
+  /// Construct from distribution parameters.
+  /**
+   * \param params The distribution parameter set.
+   */
+  explicit MultivariateNormalDistribution(const param_type& params) : params_{params} {}
+
+  /// Construct with zero mean and the given covariance.
+  /**
+   * \param covariance Real symmetric matrix that represents the covariance of the random variable.
+   *
+   * \throw std::runtime_error If the provided covariance is invalid.
+   */
+  explicit MultivariateNormalDistribution(covariance_type covariance) : params_{std::move(covariance)} {}
+
+  /// Construct with the given mean and covariance.
+  /**
+   * \param mean An object that represents the mean value of the random variable.
+   * \param covariance Real symmetric matrix that represents the covariance of the random variable.
+   *
+   * \throw std::runtime_error If the provided covariance is invalid.
+   */
+  MultivariateNormalDistribution(result_type mean, covariance_type covariance)
+      : params_{multivariate_distribution_traits<T>::to_vector(std::move(mean)), std::move(covariance)} {}
+
+  /// Copy construct from another compatible distribution.
+  /**
+   * \tparam U The result type for the other distribution.
+   * \param other Another instance of a multivariate normal distribution.
+   */
+  template <class U>
+  /* implicit */ MultivariateNormalDistribution(const MultivariateNormalDistribution<U>& other)  // NOLINT
+      : params_{other.params_}, distribution_{other.distribution_} {}
+
+  /// Move construct from another compatible distribution.
+  /**
+   * \tparam U The result type for the other distribution.
+   * \param other Another instance of a multivariate normal distribution.
+   */
+  template <class U>
+  /* implicit */ MultivariateNormalDistribution(MultivariateNormalDistribution<U>&& other) noexcept  // NOLINT
+      : params_(std::move(other.params_)), distribution_{std::move(other.distribution_)} {}
+
+  /// Copy assign from another compatible distribution.
+  /**
+   * \tparam U The result type for the other distribution.
+   * \param other Another instance of a multivariate normal distribution.
+   */
+  template <class U>
+  MultivariateNormalDistribution& operator=(const MultivariateNormalDistribution<U>& other) {
+    params_ = other.params_;
+    distribution_ = other.distribution_;
+    return *this;
+  }
+
+  /// Move assign from another compatible distribution.
+  /**
+   * \tparam U The result type for the other distribution.
+   * \param other Another instance of a multivariate normal distribution.
+   */
+  template <class U>
+  MultivariateNormalDistribution& operator=(MultivariateNormalDistribution<U>&& other) {
+    params_ = std::move(other.params_);
+    distribution_ = std::move(other.distribution_);
+    return *this;
+  }
 
   /// Resets the internal state of the distribution.
   void reset() { distribution_.reset(); }
@@ -181,7 +246,7 @@ class MultivariateNormalDistribution {
    */
   template <class Generator>
   [[nodiscard]] result_type operator()(Generator& generator) {
-    return this->operator()(generator, params_);
+    return (*this)(generator, params_);
   }
 
   /// Generates the next random object in the distribution.
@@ -194,8 +259,7 @@ class MultivariateNormalDistribution {
    */
   template <class Generator>
   [[nodiscard]] result_type operator()(Generator& generator, const param_type& params) {
-    return params.mean_ +
-           params.transform_ * Vector{}.unaryExpr([this, &generator](auto) { return distribution_(generator); });
+    return multivariate_distribution_traits<T>::from_vector(params(distribution_, generator));
   }
 
   /// Compares this object with other distribution object.
@@ -206,7 +270,7 @@ class MultivariateNormalDistribution {
    * \param other Distribution object to compare against.
    * \return True if the objects are equal, false otherwise.
    */
-  [[nodiscard]] bool operator==(const MultivariateNormalDistribution<Matrix>& other) const {
+  [[nodiscard]] bool operator==(const MultivariateNormalDistribution<T>& other) const {
     return params_ == other.params_ && distribution_ == other.distribution_;
   }
 
@@ -218,22 +282,17 @@ class MultivariateNormalDistribution {
    * \param other Distribution object to compare against.
    * \return True if the objects are not equal, false otherwise.
    */
-  [[nodiscard]] bool operator!=(const MultivariateNormalDistribution<Matrix>& other) const { return !(*this == other); }
+  [[nodiscard]] bool operator!=(const MultivariateNormalDistribution<T>& other) const { return !(*this == other); }
 
  private:
   param_type params_;
-  std::normal_distribution<Scalar> distribution_;
+  std::normal_distribution<scalar_type> distribution_;
 };
 
-/// Deduction guide to help CTAD deduce the correct Eigen type.
-template <class InputType>
-MultivariateNormalDistribution(const Eigen::EigenBase<InputType>&)
-    -> MultivariateNormalDistribution<typename InputType::PlainMatrix>;
-
-/// Deduction guide to help CTAD deduce the correct Eigen type.
-template <class InputType, class VectorType>
-MultivariateNormalDistribution(const VectorType&, const Eigen::EigenBase<InputType>&)
-    -> MultivariateNormalDistribution<typename InputType::PlainMatrix>;
+/// Deduction guide to deduce the correct result type.
+template <class T>
+MultivariateNormalDistribution(const T&, const typename multivariate_distribution_traits<T>::covariance_type&)
+    -> MultivariateNormalDistribution<typename multivariate_distribution_traits<T>::result_type>;
 
 }  // namespace beluga
 

--- a/beluga/include/beluga/random/multivariate_normal_distribution.hpp
+++ b/beluga/include/beluga/random/multivariate_normal_distribution.hpp
@@ -87,7 +87,7 @@ class MultivariateNormalDistributionParam {
   /**
    * \tparam Generator The generator type that must meet the requirements of
    * [UniformRandomBitGenerator](https://en.cppreference.com/w/cpp/named_req/UniformRandomBitGenerator).
-   * \param distribution A reference to a normal distribution instance.
+   * \param distribution A reference to a standard normal distribution instance.
    * \param generator An uniform random bit generator object.
    * \return The generated random object.
    */

--- a/beluga/test/beluga/random/test_multivariate_normal_distribution.cpp
+++ b/beluga/test/beluga/random/test_multivariate_normal_distribution.cpp
@@ -27,7 +27,7 @@ namespace {
 
 TEST(MultivariateNormalDistribution, CopyAndCompare) {
   Eigen::Matrix3d covariance = Eigen::Vector3d::Ones().asDiagonal();
-  auto distribution = beluga::MultivariateNormalDistribution{covariance};
+  auto distribution = beluga::MultivariateNormalDistribution<Eigen::Vector3d>{covariance};
   auto other_distribution = distribution;
   ASSERT_EQ(distribution, other_distribution);
   auto generator = std::mt19937{std::random_device()()};
@@ -39,12 +39,12 @@ TEST(MultivariateNormalDistribution, CopyAndCompare) {
 
 TEST(MultivariateNormalDistribution, NegativeEigenvaluesMatrix) {
   Eigen::Matrix3d covariance = Eigen::Matrix3d::Ones();
-  EXPECT_THROW(beluga::MultivariateNormalDistribution{covariance}, std::runtime_error);
+  EXPECT_THROW(beluga::MultivariateNormalDistribution<Eigen::Vector3d>{covariance}, std::runtime_error);
 }
 
 TEST(MultivariateNormalDistribution, NonSymmetricMatrix) {
   auto covariance = testing::as<Eigen::Matrix3d>({{1.0, 2.0, 0.0}, {1.0, 1.0, 0.0}, {0.0, 0.0, 1.0}});
-  EXPECT_THROW(beluga::MultivariateNormalDistribution{covariance}, std::runtime_error);
+  EXPECT_THROW(beluga::MultivariateNormalDistribution<Eigen::Vector3d>{covariance}, std::runtime_error);
 }
 
 TEST(MultivariateNormalDistribution, SampleZero) {
@@ -85,5 +85,62 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_pair(Eigen::Vector2d{3.0, 4.0}, testing::as<Eigen::Matrix2d>({{1.0, 0.0}, {0.0, 1.0}})),
         std::make_pair(Eigen::Vector2d{3.0, 4.0}, testing::as<Eigen::Matrix2d>({{1.5, -0.3}, {-0.3, 1.5}})),
         std::make_pair(Eigen::Vector2d{5.0, 6.0}, testing::as<Eigen::Matrix2d>({{2.0, 0.7}, {0.7, 2.0}}))));
+
+TEST(MultivariateNormalDistribution, RowVector) {
+  auto generator = std::mt19937{std::random_device()()};
+  auto expected_mean = Eigen::RowVector2d{1.0, 2.0};
+  auto distribution = beluga::MultivariateNormalDistribution{expected_mean, Eigen::Matrix2d::Zero()};
+  auto mean = distribution(generator);
+  ASSERT_NEAR(mean(0), expected_mean(0), 0.001);
+  ASSERT_NEAR(mean(1), expected_mean(1), 0.001);
+}
+
+TEST(MultivariateNormalDistribution, SO2Element) {
+  auto generator = std::mt19937{std::random_device()()};
+  auto expected_mean = Sophus::SO2d{1.5};
+  auto distribution = beluga::MultivariateNormalDistribution{expected_mean, Eigen::Matrix<double, 1, 1>::Zero()};
+  auto mean = distribution(generator);
+  ASSERT_NEAR((mean).log(), expected_mean.log(), 0.001);
+}
+
+TEST(MultivariateNormalDistribution, SE2Element) {
+  auto generator = std::mt19937{std::random_device()()};
+  auto expected_mean = Sophus::SE2d{Sophus::SO2d{1.57}, Eigen::Vector2d{1.0, 2.0}};
+  auto distribution = beluga::MultivariateNormalDistribution{expected_mean, Eigen::Matrix3d::Zero()};
+  auto mean = distribution(generator);
+  ASSERT_NEAR(mean.so2().log(), expected_mean.so2().log(), 0.001);
+  ASSERT_NEAR(mean.translation()(0), expected_mean.translation()(0), 0.001);
+  ASSERT_NEAR(mean.translation()(1), expected_mean.translation()(1), 0.001);
+}
+
+TEST(MultivariateNormalDistribution, SO3Element) {
+  auto generator = std::mt19937{std::random_device()()};
+  auto expected_mean = Sophus::SO3d::exp(Eigen::Vector3d{0.5, 1.0, 1.5});
+  auto distribution = beluga::MultivariateNormalDistribution{expected_mean, Eigen::Matrix3d::Zero()};
+  auto mean = distribution(generator);
+  ASSERT_NEAR(mean.log()(0), expected_mean.log()(0), 0.001);
+  ASSERT_NEAR(mean.log()(1), expected_mean.log()(1), 0.001);
+  ASSERT_NEAR(mean.log()(2), expected_mean.log()(2), 0.001);
+}
+
+TEST(MultivariateNormalDistribution, SE3Element) {
+  auto generator = std::mt19937{std::random_device()()};
+  auto expected_mean = Sophus::SE3d{Sophus::SO3d::exp(Eigen::Vector3d{0.5, 1.0, 1.5}), Eigen::Vector3d{1.0, 2.0, 3.0}};
+  auto distribution = beluga::MultivariateNormalDistribution{expected_mean, Eigen::Matrix<double, 6, 6>::Zero()};
+  auto mean = distribution(generator);
+  ASSERT_NEAR(mean.log()(0), expected_mean.log()(0), 0.001);
+  ASSERT_NEAR(mean.log()(1), expected_mean.log()(1), 0.001);
+  ASSERT_NEAR(mean.log()(2), expected_mean.log()(2), 0.001);
+  ASSERT_NEAR(mean.translation()(0), expected_mean.translation()(0), 0.001);
+  ASSERT_NEAR(mean.translation()(1), expected_mean.translation()(1), 0.001);
+  ASSERT_NEAR(mean.translation()(2), expected_mean.translation()(2), 0.001);
+}
+
+TEST(MultivariateNormalDistribution, SameCovarianceTypeAssignment) {
+  auto distribution1 = beluga::MultivariateNormalDistribution{Sophus::SE2f{}, Eigen::Matrix3f::Zero()};
+  auto distribution2 = beluga::MultivariateNormalDistribution<Eigen::Vector3f>{distribution1};
+  auto distribution3 = beluga::MultivariateNormalDistribution{Sophus::SE2f{}, Eigen::Matrix3f::Zero()};
+  distribution3 = distribution2;
+}
 
 }  // namespace

--- a/beluga/test/beluga/random/test_multivariate_normal_distribution.cpp
+++ b/beluga/test/beluga/random/test_multivariate_normal_distribution.cpp
@@ -113,34 +113,4 @@ TEST(MultivariateNormalDistribution, SE2Element) {
   ASSERT_NEAR(mean.translation()(1), expected_mean.translation()(1), 0.001);
 }
 
-TEST(MultivariateNormalDistribution, SO3Element) {
-  auto generator = std::mt19937{std::random_device()()};
-  auto expected_mean = Sophus::SO3d::exp(Eigen::Vector3d{0.5, 1.0, 1.5});
-  auto distribution = beluga::MultivariateNormalDistribution{expected_mean, Eigen::Matrix3d::Zero()};
-  auto mean = distribution(generator);
-  ASSERT_NEAR(mean.log()(0), expected_mean.log()(0), 0.001);
-  ASSERT_NEAR(mean.log()(1), expected_mean.log()(1), 0.001);
-  ASSERT_NEAR(mean.log()(2), expected_mean.log()(2), 0.001);
-}
-
-TEST(MultivariateNormalDistribution, SE3Element) {
-  auto generator = std::mt19937{std::random_device()()};
-  auto expected_mean = Sophus::SE3d{Sophus::SO3d::exp(Eigen::Vector3d{0.5, 1.0, 1.5}), Eigen::Vector3d{1.0, 2.0, 3.0}};
-  auto distribution = beluga::MultivariateNormalDistribution{expected_mean, Eigen::Matrix<double, 6, 6>::Zero()};
-  auto mean = distribution(generator);
-  ASSERT_NEAR(mean.log()(0), expected_mean.log()(0), 0.001);
-  ASSERT_NEAR(mean.log()(1), expected_mean.log()(1), 0.001);
-  ASSERT_NEAR(mean.log()(2), expected_mean.log()(2), 0.001);
-  ASSERT_NEAR(mean.translation()(0), expected_mean.translation()(0), 0.001);
-  ASSERT_NEAR(mean.translation()(1), expected_mean.translation()(1), 0.001);
-  ASSERT_NEAR(mean.translation()(2), expected_mean.translation()(2), 0.001);
-}
-
-TEST(MultivariateNormalDistribution, SameCovarianceTypeAssignment) {
-  auto distribution1 = beluga::MultivariateNormalDistribution{Sophus::SE2f{}, Eigen::Matrix3f::Zero()};
-  auto distribution2 = beluga::MultivariateNormalDistribution<Eigen::Vector3f>{distribution1};
-  auto distribution3 = beluga::MultivariateNormalDistribution{Sophus::SE2f{}, Eigen::Matrix3f::Zero()};
-  distribution3 = distribution2;
-}
-
 }  // namespace

--- a/beluga_system_tests/test/test_system.cpp
+++ b/beluga_system_tests/test/test_system.cpp
@@ -74,8 +74,6 @@ using MonteCarloLocalization2d = beluga::MonteCarloLocalization2d<
     LaserLocalizationInterface2d,
     ConcreteResamplingPoliciesPoller>;
 
-using beluga::MultivariateNormalDistribution;
-
 struct InitialPose {
   Eigen::Vector3d mean;
   Eigen::Matrix3d covariance;
@@ -112,7 +110,7 @@ TEST_P(BelugaSystemTest, testEstimatedPath) {
   auto test_data = GetParam()();
   auto& pf = *test_data.particle_filter;
   pf.initialize_states(
-      ranges::views::generate([distribution = MultivariateNormalDistribution{
+      ranges::views::generate([distribution = beluga::MultivariateNormalDistribution{
                                    test_data.initial_pose.mean, test_data.initial_pose.covariance}]() mutable {
         static auto generator = std::mt19937{std::random_device()()};
         const auto sample = distribution(generator);

--- a/beluga_system_tests/test/test_system_new.cpp
+++ b/beluga_system_tests/test/test_system_new.cpp
@@ -125,19 +125,7 @@ auto particle_filter_test(
 
   auto hasher = beluga::spatial_hash<Sophus::SE2d>{0.1, 0.1, 0.1};
 
-  // Use the initial distribution to initialize particles.
-  // TODO(nahuel): We should have a view to convert from Eigen to Sophus types.
-  /**
-   * auto particles = beluga::views::sample(initial_distribution) |
-   *                  (something to convert from Eigen::Vector3d to Sophus::SE2d) |
-   *                  ranges::views::transform(beluga::make_from_state<Particle>) |
-   *                  ranges::views::take_exactly(params.max_particles) |
-   *                  ranges::to<beluga::TupleVector>;
-   */
-  auto particles = beluga::views::sample(initial_distribution) |  //
-                   ranges::views::transform([](const auto& sample) {
-                     return Sophus::SE2d{Sophus::SO2d{sample.z()}, Eigen::Vector2d{sample.x(), sample.y()}};
-                   }) |
+  auto particles = beluga::views::sample(initial_distribution) |                  //
                    ranges::views::transform(beluga::make_from_state<Particle>) |  //
                    ranges::views::take_exactly(params.max_particles) |            //
                    ranges::to<beluga::TupleVector>;
@@ -296,7 +284,7 @@ auto get_perfect_odometry_data() {
   auto datapoints = ranges::views::zip(measurements, odometry, ground_truth);
 
   auto initial_distribution = beluga::MultivariateNormalDistribution{
-      Eigen::Vector3d{0.0, 2.0, 0.0},                                          // initial pose mean
+      Sophus::SE2d{Sophus::SO2d{}, Eigen::Vector2d{0.0, 2.0}},                 // initial pose mean
       Eigen::Matrix3d{{0.125, 0.0, 0.0}, {0.0, 0.125, 0.0}, {0.0, 0.0, 0.04}}  // initial pose covariance
   };
 


### PR DESCRIPTION
### Proposed changes

As the title says, this patch extends the multivariate normal distribution type to support row vectors, SO2, and SE2 elements as different representations of the result type.

Related to #279.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)
