### PR TITLE
Migrate motion models to functional form

### DIFF
--- a/beluga/include/beluga/actions/propagate.hpp
+++ b/beluga/include/beluga/actions/propagate.hpp
@@ -17,11 +17,13 @@
 
 #include <algorithm>
 #include <execution>
+#include <type_traits>
 
 #include <beluga/type_traits/particle_traits.hpp>
 #include <beluga/views/particles.hpp>
 
 #include <range/v3/action/action.hpp>
+#include <range/v3/utility/random.hpp>
 #include <range/v3/view/common.hpp>
 
 namespace beluga::actions {
@@ -34,47 +36,61 @@ struct propagate_base_fn {
   /**
    * \tparam ExecutionPolicy An [execution policy](https://en.cppreference.com/w/cpp/algorithm/execution_policy_tag_t).
    * \tparam Range An [input range](https://en.cppreference.com/w/cpp/ranges/input_range) of particles.
-   * \tparam Model A callable that can compute the new state from the previous state.
+   * \tparam StateSamplingFunction A callable that samples a posterior state given a prior state. Callables satisfying
+   * \ref StateSamplingFunctionPage are also supported. This will be bound to the default random number generator for
+   * ranges.
    * \param policy The execution policy to use.
    * \param range An existing range of particles to apply this action to.
-   * \param model A callable instance to compute the states from the previous states.
+   * \param fn A state sampling function instance.
    */
   template <
       class ExecutionPolicy,
       class Range,
-      class Model,
+      class StateSamplingFunction,
       std::enable_if_t<std::is_execution_policy_v<std::decay_t<ExecutionPolicy>>, int> = 0,
       std::enable_if_t<ranges::range<Range>, int> = 0>
-  constexpr auto operator()(ExecutionPolicy&& policy, Range& range, Model model) const -> Range& {
+  constexpr auto operator()(ExecutionPolicy&& policy, Range& range, StateSamplingFunction fn) const -> Range& {
     static_assert(beluga::is_particle_range_v<Range>);
     auto states = range | beluga::views::states | ranges::views::common;
+
+    auto unary_fn = [&]() {
+      using States = decltype(states);
+      using State = ranges::range_value_t<States>;
+      using Generator = decltype(ranges::detail::get_random_engine());
+      if constexpr (std::is_invocable_v<StateSamplingFunction, State, Generator>) {
+        return [fn = std::move(fn)](const State& state) { return fn(state, ranges::detail::get_random_engine()); };
+      } else {
+        return std::move(fn);
+      }
+    }();
+
     std::transform(
         policy,              // rvalue policies are not supported in some STL implementations
         std::begin(states),  //
         std::end(states),    //
         std::begin(states),  //
-        std::move(model));
+        std::move(unary_fn));
     return range;
   }
 
   /// Overload that re-orders arguments from a view closure.
   template <
       class Range,
-      class Model,
+      class StateSamplingFunction,
       class ExecutionPolicy,
       std::enable_if_t<ranges::range<Range>, int> = 0,
       std::enable_if_t<std::is_execution_policy_v<ExecutionPolicy>, int> = 0>
-  constexpr auto operator()(Range&& range, Model model, ExecutionPolicy policy) const -> Range& {
-    return (*this)(std::move(policy), std::forward<Range>(range), std::move(model));
+  constexpr auto operator()(Range&& range, StateSamplingFunction fn, ExecutionPolicy policy) const -> Range& {
+    return (*this)(std::move(policy), std::forward<Range>(range), std::move(fn));
   }
 
   /// Overload that returns a view closure to compose with other views.
   template <
-      class ExecutionPolicy,  //
-      class Model,            //
+      class ExecutionPolicy,        //
+      class StateSamplingFunction,  //
       std::enable_if_t<std::is_execution_policy_v<ExecutionPolicy>, int> = 0>
-  constexpr auto operator()(ExecutionPolicy policy, Model model) const {
-    return ranges::make_action_closure(ranges::bind_back(propagate_base_fn{}, std::move(model), std::move(policy)));
+  constexpr auto operator()(ExecutionPolicy policy, StateSamplingFunction fn) const {
+    return ranges::make_action_closure(ranges::bind_back(propagate_base_fn{}, std::move(fn), std::move(policy)));
   }
 };
 
@@ -84,27 +100,28 @@ struct propagate_fn : public propagate_base_fn {
 
   /// Overload that defines a default execution policy.
   template <
-      class Range,  //
-      class Model,  //
+      class Range,                  //
+      class StateSamplingFunction,  //
       std::enable_if_t<ranges::range<Range>, int> = 0>
-  constexpr auto operator()(Range&& range, Model model) const -> Range& {
-    return (*this)(std::execution::seq, std::forward<Range>(range), std::move(model));
+  constexpr auto operator()(Range&& range, StateSamplingFunction fn) const -> Range& {
+    return (*this)(std::execution::seq, std::forward<Range>(range), std::move(fn));
   }
 
   /// Overload that returns a view closure to compose with other views.
-  template <class Model>
-  constexpr auto operator()(Model model) const {
-    return ranges::make_action_closure(ranges::bind_back(propagate_fn{}, std::move(model)));
+  template <class StateSamplingFunction>
+  constexpr auto operator()(StateSamplingFunction fn) const {
+    return ranges::make_action_closure(ranges::bind_back(propagate_fn{}, std::move(fn)));
   }
 };
 
 }  // namespace detail
 
 /// [Range adaptor object](https://en.cppreference.com/w/cpp/named_req/RangeAdaptorObject) that
-/// can update the state in a particle range using a motion model.
+/// can update the state in a particle range using a state transition (or sampling) function.
 /**
- * This action updates particle states based on their current value and a state-transition function (or motion model).
- * Every other particle attribute (such as importance sampling weights) is left unchanged.
+ * This action updates particle states based on their current value and a state transition
+ * (or sampling) function. Every other particle attribute (such as importance sampling weights)
+ * is left unchanged.
  */
 inline constexpr detail::propagate_fn propagate;
 

--- a/beluga/include/beluga/motion.hpp
+++ b/beluga/include/beluga/motion.hpp
@@ -31,12 +31,12 @@
  * \section MotionModelRequirements Requirements
  * A type `T` satisfies the `MotionModel` requirements if the following is satisfied:
  * - `T::state_type` is a valid type, representing a particle state.
- * - `T::control_action_type` is a valid type, representing a control action
+ * - `T::control_type` is a valid type, representing a control action
  *    to condition the motion model.
  *
  * Given:
  * - A possibly const instance `cp` of `T`.
- * - A possibly const instance `u` of `T::control_action_type` (or convertible type `U`).
+ * - A possibly const instance `u` of `T::control_type` (or convertible type `U`).
  *
  * Then:
  * - `cp(u)` returns a callable satisfying \ref StateSamplingFunctionPage for `T::state_type`.

--- a/beluga/include/beluga/motion.hpp
+++ b/beluga/include/beluga/motion.hpp
@@ -31,20 +31,31 @@
  * \section MotionModelRequirements Requirements
  * A type `T` satisfies the `MotionModel` requirements if the following is satisfied:
  * - `T::state_type` is a valid type, representing a particle state.
- * - `T::update_type` is a valid type, representing a motion model update.
+ * - `T::control_action_type` is a valid type, representing a control action
+ *    to condition the motion model.
  *
  * Given:
- * - An instance `p` of `T`.
  * - A possibly const instance `cp` of `T`.
- * - A possibly const instance of `T::update_type` `u`.
- * - A possibly const instance of `T::state_type` `s`.
+ * - A possibly const instance `u` of `T::control_action_type` (or convertible type `U`).
  *
  * Then:
- * - `p.update_motion(u)` will update the motion model with `u`.
- *   This will not actually update the particle states, but the update done here
- *   will be used in subsequent calls to the `apply_motion()` method.
- * - `cp.apply_motion(s)` returns a `T::state_type`, that is the result of applying the motion model
- *   to `s` based on the updates.
+ * - `cp(u)` returns a callable satisfying \ref StateSamplingFunctionPage for `T::state_type`.
+ *
+ * \section StateSamplingFunctionPage Beluga named requirements: StateSamplingFunction
+ * Requirements for a callable to sample a motion distribution when propagating
+ * particle states in a Beluga `ParticleFilter`.
+ *
+ * \section StateSamplingFunctionRequirements Requirements
+ * A type `F` satisfies the `StateSamplingFunction` requirements for some state type `S` if:
+ *
+ * Given:
+ * - A possibly const instance `fn` of `F`.
+ * - A possible const instance `s` of `S`.
+ * - An instance `e` satisfying [URNG](https://en.cppreference.com/w/cpp/named_req/UniformRandomBitGenerator)
+ * requirements.
+ *
+ * Then:
+ * - `fn(s, e)` returns another sampled state `ss` of `S`.
  *
  * \section MotionModelLinks See also
  * - beluga::DifferentialDriveModel
@@ -54,7 +65,7 @@
 
 namespace beluga {
 
-/// Pure abstract class representing the odometry motion model interface.
+/// Pure abstract class representing the odometry motion model mixin interface.
 struct OdometryMotionModelInterface2d {
   /// Update type of the motion model.
   using update_type = Sophus::SE2d;

--- a/beluga/include/beluga/motion/differential_drive_model.hpp
+++ b/beluga/include/beluga/motion/differential_drive_model.hpp
@@ -126,7 +126,7 @@ class DifferentialDriveModel {
                                    params_.rotation_noise_from_translation * distance_variance)};
 
     return [=](const state_type& state, auto& gen) {
-      auto distribution = std::normal_distribution<double>{};
+      static thread_local auto distribution = std::normal_distribution<double>{};
       const auto first_rotation = Sophus::SO2d{distribution(gen, first_rotation_params)};
       const auto translation = Eigen::Vector2d{distribution(gen, translation_params), 0.0};
       const auto second_rotation = Sophus::SO2d{distribution(gen, second_rotation_params)};

--- a/beluga/include/beluga/motion/omnidirectional_drive_model.hpp
+++ b/beluga/include/beluga/motion/omnidirectional_drive_model.hpp
@@ -131,7 +131,7 @@ class OmnidirectionalDriveModel {
                  params_.translation_noise_from_rotation * rotation_variance(rotation))};
 
     return [=](const state_type& state, auto& gen) {
-      auto distribution = std::normal_distribution<double>{};
+      static thread_local auto distribution = std::normal_distribution<double>{};
       // This is an implementation based on the same set of parameters that is used in
       // nav2's omni_motion_model. To simplify the implementation, the following
       // variable substitutions were performed:

--- a/beluga/include/beluga/motion/stationary_model.hpp
+++ b/beluga/include/beluga/motion/stationary_model.hpp
@@ -56,7 +56,7 @@ class StationaryModel {
   template <class Control, typename = common_tuple_type_t<Control, control_type>>
   [[nodiscard]] auto operator()([[maybe_unused]] Control&&) const {
     return [](const state_type& state, auto& gen) {
-      auto distribution = std::normal_distribution<>{0, 0.02};
+      static thread_local auto distribution = std::normal_distribution<>{0, 0.02};
       return state *
              Sophus::SE2d{Sophus::SO2d{distribution(gen)}, Eigen::Vector2d{distribution(gen), distribution(gen)}};
     };

--- a/beluga/include/beluga/motion/stationary_model.hpp
+++ b/beluga/include/beluga/motion/stationary_model.hpp
@@ -17,6 +17,10 @@
 
 #include <optional>
 #include <random>
+#include <tuple>
+#include <type_traits>
+
+#include <beluga/type_traits/tuple_traits.hpp>
 
 #include <sophus/se2.hpp>
 #include <sophus/so2.hpp>
@@ -30,41 +34,33 @@ namespace beluga {
 
 /// A stationary motion model.
 /**
- * This class implements the OdometryMotionModelInterface2d and satisfies \ref MotionModelPage.
+ * This class satisfies \ref MotionModelPage.
  *
- * It ignores all odometry updates and only adds Gaussian noise to the
- * input states.
+ * It ignores all odometry updates and only adds Gaussian noise to the input states.
  */
 class StationaryModel {
  public:
-  /// Update type of the motion model.
-  using update_type = Sophus::SE2d;
-  /// State type of a particle.
+  /// Current and previous odometry estimates as motion model control action.
+  using control_type = std::tuple<Sophus::SE2d, Sophus::SE2d>;
+  /// 2D pose as motion model state (to match that of the particles).
   using state_type = Sophus::SE2d;
 
-  /// Applies motion to the given particle state.
+  /// Computes a state sampling function conditioned on a given control action.
   /**
    * The updated state will be centered around `state` with some covariance.
+   * For this model, control actions are ignored.
    *
-   * \tparam Generator  A random number generator that must satisfy the
-   *  [UniformRandomBitGenerator](https://en.cppreference.com/w/cpp/named_req/UniformRandomBitGenerator)
-   *  requirements.
-   * \param state The state of the particle to which the motion will be applied.
-   * \param gen An uniform random bit generator object.
-   * \return The new particle state.
+   * \tparam Control A tuple-like container matching the model's `control_action_type`.
+   * \return a callable satisfying \ref StateSamplingFunctionPage.
    */
-  template <class Generator>
-  [[nodiscard]] state_type apply_motion(const state_type& state, Generator& gen) const {
-    auto distribution = std::normal_distribution<>{0, 0.02};
-    return state * Sophus::SE2d{Sophus::SO2d{distribution(gen)}, Eigen::Vector2d{distribution(gen), distribution(gen)}};
+  template <class Control, typename = common_tuple_type_t<Control, control_type>>
+  [[nodiscard]] auto operator()([[maybe_unused]] Control&&) const {
+    return [](const state_type& state, auto& gen) {
+      auto distribution = std::normal_distribution<>{0, 0.02};
+      return state *
+             Sophus::SE2d{Sophus::SO2d{distribution(gen)}, Eigen::Vector2d{distribution(gen), distribution(gen)}};
+    };
   }
-
-  /**
-   * \copydoc OdometryMotionModelInterface2d::update_motion(const Sophus::SE2d&)
-   *
-   * For this model, odometry updates are ignored.
-   */
-  void update_motion([[maybe_unused]] const update_type& pose) {}
 };
 
 }  // namespace beluga

--- a/beluga/test/beluga/motion/test_differential_drive_model.cpp
+++ b/beluga/test/beluga/motion/test_differential_drive_model.cpp
@@ -35,58 +35,59 @@ using UUT = beluga::DifferentialDriveModel;
 
 class DifferentialDriveModelTest : public ::testing::Test {
  protected:
-  UUT model_{beluga::DifferentialDriveModelParam{0.0, 0.0, 0.0, 0.0}};  // No variance
+  const UUT motion_model_{beluga::DifferentialDriveModelParam{0.0, 0.0, 0.0, 0.0}};  // No variance
   std::mt19937 generator_{std::random_device()()};
 };
 
-TEST_F(DifferentialDriveModelTest, NoUpdate) {
-  constexpr double kTolerance = 0.001;
-  const auto pose = SE2d{SO2d{Constants::pi() / 3}, Vector2d{2.0, 5.0}};
-  ASSERT_THAT(model_.apply_motion(pose, generator_), SE2Near(pose, kTolerance));
-}
-
 TEST_F(DifferentialDriveModelTest, OneUpdate) {
   constexpr double kTolerance = 0.001;
+  const auto control_action = std::make_tuple(
+      SE2d{SO2d{Constants::pi()}, Vector2d{1.0, -2.0}}, SE2d{SO2d{Constants::pi()}, Vector2d{1.0, -2.0}});
+  const auto state_sampling_function = motion_model_(control_action);
   const auto pose = SE2d{SO2d{Constants::pi() / 3}, Vector2d{2.0, 5.0}};
-  model_.update_motion(SE2d{SO2d{Constants::pi()}, Vector2d{1.0, -2.0}});
-  ASSERT_THAT(model_.apply_motion(pose, generator_), SE2Near(pose, kTolerance));
+  ASSERT_THAT(state_sampling_function(pose, generator_), SE2Near(pose, kTolerance));
 }
 
 TEST_F(DifferentialDriveModelTest, Translate) {
   constexpr double kTolerance = 0.001;
-  model_.update_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
-  model_.update_motion(SE2d{SO2d{0.0}, Vector2d{1.0, 0.0}});
-  const auto result1 = model_.apply_motion(SE2d{SO2d{0.0}, Vector2d{2.0, 0.0}}, generator_);
+  const auto control_action = std::make_tuple(SE2d{SO2d{0.0}, Vector2d{1.0, 0.0}}, SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
+  const auto state_sampling_function = motion_model_(control_action);
+
+  const auto result1 = state_sampling_function(SE2d{SO2d{0.0}, Vector2d{2.0, 0.0}}, generator_);
   ASSERT_THAT(result1, SE2Near(SO2d{0.0}, Vector2d{3.0, 0.0}, kTolerance));
-  const auto result2 = model_.apply_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 3.0}}, generator_);
+  const auto result2 = state_sampling_function(SE2d{SO2d{0.0}, Vector2d{0.0, 3.0}}, generator_);
   ASSERT_THAT(result2, SE2Near(SO2d{0.0}, Vector2d{1.0, 3.0}, kTolerance));
 }
 
 TEST_F(DifferentialDriveModelTest, RotateTranslate) {
   constexpr double kTolerance = 0.001;
-  model_.update_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
-  model_.update_motion(SE2d{SO2d{Constants::pi() / 2}, Vector2d{0.0, 1.0}});
-  const auto result1 = model_.apply_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}}, generator_);
+  const auto control_action =
+      std::make_tuple(SE2d{SO2d{Constants::pi() / 2}, Vector2d{0.0, 1.0}}, SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
+  const auto state_sampling_function = motion_model_(control_action);
+
+  const auto result1 = state_sampling_function(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}}, generator_);
   ASSERT_THAT(result1, SE2Near(SO2d{Constants::pi() / 2}, Vector2d{0.0, 1.0}, kTolerance));
-  const auto result2 = model_.apply_motion(SE2d{SO2d{-Constants::pi() / 2}, Vector2d{2.0, 3.0}}, generator_);
+  const auto result2 = state_sampling_function(SE2d{SO2d{-Constants::pi() / 2}, Vector2d{2.0, 3.0}}, generator_);
   ASSERT_THAT(result2, SE2Near(SO2d{0.0}, Vector2d{3.0, 3.0}, kTolerance));
 }
 
 TEST_F(DifferentialDriveModelTest, Rotate) {
   constexpr double kTolerance = 0.001;
-  model_.update_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
-  model_.update_motion(SE2d{SO2d{Constants::pi() / 4}, Vector2d{0.0, 0.0}});
-  const auto result1 = model_.apply_motion(SE2d{SO2d{Constants::pi()}, Vector2d{0.0, 0.0}}, generator_);
+  const auto control_action =
+      std::make_tuple(SE2d{SO2d{Constants::pi() / 4}, Vector2d{0.0, 0.0}}, SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
+  const auto state_sampling_function = motion_model_(control_action);
+  const auto result1 = state_sampling_function(SE2d{SO2d{Constants::pi()}, Vector2d{0.0, 0.0}}, generator_);
   ASSERT_THAT(result1, SE2Near(SO2d{Constants::pi() * 5 / 4}, Vector2d{0.0, 0.0}, kTolerance));
-  const auto result2 = model_.apply_motion(SE2d{SO2d{-Constants::pi() / 2}, Vector2d{0.0, 0.0}}, generator_);
+  const auto result2 = state_sampling_function(SE2d{SO2d{-Constants::pi() / 2}, Vector2d{0.0, 0.0}}, generator_);
   ASSERT_THAT(result2, SE2Near(SO2d{-Constants::pi() / 4}, Vector2d{0.0, 0.0}, kTolerance));
 }
 
 TEST_F(DifferentialDriveModelTest, RotateTranslateRotate) {
   constexpr double kTolerance = 0.001;
-  model_.update_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
-  model_.update_motion(SE2d{SO2d{-Constants::pi() / 2}, Vector2d{1.0, 2.0}});
-  const auto result = model_.apply_motion(SE2d{SO2d{Constants::pi()}, Vector2d{3.0, 4.0}}, generator_);
+  const auto control_action =
+      std::make_tuple(SE2d{SO2d{-Constants::pi() / 2}, Vector2d{1.0, 2.0}}, SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
+  const auto state_sampling_function = motion_model_(control_action);
+  const auto result = state_sampling_function(SE2d{SO2d{Constants::pi()}, Vector2d{3.0, 4.0}}, generator_);
   ASSERT_THAT(result, SE2Near(SO2d{Constants::pi() / 2}, Vector2d{2.0, 2.0}, kTolerance));
 }
 
@@ -109,12 +110,14 @@ TEST(DifferentialDriveModelSamples, Translate) {
   const double alpha = 0.2;
   const double origin = 5.0;
   const double distance = 3.0;
-  auto model = UUT{beluga::DifferentialDriveModelParam{0.0, 0.0, alpha, 0.0}};  // Translation variance
+  const auto motion_model = UUT{beluga::DifferentialDriveModelParam{0.0, 0.0, alpha, 0.0}};  // Translation variance
   auto generator = std::mt19937{std::random_device()()};
-  model.update_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
-  model.update_motion(SE2d{SO2d{0.0}, Vector2d{distance, 0.0}});
+  const auto control_action =
+      std::make_tuple(SE2d{SO2d{0.0}, Vector2d{distance, 0.0}}, SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
+  const auto state_sampling_function = motion_model(control_action);
   auto view = ranges::views::generate([&]() {
-                return model.apply_motion(SE2d{SO2d{0.0}, Vector2d{origin, 0.0}}, generator).translation().x();
+                const auto pose = SE2d{SO2d{0.0}, Vector2d{origin, 0.0}};
+                return state_sampling_function(pose, generator).translation().x();
               }) |
               ranges::views::take_exactly(1'000'000) | ranges::views::common;
   const auto [mean, stddev] = get_statistics(view);
@@ -127,12 +130,14 @@ TEST(DifferentialDriveModelSamples, RotateFirstQuadrant) {
   const double alpha = 0.2;
   const double initial_angle = Constants::pi() / 6;
   const double motion_angle = Constants::pi() / 4;
-  auto model = UUT{beluga::DifferentialDriveModelParam{alpha, 0.0, 0.0, 0.0}};  // Rotation variance
+  const auto motion_model = UUT{beluga::DifferentialDriveModelParam{alpha, 0.0, 0.0, 0.0}};  // Rotation variance
   auto generator = std::mt19937{std::random_device()()};
-  model.update_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
-  model.update_motion(SE2d{SO2d{motion_angle}, Vector2d{0.0, 0.0}});
+  const auto control_action =
+      std::make_tuple(SE2d{SO2d{motion_angle}, Vector2d{0.0, 0.0}}, SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
+  const auto state_sampling_function = motion_model(control_action);
   auto view = ranges::views::generate([&]() {
-                return model.apply_motion(SE2d{SO2d{initial_angle}, Vector2d{0.0, 0.0}}, generator).so2().log();
+                const auto pose = SE2d{SO2d{initial_angle}, Vector2d{0.0, 0.0}};
+                return state_sampling_function(pose, generator).so2().log();
               }) |
               ranges::views::take_exactly(1'000'000) | ranges::views::common;
   const auto [mean, stddev] = get_statistics(view);
@@ -145,12 +150,14 @@ TEST(DifferentialDriveModelSamples, RotateThirdQuadrant) {
   const double alpha = 0.2;
   const double initial_angle = Constants::pi() / 6;
   const double motion_angle = -Constants::pi() * 3 / 4;
-  auto model = UUT{beluga::DifferentialDriveModelParam{alpha, 0.0, 0.0, 0.0}};  // Rotation variance
+  const auto motion_model = UUT{beluga::DifferentialDriveModelParam{alpha, 0.0, 0.0, 0.0}};  // Rotation variance
   auto generator = std::mt19937{std::random_device()()};
-  model.update_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
-  model.update_motion(SE2d{SO2d{motion_angle}, Vector2d{0.0, 0.0}});
+  const auto control_action =
+      std::make_tuple(SE2d{SO2d{motion_angle}, Vector2d{0.0, 0.0}}, SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
+  const auto state_sampling_function = motion_model(control_action);
   auto view = ranges::views::generate([&]() {
-                return model.apply_motion(SE2d{SO2d{initial_angle}, Vector2d{0.0, 0.0}}, generator).so2().log();
+                const auto pose = SE2d{SO2d{initial_angle}, Vector2d{0.0, 0.0}};
+                return state_sampling_function(pose, generator).so2().log();
               }) |
               ranges::views::take_exactly(1'000'000) | ranges::views::common;
   const auto [mean, stddev] = get_statistics(view);
@@ -164,12 +171,14 @@ TEST(DifferentialDriveModelSamples, RotateThirdQuadrant) {
 TEST(DifferentialDriveModelSamples, RotateTranslateRotateFirstQuadrant) {
   const double tolerance = 0.01;
   const double alpha = 0.2;
-  auto model = UUT{beluga::DifferentialDriveModelParam{0.0, 0.0, 0.0, alpha}};  // Translation variance from rotation
+  const auto motion_model =
+      UUT{beluga::DifferentialDriveModelParam{0.0, 0.0, 0.0, alpha}};  // Translation variance from rotation
   auto generator = std::mt19937{std::random_device()()};
-  model.update_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
-  model.update_motion(SE2d{SO2d{0.0}, Vector2d{1.0, 1.0}});
+  const auto control_action = std::make_tuple(SE2d{SO2d{0.0}, Vector2d{1.0, 1.0}}, SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
+  const auto state_sampling_function = motion_model(control_action);
   auto view = ranges::views::generate([&]() {
-                return model.apply_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}}, generator).translation().norm();
+                const auto pose = SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}};
+                return state_sampling_function(pose, generator).translation().norm();
               }) |
               ranges::views::take_exactly(1'000'000) | ranges::views::common;
   const auto [mean, stddev] = get_statistics(view);
@@ -187,12 +196,15 @@ TEST(DifferentialDriveModelSamples, RotateTranslateRotateFirstQuadrant) {
 TEST(DifferentialDriveModelSamples, RotateTranslateRotateThirdQuadrant) {
   const double tolerance = 0.01;
   const double alpha = 0.2;
-  auto model = UUT{beluga::DifferentialDriveModelParam{0.0, 0.0, 0.0, alpha}};  // Translation variance from rotation
+  const auto motion_model =
+      UUT{beluga::DifferentialDriveModelParam{0.0, 0.0, 0.0, alpha}};  // Translation variance from rotation
   auto generator = std::mt19937{std::random_device()()};
-  model.update_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
-  model.update_motion(SE2d{SO2d{0.0}, Vector2d{-1.0, -1.0}});
+  const auto control_action =
+      std::make_tuple(SE2d{SO2d{0.0}, Vector2d{-1.0, -1.0}}, SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
+  const auto state_sampling_function = motion_model(control_action);
   auto view = ranges::views::generate([&]() {
-                return model.apply_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}}, generator).translation().norm();
+                const auto pose = SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}};
+                return state_sampling_function(pose, generator).translation().norm();
               }) |
               ranges::views::take_exactly(1'000'000) | ranges::views::common;
   const auto [mean, stddev] = get_statistics(view);

--- a/beluga/test/beluga/motion/test_omnidirectional_drive_model.cpp
+++ b/beluga/test/beluga/motion/test_omnidirectional_drive_model.cpp
@@ -33,58 +33,56 @@ using UUT = beluga::OmnidirectionalDriveModel;
 
 class OmnidirectionalDriveModelTest : public ::testing::Test {
  protected:
-  UUT model_{beluga::OmnidirectionalDriveModelParam{0.0, 0.0, 0.0, 0.0, 0.0}};  // No variance
+  const UUT motion_model_{beluga::OmnidirectionalDriveModelParam{0.0, 0.0, 0.0, 0.0, 0.0}};  // No variance
   std::mt19937 generator_{std::random_device()()};
 };
 
-TEST_F(OmnidirectionalDriveModelTest, NoUpdate) {
-  constexpr double kTolerance = 0.001;
-  const auto pose = SE2d{SO2d{Constants::pi() / 3}, Vector2d{2.0, 5.0}};
-  ASSERT_THAT(model_.apply_motion(pose, generator_), SE2Near(pose, kTolerance));
-}
-
 TEST_F(OmnidirectionalDriveModelTest, OneUpdate) {
   constexpr double kTolerance = 0.001;
+  const auto control_action = std::make_tuple(
+      SE2d{SO2d{Constants::pi()}, Vector2d{1.0, -2.0}}, SE2d{SO2d{Constants::pi()}, Vector2d{1.0, -2.0}});
+  const auto state_sampling_function = motion_model_(control_action);
   const auto pose = SE2d{SO2d{Constants::pi() / 3}, Vector2d{2.0, 5.0}};
-  model_.update_motion(SE2d{SO2d{Constants::pi()}, Vector2d{1.0, -2.0}});
-  ASSERT_THAT(model_.apply_motion(pose, generator_), SE2Near(pose, kTolerance));
+  ASSERT_THAT(state_sampling_function(pose, generator_), SE2Near(pose, kTolerance));
 }
 
 TEST_F(OmnidirectionalDriveModelTest, Translate) {
   constexpr double kTolerance = 0.001;
-  model_.update_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
-  model_.update_motion(SE2d{SO2d{0.0}, Vector2d{1.0, 0.0}});
-  const auto result1 = model_.apply_motion(SE2d{SO2d{0.0}, Vector2d{2.0, 0.0}}, generator_);
+  const auto control_action = std::make_tuple(SE2d{SO2d{0.0}, Vector2d{1.0, 0.0}}, SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
+  const auto state_sampling_function = motion_model_(control_action);
+  const auto result1 = state_sampling_function(SE2d{SO2d{0.0}, Vector2d{2.0, 0.0}}, generator_);
   ASSERT_THAT(result1, SE2Near(SO2d{0.0}, Vector2d{3.0, 0.0}, kTolerance));
-  const auto result2 = model_.apply_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 3.0}}, generator_);
+  const auto result2 = state_sampling_function(SE2d{SO2d{0.0}, Vector2d{0.0, 3.0}}, generator_);
   ASSERT_THAT(result2, SE2Near(SO2d{0.0}, Vector2d{1.0, 3.0}, kTolerance));
 }
 
 TEST_F(OmnidirectionalDriveModelTest, RotateTranslate) {
   constexpr double kTolerance = 0.001;
-  model_.update_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
-  model_.update_motion(SE2d{SO2d{Constants::pi() / 2}, Vector2d{0.0, 1.0}});
-  const auto result1 = model_.apply_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}}, generator_);
+  const auto control_action =
+      std::make_tuple(SE2d{SO2d{Constants::pi() / 2}, Vector2d{0.0, 1.0}}, SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
+  const auto state_sampling_function = motion_model_(control_action);
+  const auto result1 = state_sampling_function(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}}, generator_);
   ASSERT_THAT(result1, SE2Near(SO2d{Constants::pi() / 2}, Vector2d{0.0, 1.0}, kTolerance));
-  const auto result2 = model_.apply_motion(SE2d{SO2d{-Constants::pi() / 2}, Vector2d{2.0, 3.0}}, generator_);
+  const auto result2 = state_sampling_function(SE2d{SO2d{-Constants::pi() / 2}, Vector2d{2.0, 3.0}}, generator_);
   ASSERT_THAT(result2, SE2Near(SO2d{0.0}, Vector2d{3.0, 3.0}, kTolerance));
 }
 
 TEST_F(OmnidirectionalDriveModelTest, Rotate) {
   constexpr double kTolerance = 0.001;
-  model_.update_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
-  model_.update_motion(SE2d{SO2d{Constants::pi() / 4}, Vector2d{0.0, 0.0}});
-  const auto result1 = model_.apply_motion(SE2d{SO2d{Constants::pi()}, Vector2d{0.0, 0.0}}, generator_);
+  const auto control_action =
+      std::make_tuple(SE2d{SO2d{Constants::pi() / 4}, Vector2d{0.0, 0.0}}, SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
+  const auto state_sampling_function = motion_model_(control_action);
+  const auto result1 = state_sampling_function(SE2d{SO2d{Constants::pi()}, Vector2d{0.0, 0.0}}, generator_);
   ASSERT_THAT(result1, SE2Near(SO2d{Constants::pi() * 5 / 4}, Vector2d{0.0, 0.0}, kTolerance));
-  const auto result2 = model_.apply_motion(SE2d{SO2d{-Constants::pi() / 2}, Vector2d{0.0, 0.0}}, generator_);
+  const auto result2 = state_sampling_function(SE2d{SO2d{-Constants::pi() / 2}, Vector2d{0.0, 0.0}}, generator_);
   ASSERT_THAT(result2, SE2Near(SO2d{-Constants::pi() / 4}, Vector2d{0.0, 0.0}, kTolerance));
 }
 
 TEST_F(OmnidirectionalDriveModelTest, TranslateStrafe) {
   constexpr double kTolerance = 0.001;
-  model_.update_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
-  model_.update_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 1.0}});
-  const auto result1 = model_.apply_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}}, generator_);
+  const auto control_action = std::make_tuple(SE2d{SO2d{0.0}, Vector2d{0.0, 1.0}}, SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
+  const auto state_sampling_function = motion_model_(control_action);
+  const auto result1 = state_sampling_function(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}}, generator_);
   ASSERT_THAT(result1, SE2Near(SO2d{0.0}, Vector2d{0.0, 1.0}, kTolerance));
 }
 
@@ -107,12 +105,15 @@ TEST(OmnidirectionalDriveModelSamples, Translate) {
   const double alpha = 0.2;
   const double origin = 5.0;
   const double distance = 3.0;
-  auto model = UUT{beluga::OmnidirectionalDriveModelParam{0.0, 0.0, alpha, 0.0, 0.0}};  // Translation variance
+  const auto motion_model =
+      UUT{beluga::OmnidirectionalDriveModelParam{0.0, 0.0, alpha, 0.0, 0.0}};  // Translation variance
   auto generator = std::mt19937{std::random_device()()};
-  model.update_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
-  model.update_motion(SE2d{SO2d{0.0}, Vector2d{distance, 0.0}});
+  const auto control_action =
+      std::make_tuple(SE2d{SO2d{0.0}, Vector2d{distance, 0.0}}, SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
+  const auto state_sampling_function = motion_model(control_action);
   auto view = ranges::views::generate([&]() {
-                return model.apply_motion(SE2d{SO2d{0.0}, Vector2d{origin, 0.0}}, generator).translation().x();
+                const auto pose = SE2d{SO2d{0.0}, Vector2d{origin, 0.0}};
+                return state_sampling_function(pose, generator).translation().x();
               }) |
               ranges::views::take_exactly(1'000'000) | ranges::views::common;
   const auto [mean, stddev] = get_statistics(view);
@@ -125,12 +126,14 @@ TEST(OmnidirectionalDriveModelSamples, RotateFirstQuadrant) {
   const double alpha = 0.2;
   const double initial_angle = Constants::pi() / 6;
   const double motion_angle = Constants::pi() / 4;
-  auto model = UUT{beluga::OmnidirectionalDriveModelParam{alpha, 0.0, 0.0, 0.0, 0.0}};
+  const auto motion_model = UUT{beluga::OmnidirectionalDriveModelParam{alpha, 0.0, 0.0, 0.0, 0.0}};
   auto generator = std::mt19937{std::random_device()()};
-  model.update_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
-  model.update_motion(SE2d{SO2d{motion_angle}, Vector2d{0.0, 0.0}});
+  const auto control_action =
+      std::make_tuple(SE2d{SO2d{motion_angle}, Vector2d{0.0, 0.0}}, SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
+  const auto state_sampling_function = motion_model(control_action);
   auto view = ranges::views::generate([&]() {
-                return model.apply_motion(SE2d{SO2d{initial_angle}, Vector2d{0.0, 0.0}}, generator).so2().log();
+                const auto pose = SE2d{SO2d{initial_angle}, Vector2d{0.0, 0.0}};
+                return state_sampling_function(pose, generator).so2().log();
               }) |
               ranges::views::take_exactly(1'000'000) | ranges::views::common;
   const auto [mean, stddev] = get_statistics(view);
@@ -143,12 +146,14 @@ TEST(OmnidirectionalDriveModelSamples, RotateThirdQuadrant) {
   const double alpha = 0.2;
   const double initial_angle = Constants::pi() / 6;
   const double motion_angle = -Constants::pi() * 3 / 4;
-  auto model = UUT{beluga::OmnidirectionalDriveModelParam{alpha, 0.0, 0.0, 0.0, 0.0}};
+  const auto motion_model = UUT{beluga::OmnidirectionalDriveModelParam{alpha, 0.0, 0.0, 0.0, 0.0}};
   auto generator = std::mt19937{std::random_device()()};
-  model.update_motion(SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
-  model.update_motion(SE2d{SO2d{motion_angle}, Vector2d{0.0, 0.0}});
+  const auto control_action =
+      std::make_tuple(SE2d{SO2d{motion_angle}, Vector2d{0.0, 0.0}}, SE2d{SO2d{0.0}, Vector2d{0.0, 0.0}});
+  const auto state_sampling_function = motion_model(control_action);
   auto view = ranges::views::generate([&]() {
-                return model.apply_motion(SE2d{SO2d{initial_angle}, Vector2d{0.0, 0.0}}, generator).so2().log();
+                const auto pose = SE2d{SO2d{initial_angle}, Vector2d{0.0, 0.0}};
+                return state_sampling_function(pose, generator).so2().log();
               }) |
               ranges::views::take_exactly(1'000'000) | ranges::views::common;
   const auto [mean, stddev] = get_statistics(view);

--- a/beluga/test/beluga/type_traits/test_tuple_traits.cpp
+++ b/beluga/test/beluga/type_traits/test_tuple_traits.cpp
@@ -31,6 +31,14 @@ static_assert(
 static_assert(!beluga::is_tuple_like_v<int>);
 static_assert(!beluga::is_tuple_like_v<struct Object>);
 
+static_assert(
+    std::is_same_v<beluga::common_tuple_type_t<std::pair<int, int>, std::tuple<int, int>>, std::tuple<int, int>>);
+static_assert(
+    std::is_same_v<beluga::common_tuple_type_t<std::array<int, 2>, std::tuple<int, int>>, std::tuple<int, int>>);
+static_assert(
+    std::is_same_v<beluga::common_tuple_type_t<std::array<float, 2>, std::tuple<char, int>>, std::tuple<float, float>>);
+static_assert(!beluga::has_common_tuple_type_v<std::tuple<int, int, bool>, std::tuple<int, int>>);
+
 static_assert(beluga::tuple_index_v<int, std::tuple<int, double>> == 0);
 static_assert(beluga::tuple_index_v<double, std::tuple<int, double>> == 1);
 


### PR DESCRIPTION
### Proposed changes

This patch migrates motion models to a functional form. Combined with #320, this affords:

```c++
beluga::actions::propagate(std::execution::par, motion(control_action_window << odom))
```

when propagating particles. 

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)