### PR TITLE
Migrate sensor models to functional form

### DIFF
--- a/beluga/include/beluga/sensor.hpp
+++ b/beluga/include/beluga/sensor.hpp
@@ -31,16 +31,26 @@
  * - `T::measurement_type` is a valid type, representing a sensor measurement.
  *
  * Given:
- * - An instance `p` of `T`.
  * - A possibly const instance `cp` of `T`.
- * - A possibly const instance `m` of `T::measurement_type`.
- * - A possibly const instance `s` of `T::state_type`.
+ * - A movable instance `m` of `T::measurement_type`.
  *
  * Then:
- * - `p.update_sensor(m)` will update the sensor model with `p`.
- *   This will not actually update the particle weights, but the update done here
- *   will be used in the following `importance_weight()` method calls.
- * - `cp.importance_weight(s)` returns a `T::weight_type` instance representing the weight of the particle.
+ * - `cp(m)` returns a callable satisfying \ref StateWeightingFunctionPage
+ * for states of `T::state_type` and weights of `T::weight_type` types.
+ *
+ * \section StateWeightingFunctionPage Beluga named requirements: StateWeightingFunction
+ * Requirements on a callable used for reweighting particle states in a Beluga `ParticleFilter`.
+ *
+ * \section StateWeightingFunctionRequirements Requirements
+ * A type `F` satisfies the `StateWeightingFunction` requirements for some state type `S`
+ * and weight type `W` if:
+ *
+ * Given:
+ * - A possibly const instance `fn` of `F`.
+ * - A possible const instance `s` of `S`.
+ *
+ * Then:
+ * - `fn(s)` returns a weight `w` of `W`.
  *
  * \section SensorModelLinks See also
  * - beluga::LikelihoodFieldModel

--- a/beluga/include/beluga/sensor/landmark_sensor_model.hpp
+++ b/beluga/include/beluga/sensor/landmark_sensor_model.hpp
@@ -48,8 +48,7 @@ struct LandmarkModelParam {
 
 /// Generic landmark model for discrete detection sensors (both 2D and 3D).
 /**
- * This class implements the LandmarkSensorModelInterface interface
- * and satisfies \ref SensorModelPage.
+ * This class satisfies \ref SensorModelPage.
  *
  * This sensor model is a generalization of the model described in Probabilistic
  * Robotics \cite thrun2005probabilistic Chapter 6.6 .
@@ -73,114 +72,103 @@ class LandmarkSensorModel {
 
   /// Constructs a LandmarkSensorModel instance.
   /**
-   * \param params Parameters to configure this instance.
-   *  See beluga::BeamModelParams for details.
-   * \param landmark_map Map of landmarks to be used by this sensor model.
+   * \param params Parameters to configure this instance. See beluga::BeamModelParams for details.
+   * \param landmark_map Map of landmarks to be used by the sensor model to compute importance weights
+   *  for particle states.
    */
   explicit LandmarkSensorModel(param_type params, LandmarkMap landmark_map)
       : params_{std::move(params)}, landmark_map_{std::move(landmark_map)} {}
 
-  /// Gets the importance weight for a particle with the provided state.
+  /// Returns a state weighting function conditioned on landmark position detections.
   /**
-   * \param state State of the particle to calculate its importance weight.
-   * \return Calculated importance weight.
+   * \param detections 2D lidar hit points in the reference frame of filter particles.
+   * \return a state weighting function satisfying \ref StateWeightingFunctionPage
+   *  and borrowing a reference to this sensor model (and thus their lifetime are bound).
    */
-  [[nodiscard]] weight_type importance_weight(const state_type& state) const {
-    Sophus::SE3d robot_pose_in_world;
+  [[nodiscard]] auto operator()(measurement_type&& detections) const {
+    return [this, detections = std::move(detections)](const state_type& state) -> weight_type {
+      Sophus::SE3d robot_pose_in_world;
 
-    if constexpr (std::is_same_v<state_type, Sophus::SE3d>) {
-      // The robot pose state is already given in 3D,
-      robot_pose_in_world = state;
-    } else {
-      // The robot pose state is given in 2D. Notice that in this case
-      // the 2D pose of the robot is assumed to be that of the robot footprint (projection of the robot
-      // on the z=0 plane of the 3D world frame). This is so that we can tie the sensor reference frame
-      // to the world frame where the landmarks are given without additional structural information.
-      robot_pose_in_world = Sophus::SE3d{
-          Sophus::SO3d::rotZ(state.so2().log()),
-          Eigen::Vector3d{state.translation().x(), state.translation().y(), 0.0}};
-    }
-
-    const auto detection_weight = [this, &robot_pose_in_world](const auto& detection) {
-      // calculate range and detection_bearing_in_robot to the detection from the robot
-      // the detection is already in robot frame
-      const auto& detection_category = detection.category;
-      const auto& detection_position_in_robot = detection.detection_position_in_robot;
-
-      const auto detection_range_in_robot = detection_position_in_robot.norm();
-      const auto detection_bearing_in_robot = detection_position_in_robot.normalized();
-
-      // convert the detection to the world frame to query the map
-      const auto detection_position_in_world = robot_pose_in_world * detection_position_in_robot;
-
-      // find the closest matching landmark in the world map
-      const auto opt_landmark_position_in_world =
-          landmark_map_.find_nearest_landmark(detection_position_in_world, detection_category);
-
-      // if we did not find a matching landmark, return 0.0
-      if (!opt_landmark_position_in_world) {
-        return 0.0;
+      if constexpr (std::is_same_v<state_type, Sophus::SE3d>) {
+        // The robot pose state is already given in 3D,
+        robot_pose_in_world = state;
+      } else {
+        // The robot pose state is given in 2D. Notice that in this case
+        // the 2D pose of the robot is assumed to be that of the robot footprint (projection of the robot
+        // on the z=0 plane of the 3D world frame). This is so that we can tie the sensor reference frame
+        // to the world frame where the landmarks are given without additional structural information.
+        robot_pose_in_world = Sophus::SE3d{
+            Sophus::SO3d::rotZ(state.so2().log()),
+            Eigen::Vector3d{state.translation().x(), state.translation().y(), 0.0}};
       }
 
-      // convert landmark pose to world frame
-      // ignore height, because we are modelling the detection in 2D
-      const auto& landmark_position_in_world = *opt_landmark_position_in_world;
-      const auto landmark_in_robot_position = robot_pose_in_world.inverse() * landmark_position_in_world;
+      const auto detection_weight = [this, &robot_pose_in_world](const auto& detection) {
+        // calculate range and detection_bearing_in_robot to the detection from the robot
+        // the detection is already in robot frame
+        const auto& detection_category = detection.category;
+        const auto& detection_position_in_robot = detection.detection_position_in_robot;
 
-      const auto landmark_range_in_robot = landmark_in_robot_position.norm();
-      const auto landmark_bearing_in_robot = landmark_in_robot_position.normalized();
+        const auto detection_range_in_robot = detection_position_in_robot.norm();
+        const auto detection_bearing_in_robot = detection_position_in_robot.normalized();
 
-      // calculate the aperture angle between the detection and the landmark
-      const auto cos_aperture = landmark_bearing_in_robot.dot(detection_bearing_in_robot);
-      const auto sin_aperture = landmark_bearing_in_robot.cross(detection_bearing_in_robot).norm();
-      const auto bearing_error = std::atan2(sin_aperture, cos_aperture);
+        // convert the detection to the world frame to query the map
+        const auto detection_position_in_world = robot_pose_in_world * detection_position_in_robot;
 
-      const auto range_error = detection_range_in_robot - landmark_range_in_robot;
+        // find the closest matching landmark in the world map
+        const auto opt_landmark_position_in_world =
+            landmark_map_.find_nearest_landmark(detection_position_in_world, detection_category);
 
-      // apply the error model from Probabilistic Robotics
-      const auto range_error_prob =
-          std::exp(-range_error * range_error / (2. * params_.sigma_range * params_.sigma_range));
-      const auto bearing_error_prob =
-          std::exp(-bearing_error * bearing_error / (2. * params_.sigma_bearing * params_.sigma_bearing));
+        // if we did not find a matching landmark, return 0.0
+        if (!opt_landmark_position_in_world) {
+          return 0.0;
+        }
 
-      // We'll assume the probability of identification error to be zero
-      const auto prob = range_error_prob * bearing_error_prob;
+        // convert landmark pose to world frame
+        // ignore height, because we are modelling the detection in 2D
+        const auto& landmark_position_in_world = *opt_landmark_position_in_world;
+        const auto landmark_in_robot_position = robot_pose_in_world.inverse() * landmark_position_in_world;
 
-      // TODO(unknown): We continue to use the sum-of-cubes formula that nav2 uses
-      // See https://github.com/Ekumen-OS/beluga/issues/153
-      return prob * prob * prob;
+        const auto landmark_range_in_robot = landmark_in_robot_position.norm();
+        const auto landmark_bearing_in_robot = landmark_in_robot_position.normalized();
+
+        // calculate the aperture angle between the detection and the landmark
+        const auto cos_aperture = landmark_bearing_in_robot.dot(detection_bearing_in_robot);
+        const auto sin_aperture = landmark_bearing_in_robot.cross(detection_bearing_in_robot).norm();
+        const auto bearing_error = std::atan2(sin_aperture, cos_aperture);
+
+        const auto range_error = detection_range_in_robot - landmark_range_in_robot;
+
+        // apply the error model from Probabilistic Robotics
+        const auto range_error_prob =
+            std::exp(-range_error * range_error / (2. * params_.sigma_range * params_.sigma_range));
+        const auto bearing_error_prob =
+            std::exp(-bearing_error * bearing_error / (2. * params_.sigma_bearing * params_.sigma_bearing));
+
+        // We'll assume the probability of identification error to be zero
+        const auto prob = range_error_prob * bearing_error_prob;
+
+        // TODO(unknown): We continue to use the sum-of-cubes formula that nav2 uses
+        // See https://github.com/Ekumen-OS/beluga/issues/153
+        return prob * prob * prob;
+      };
+
+      return std::transform_reduce(detections.cbegin(), detections.cend(), 1.0, std::plus{}, detection_weight);
     };
-
-    return std::transform_reduce(points_.cbegin(), points_.cend(), 1.0, std::plus{}, detection_weight);
   }
 
-  /// \copydoc LandmarkSensorModelInterface::update_sensor(measurement_type&&points)
-  void update_sensor(measurement_type&& points) { points_ = std::move(points); }
-
-  /// \copydoc LandmarkSensorModelInterface::update_map(Map&& map)
+  /// Update the sensor model with a new landmark `map`.
   void update_map(map_type&& map) { landmark_map_ = std::move(map); }
 
  private:
   param_type params_;
   LandmarkMap landmark_map_;
-  measurement_type points_;
 };
 
 /// Sensor model based on discrete landmarks for 2D state types.
-/**
- * This class implements the BearingSensorModelInterface interface
- * and satisfies \ref SensorModelPage.
- * \tparam LandmarkMap class managing the list of known landmarks.
- */
 template <class LandmarkMap>
 using LandmarkSensorModel2d = LandmarkSensorModel<LandmarkMap, Sophus::SE2d>;
 
 /// Sensor model based on discrete landmarks for 3D state types.
-/**
- * This class implements the BearingSensorModelInterface interface
- * and satisfies \ref SensorModelPage.
- * \tparam LandmarkMap class managing the list of known landmarks.
- */
 template <class LandmarkMap>
 using LandmarkSensorModel3d = LandmarkSensorModel<LandmarkMap, Sophus::SE3d>;
 

--- a/beluga/include/beluga/sensor/likelihood_field_model.hpp
+++ b/beluga/include/beluga/sensor/likelihood_field_model.hpp
@@ -136,7 +136,7 @@ class LikelihoodFieldModel {
   /**
    * This method re-computes the underlying likelihood field.
    *
-   * \param map New occupancy grid representing the static map.
+   * \param grid New occupancy grid representing the static map.
    */
   void update_map(const map_type& grid) {
     likelihood_field_ = make_likelihood_field(params_, grid);

--- a/beluga/test/beluga/sensor/test_likelihood_field_model.cpp
+++ b/beluga/test/beluga/sensor/test_likelihood_field_model.cpp
@@ -46,14 +46,15 @@ TEST(LikelihoodFieldModel, LikelihoodField) {
   // clang-format on
 
   const auto params = beluga::LikelihoodFieldModelParam{2.0, 20.0, 0.5, 0.5, 0.2};
-  auto model = UUT{params, grid};
+  auto sensor_model = UUT{params, grid};
 
   // the likelihood field model includes an optimization that stores the likelihood elevated to the cube
   auto expected_cubed_likelihood =
       expected_likelihood_field | ranges::views::transform([](auto v) { return v * v * v; }) | ranges::to<std::vector>;
 
   ASSERT_THAT(
-      model.likelihood_field().data(), testing::Pointwise(testing::DoubleNear(0.003), expected_cubed_likelihood));
+      sensor_model.likelihood_field().data(),
+      testing::Pointwise(testing::DoubleNear(0.003), expected_cubed_likelihood));
 }
 
 TEST(LikelihoodFieldModel, ImportanceWeight) {
@@ -69,22 +70,33 @@ TEST(LikelihoodFieldModel, ImportanceWeight) {
   // clang-format on
 
   const auto params = beluga::LikelihoodFieldModelParam{2.0, 20.0, 0.5, 0.5, 0.2};
-  auto model = UUT{params, grid};
+  auto sensor_model = UUT{params, grid};
 
-  model.update_sensor(std::vector<std::pair<double, double>>{{1.25, 1.25}});
-  ASSERT_NEAR(2.068, model.importance_weight(grid.origin()), 0.003);
+  {
+    auto state_weighting_function = sensor_model(std::vector<std::pair<double, double>>{{1.25, 1.25}});
+    ASSERT_NEAR(2.068, state_weighting_function(grid.origin()), 0.003);
+  }
 
-  model.update_sensor(std::vector<std::pair<double, double>>{{2.25, 2.25}});
-  ASSERT_NEAR(1.000, model.importance_weight(grid.origin()), 0.003);
+  {
+    auto state_weighting_function = sensor_model(std::vector<std::pair<double, double>>{{2.25, 2.25}});
+    ASSERT_NEAR(1.000, state_weighting_function(grid.origin()), 0.003);
+  }
 
-  model.update_sensor(std::vector<std::pair<double, double>>{{-50.0, 50.0}});
-  ASSERT_NEAR(1.000, model.importance_weight(grid.origin()), 0.003);
+  {
+    auto state_weighting_function = sensor_model(std::vector<std::pair<double, double>>{{-50.0, 50.0}});
+    ASSERT_NEAR(1.000, state_weighting_function(grid.origin()), 0.003);
+  }
 
-  model.update_sensor(std::vector<std::pair<double, double>>{{1.20, 1.20}, {1.25, 1.25}, {1.30, 1.30}});
-  ASSERT_NEAR(4.205, model.importance_weight(grid.origin()), 0.01);
+  {
+    auto state_weighting_function =
+        sensor_model(std::vector<std::pair<double, double>>{{1.20, 1.20}, {1.25, 1.25}, {1.30, 1.30}});
+    ASSERT_NEAR(4.205, state_weighting_function(grid.origin()), 0.01);
+  }
 
-  model.update_sensor(std::vector<std::pair<double, double>>{{0.0, 0.0}});
-  ASSERT_NEAR(2.068, model.importance_weight(Sophus::SE2d{Sophus::SO2d{}, Eigen::Vector2d{1.25, 1.25}}), 0.003);
+  {
+    auto state_weighting_function = sensor_model(std::vector<std::pair<double, double>>{{0.0, 0.0}});
+    ASSERT_NEAR(2.068, state_weighting_function(Sophus::SE2d{Sophus::SO2d{}, Eigen::Vector2d{1.25, 1.25}}), 0.003);
+  }
 }
 
 TEST(LikelihoodFieldModel, GridWithOffset) {
@@ -101,13 +113,17 @@ TEST(LikelihoodFieldModel, GridWithOffset) {
   // clang-format on
 
   const auto params = beluga::LikelihoodFieldModelParam{2.0, 20.0, 0.5, 0.5, 0.2};
-  auto model = UUT{params, grid};
+  auto sensor_model = UUT{params, grid};
 
-  model.update_sensor(std::vector<std::pair<double, double>>{{4.5, 4.5}});
-  ASSERT_NEAR(2.068, model.importance_weight(Sophus::SE2d{}), 0.003);
+  {
+    auto state_weighting_function = sensor_model(std::vector<std::pair<double, double>>{{4.5, 4.5}});
+    ASSERT_NEAR(2.068, state_weighting_function(Sophus::SE2d{}), 0.003);
+  }
 
-  model.update_sensor(std::vector<std::pair<double, double>>{{9.5, 9.5}});
-  ASSERT_NEAR(2.068, model.importance_weight(grid.origin()), 0.003);
+  {
+    auto state_weighting_function = sensor_model(std::vector<std::pair<double, double>>{{9.5, 9.5}});
+    ASSERT_NEAR(2.068, state_weighting_function(grid.origin()), 0.003);
+  }
 }
 
 TEST(LikelihoodFieldModel, GridWithRotation) {
@@ -124,13 +140,17 @@ TEST(LikelihoodFieldModel, GridWithRotation) {
   // clang-format on
 
   const auto params = beluga::LikelihoodFieldModelParam{2.0, 20.0, 0.5, 0.5, 0.2};
-  auto model = UUT{params, grid};
+  auto sensor_model = UUT{params, grid};
 
-  model.update_sensor(std::vector<std::pair<double, double>>{{-9.5, 9.5}});
-  ASSERT_NEAR(2.068, model.importance_weight(Sophus::SE2d{}), 0.003);
+  {
+    auto state_weighting_function = sensor_model(std::vector<std::pair<double, double>>{{-9.5, 9.5}});
+    ASSERT_NEAR(2.068, state_weighting_function(Sophus::SE2d{}), 0.003);
+  }
 
-  model.update_sensor(std::vector<std::pair<double, double>>{{9.5, 9.5}});
-  ASSERT_NEAR(2.068, model.importance_weight(grid.origin()), 0.003);
+  {
+    auto state_weighting_function = sensor_model(std::vector<std::pair<double, double>>{{9.5, 9.5}});
+    ASSERT_NEAR(2.068, state_weighting_function(grid.origin()), 0.003);
+  }
 }
 
 TEST(LikelihoodFieldModel, GridWithRotationAndOffset) {
@@ -150,13 +170,17 @@ TEST(LikelihoodFieldModel, GridWithRotationAndOffset) {
   // clang-format on
 
   const auto params = beluga::LikelihoodFieldModelParam{2.0, 20.0, 0.5, 0.5, 0.2};
-  auto model = UUT{params, grid};
+  auto sensor_model = UUT{params, grid};
 
-  model.update_sensor(std::vector<std::pair<double, double>>{{-4.5, 4.5}});
-  ASSERT_NEAR(2.068, model.importance_weight(Sophus::SE2d{}), 0.003);
+  {
+    auto state_weighting_function = sensor_model(std::vector<std::pair<double, double>>{{-4.5, 4.5}});
+    ASSERT_NEAR(2.068, state_weighting_function(Sophus::SE2d{}), 0.003);
+  }
 
-  model.update_sensor(std::vector<std::pair<double, double>>{{9.5, 9.5}});
-  ASSERT_NEAR(2.068, model.importance_weight(grid.origin()), 0.003);
+  {
+    auto state_weighting_function = sensor_model(std::vector<std::pair<double, double>>{{9.5, 9.5}});
+    ASSERT_NEAR(2.068, state_weighting_function(grid.origin()), 0.003);
+  }
 }
 
 TEST(LikelihoodFieldModel, GridUpdates) {
@@ -174,10 +198,12 @@ TEST(LikelihoodFieldModel, GridUpdates) {
   // clang-format on
 
   const auto params = beluga::LikelihoodFieldModelParam{2.0, 20.0, 0.5, 0.5, 0.2};
-  auto model = UUT{params, std::move(grid)};
+  auto sensor_model = UUT{params, std::move(grid)};
 
-  model.update_sensor(std::vector<std::pair<double, double>>{{1., 1.}});
-  EXPECT_NEAR(2.068577607986223, model.importance_weight(origin), 1e-6);
+  {
+    auto state_weighting_function = sensor_model(std::vector<std::pair<double, double>>{{1., 1.}});
+    EXPECT_NEAR(2.068577607986223, state_weighting_function(origin), 1e-6);
+  }
 
   // clang-format off
   grid = StaticOccupancyGrid<5, 5>{{
@@ -188,10 +214,12 @@ TEST(LikelihoodFieldModel, GridUpdates) {
     false, false, false, false, true},
     kResolution, origin};
   // clang-format on
-  model.update_map(std::move(grid));
+  sensor_model.update_map(std::move(grid));
 
-  model.update_sensor(std::vector<std::pair<double, double>>{{1., 1.}});
-  EXPECT_NEAR(1.0, model.importance_weight(origin), 1e-3);
+  {
+    auto state_weighting_function = sensor_model(std::vector<std::pair<double, double>>{{1., 1.}});
+    EXPECT_NEAR(1.0, state_weighting_function(origin), 1e-3);
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
### Proposed changes

Depends on #324. This patch migrates sensor models to a functional form. This affords:

```c++
beluga::actions::reweight(std::execution::par, sensor(std::move(measurement)))
```

when reweighting particles.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)