### PR TITLE
Fix landmark models probability aggregation formula

### DIFF
--- a/beluga/include/beluga/sensor/bearing_sensor_model.hpp
+++ b/beluga/include/beluga/sensor/bearing_sensor_model.hpp
@@ -127,15 +127,10 @@ class BearingSensorModel {
         const auto bearing_error_prob =
             std::exp(-bearing_error * bearing_error / (2. * params_.sigma_bearing * params_.sigma_bearing));
 
-        // We'll assume the probability of identification error to be zero
-        const auto prob = bearing_error_prob;
-
-        // TODO(unknown): We continue to use the sum-of-cubes formula that nav2 uses
-        // See https://github.com/Ekumen-OS/beluga/issues/153
-        return prob * prob * prob;
+        return bearing_error_prob;
       };
 
-      return std::transform_reduce(detections.cbegin(), detections.cend(), 1.0, std::plus{}, detection_weight);
+      return std::transform_reduce(detections.cbegin(), detections.cend(), 1.0, std::multiplies{}, detection_weight);
     };
   }
 

--- a/beluga/include/beluga/sensor/landmark_sensor_model.hpp
+++ b/beluga/include/beluga/sensor/landmark_sensor_model.hpp
@@ -145,14 +145,10 @@ class LandmarkSensorModel {
             std::exp(-bearing_error * bearing_error / (2. * params_.sigma_bearing * params_.sigma_bearing));
 
         // We'll assume the probability of identification error to be zero
-        const auto prob = range_error_prob * bearing_error_prob;
-
-        // TODO(unknown): We continue to use the sum-of-cubes formula that nav2 uses
-        // See https://github.com/Ekumen-OS/beluga/issues/153
-        return prob * prob * prob;
+        return range_error_prob * bearing_error_prob;
       };
 
-      return std::transform_reduce(detections.cbegin(), detections.cend(), 1.0, std::plus{}, detection_weight);
+      return std::transform_reduce(detections.cbegin(), detections.cend(), 1.0, std::multiplies{}, detection_weight);
     };
   }
 

--- a/beluga/test/beluga/sensor/test_bearing_sensor_model.cpp
+++ b/beluga/test/beluga/sensor/test_bearing_sensor_model.cpp
@@ -34,9 +34,8 @@ using Sensor3D = beluga::BearingSensorModel3d<LandmarkMap>;
 LandmarkMapBoundaries default_map_boundaries{Eigen::Vector3d{-10.0, -10.0, 0.0}, Eigen::Vector3d{10.0, 10.0, 0.0}};
 
 double expected_aggregate_probability(std::vector<double> landmark_probs) {
-  // nav2_amcl formula, $1.0 + \sum_{i=1}^n p_i^3$
   return std::transform_reduce(
-      landmark_probs.cbegin(), landmark_probs.cend(), 1.0, std::plus{}, [](const double v) { return v * v * v; });
+      landmark_probs.cbegin(), landmark_probs.cend(), 1.0, std::multiplies{}, [](const double v) { return v; });
 }
 
 BearingModelParam get_default_model_params() {

--- a/beluga/test/beluga/sensor/test_landmark_sensor_model.cpp
+++ b/beluga/test/beluga/sensor/test_landmark_sensor_model.cpp
@@ -36,9 +36,8 @@ using Sensor2D = beluga::LandmarkSensorModel2d<LandmarkMap>;
 using Sensor3D = beluga::LandmarkSensorModel3d<LandmarkMap>;
 
 double expected_aggregate_probability(std::vector<double> landmark_probs) {
-  // nav2_amcl formula, $1.0 + \sum_{i=1}^n p_i^3$
   return std::transform_reduce(
-      landmark_probs.cbegin(), landmark_probs.cend(), 1.0, std::plus{}, [](const double v) { return v * v * v; });
+      landmark_probs.cbegin(), landmark_probs.cend(), 1.0, std::multiplies{}, [](const double v) { return v; });
 }
 
 LandmarkModelParam get_default_model_params() {


### PR DESCRIPTION
### Proposed changes

The sum-of-cubes-plus-1 formula works really bad for landmark models, causing them almost not throw particles that don't really fit what the sensors see, because the high and low values of the probability is not really very different if the number of landmarks is low.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)