### PR TITLE
Make dev container run in detached mode

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -80,4 +80,4 @@ else
     PRIVILEGED_CONTAINER=$PRIVILEGED_CONTAINER USERID=$(id -u) GROUPID=$(id -g) docker compose run --rm --detach --name $DEV_CONTAINER_NAME  dev
 fi
 
-USERID=$(id -u) GROUPID=$(id -g) docker exec -it $DEV_CONTAINER_NAME /bin/bash -c 'source /ros_entrypoint.sh && /bin/bash'
+docker exec -it $DEV_CONTAINER_NAME /ros_entrypoint.sh /bin/bash

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -80,9 +80,9 @@ DEV_CONTAINER_NAME=beluga_dev
 if docker ps -a --format '{{.Names}}' | grep -q $DEV_CONTAINER_NAME; then
     # Attach to the container if it is running
     echo "Found dev container running, attaching to it..."
-    docker exec -it "$DEV_CONTAINER_NAME" /bin/bash
 else
     echo "Container '$DEV_CONTAINER_NAME' does not exist or is not running, proceeding to run it."
     PRIVILEGED_CONTAINER=$PRIVILEGED_CONTAINER USERID=$(id -u) GROUPID=$(id -g) docker compose run --rm --detach --name $DEV_CONTAINER_NAME  dev
-    docker exec -it "$DEV_CONTAINER_NAME" /bin/bash
 fi
+
+docker exec -it "$DEV_CONTAINER_NAME" /bin/bash

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -85,4 +85,4 @@ else
     PRIVILEGED_CONTAINER=$PRIVILEGED_CONTAINER USERID=$(id -u) GROUPID=$(id -g) docker compose run --rm --detach --name $DEV_CONTAINER_NAME  dev
 fi
 
-docker exec -it "$DEV_CONTAINER_NAME" /bin/bash
+USERID=$(id -u) GROUPID=$(id -g) docker exec -it $DEV_CONTAINER_NAME fixuid -q /bin/bash -c 'source /ros_entrypoint.sh && /bin/bash'

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -68,11 +68,6 @@ done
 
 DEV_CONTAINER_NAME=beluga_dev
 
-# Note: The `--build` flag was added to docker compose run after
-# https://github.com/docker/compose/releases/tag/v2.13.0.
-# We have this for convenience and compatibility with previous versions.
-# Otherwise, we could just forward the script arguments to the run verb.
-
 # Kill the container JIC it already exists, if building, to ensure we don't attach to an old container.
 [[ "$BUILD" = true ]] && docker compose build dev && docker rm -f $DEV_CONTAINER_NAME  2>/dev/null
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -80,4 +80,4 @@ else
     PRIVILEGED_CONTAINER=$PRIVILEGED_CONTAINER USERID=$(id -u) GROUPID=$(id -g) docker compose run --rm --detach --name $DEV_CONTAINER_NAME  dev
 fi
 
-USERID=$(id -u) GROUPID=$(id -g) docker exec -it $DEV_CONTAINER_NAME fixuid -q /bin/bash -c 'source /ros_entrypoint.sh && /bin/bash'
+USERID=$(id -u) GROUPID=$(id -g) docker exec -it $DEV_CONTAINER_NAME /bin/bash -c 'source /ros_entrypoint.sh && /bin/bash'


### PR DESCRIPTION
### Proposed changes

When developing, it's convenient to preserve the container status to keep the builds hot and command history present.
This PR adds such functionality to the `docker/run.sh` script.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)


### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)
