### PR TITLE
Clang tidy doesn't sort includes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,7 +7,6 @@ Checks: >
   bugprone-*,
   google-*,
   llvm-header-guard,
-  llvm-include-order,
   misc-*,
   modernize-*,
   performance-*,


### PR DESCRIPTION
### Proposed changes
The way `clang-format` sorts includes conflicts with `clang-tidy`'s, and can only be fixed by the user including empty lines between include blocks in a non intuitive manner.

This PR removes the sorting behavior of `clang-tidy` and will delegate that functionality solely to `clang-format`.
#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)

