### PR TITLE
Allow coverage to drop by 1%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,12 +13,19 @@ component_management:
       - type: project  # Measure overall project coverage.
         # The minimum coverage ratio to send a success status is the base
         # commit coverage (pull request base or parent commit).
-        target: auto
-        # Allow the coverage to drop by this percentage.
-        threshold: 1%
+        target: 95%
         # If the patch coverage is 100% and there are no unexpected changes,
         # pass the project status.
         removed_code_behavior: fully_covered_patch
+
+      - type: patch  # Measure lines adjusted in the pull request.
+        # The minimum coverage ratio to send a success status is the base
+        # commit coverage (pull request base or parent commit).
+        target: auto
+        # Allow the coverage to drop by this percentage.
+        threshold: 1%
+        # Only post patch status to pull requests.
+        only_pulls: true
 
   individual_components:
     - component_id: package_beluga

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,6 +14,8 @@ component_management:
         # The minimum coverage ratio to send a success status is the base
         # commit coverage (pull request base or parent commit).
         target: auto
+        # Allow the coverage to drop by this percentage.
+        threshold: 1%
         # If the patch coverage is 100% and there are no unexpected changes,
         # pass the project status.
         removed_code_behavior: fully_covered_patch

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -41,6 +41,17 @@ component_management:
       name: beluga_ros
       paths:
         - beluga_ros/**
+      statuses:
+        # Beluga ROS has its own statutes since it currently has lower coverage.
+        # See `default_rules` for details.
+        - type: project
+          target: 90%
+          removed_code_behavior: fully_coverred_patch
+
+        - type: patch
+          target: auto
+          threshold: 1%
+          only_pulls: true
 
 coverage:
   # Disable project and patch level coverage status check in favor of

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,8 +11,7 @@ component_management:
   default_rules:
     statuses:
       - type: project  # Measure overall project coverage.
-        # The minimum coverage ratio to send a success status is the base
-        # commit coverage (pull request base or parent commit).
+        # The minimum coverage ratio to send a success status.
         target: 95%
         # If the patch coverage is 100% and there are no unexpected changes,
         # pass the project status.


### PR DESCRIPTION
### Proposed changes

As the title says, this reduces the amount of false positives in detecting test coverage regressions.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)
