### PR TITLE
Isolate Flatland dependency

### DIFF
--- a/beluga_example/README.md
+++ b/beluga_example/README.md
@@ -44,9 +44,10 @@ The following examples are easier to run in [Beluga development containers](../D
     rosrun teleop_twist_keyboard teleop_twist_keyboard
     ```
 
-    Note that this example uses [Flatland](https://flatland-simulator.readthedocs.io) for simulation.
-    A Flatland source installation is provisioned in development containers.
-    You will have to provision one yourself to run this elsewhere.
+    > [!IMPORTANT]
+    > Note that this example uses [Flatland](https://flatland-simulator.readthedocs.io) for simulation.
+    > A Flatland source installation is provisioned in development containers.
+    > You will have to provision one yourself to run this elsewhere.
 
 1. **Launch a localization node manually**.
 

--- a/beluga_example/README.md
+++ b/beluga_example/README.md
@@ -44,10 +44,9 @@ The following examples are easier to run in [Beluga development containers](../D
     rosrun teleop_twist_keyboard teleop_twist_keyboard
     ```
 
-    > [!IMPORTANT]
-    > Note that this example uses [Flatland](https://flatland-simulator.readthedocs.io) for simulation.
-    > A Flatland source installation is provisioned in development containers.
-    > You will have to provision one yourself to run this elsewhere.
+    Note that this example uses [Flatland](https://flatland-simulator.readthedocs.io) for simulation.
+    A Flatland source installation is provisioned in development containers.
+    You will have to provision one yourself to run this elsewhere.
 
 1. **Launch a localization node manually**.
 

--- a/beluga_example/README.md
+++ b/beluga_example/README.md
@@ -4,7 +4,9 @@ This package contains example launch files that demonstrate the use of Beluga-ba
 
 ## Examples
 
-1. **Run an example application using a ROS bag** (inside development container).
+The following examples are easier to run in [Beluga development containers](../DEVELOPING.md#environment).
+
+1. **Run an example application using a ROS bag**.
 
     For ROS 2 distributions, run:
     ```bash
@@ -20,7 +22,7 @@ This package contains example launch files that demonstrate the use of Beluga-ba
     roslaunch beluga_example perfect_odometry.launch
     ```
 
-1. **Run an example application using a simulation and teleop controls** (inside development container).
+1. **Run an example application using a simulation and teleop controls**.
 
     For ROS 2 distributions, in two separate terminals run:
     ```bash
@@ -41,6 +43,10 @@ This package contains example launch files that demonstrate the use of Beluga-ba
     ```bash
     rosrun teleop_twist_keyboard teleop_twist_keyboard
     ```
+
+    Note that this example uses [Flatland](https://flatland-simulator.readthedocs.io) for simulation.
+    A Flatland source installation is provisioned in development containers.
+    You will have to provision one yourself to run this elsewhere.
 
 1. **Launch a localization node manually**.
 
@@ -77,24 +83,3 @@ This package contains example launch files that demonstrate the use of Beluga-ba
    | `map`            | 5     | Keep last    | Reliable     | Transient local |
    | `particle_cloud` | 5     | Keep last    | Best effort  | Volatile        |
    | `pose`           | 5     | Keep last    | Reliable     | Volatile        |
-
-
-- Launch a pre-recorded ROS bag with perfect odometry and Beluga AMCL.
-  ```bash
-  ros2 launch beluga_example perfect_odometry.launch.xml
-  ```
-
-- Launch a pre-recorded ROS bag and Beluga AMCL as a composable node.
-  ```bash
-  ros2 launch beluga_example perfect_odometry.launch.xml use_composition:=True
-  ```
-
-- Launch a simulation that can be teleoperated together with Beluga AMCL.
-  ```bash
-  ros2 launch beluga_example simulation.launch.xml
-  ```
-
-- Launch Beluga AMCL, a map server, and a lifecycle manager. Useful for testing on real robots.
-  ```bash
-  ros2 launch beluga_example localization_launch.py use_composition:=True
-  ```

--- a/beluga_example/colcon.pkg
+++ b/beluga_example/colcon.pkg
@@ -1,0 +1,4 @@
+{
+    "name": "beluga_example",
+    "dependencies": ["flatland_server", "flatland_plugins"]
+}

--- a/beluga_example/package.xml
+++ b/beluga_example/package.xml
@@ -16,8 +16,6 @@
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
   <exec_depend>beluga_amcl</exec_depend>
-  <exec_depend>flatland_plugins</exec_depend>
-  <exec_depend>flatland_server</exec_depend>
   <exec_depend condition="$ROS_VERSION == 1">amcl</exec_depend>
   <exec_depend condition="$ROS_VERSION == 1">map_server</exec_depend>
   <exec_depend condition="$ROS_VERSION == 1">roslaunch</exec_depend>

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -58,14 +58,14 @@ sudo apt update && sudo apt upgrade
 
 ::::
 
-Then use `rosdep` to install all Beluga packages' dependencies:
+Then use `rosdep` to install Beluga packages' dependencies:
 
 ::::{tab-set}
 
 :::{tab-item} Ubuntu
 ```bash
 rosdep update
-rosdep install -r --from-paths ~/ws/src/beluga -y -i -t build -t exec --skip-keys 'flatland_server flatland_plugins'
+rosdep install -r --from-paths ~/ws/src/beluga -y -i -t build -t exec
 ```
 :::
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -28,7 +28,17 @@ roslaunch beluga_example perfect_odometry.launch
 
 ## Run Beluga in simulation
 
-Simulation streamlines and speeds up robotics development workflows, even if purely functional like in this example using [Flatland](https://flatland-simulator.readthedocs.io/en/latest/). On two separate terminals run:
+Simulation streamlines and speeds up robotics development workflows, even if purely functional like in this example using [Flatland](https://flatland-simulator.readthedocs.io).
+
+:::{important}
+Flatland must be installed separately to run the following commands.
+:::
+
+:::{tip}
+You can use [Beluga development containers](https://github.com/Ekumen-OS/beluga/blob/main/DEVELOPING.md#environment), provisioned by default with a Flatland source installation, to run the following commands.
+:::
+
+On two separate terminals run:
 
 ::::{tab-set}
 


### PR DESCRIPTION
### Proposed changes

This patch separates the Flatland dependency from the usual ROS workflow, documenting the necessary steps to satisfy it when and if necessary. This should fix the recent breakage in Beluga doc jobs up in the ROS buildfarm (e.g. [Hdev](https://build.ros2.org/job/Hdev__beluga__ubuntu_jammy_amd64/1/display/redirect), [Idev](https://build.ros2.org/job/Idev__beluga__ubuntu_jammy_amd64)).

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)
