### PR TITLE
Add missing beluga_benchmark deps

### DIFF
--- a/beluga_benchmark/package.xml
+++ b/beluga_benchmark/package.xml
@@ -21,6 +21,9 @@
   <exec_depend condition="$ROS_VERSION == 2">python3-pandas</exec_depend>
   <exec_depend condition="$ROS_VERSION == 2">python3-tk</exec_depend>
 
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_auto</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_common</test_depend>
+
   <export>
     <build_type condition="$ROS_VERSION == 1">cmake</build_type>
     <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>


### PR DESCRIPTION
### Proposed changes

This patch adds missing dependencies to `beluga_benchmark` package.xml. We never noticed because we don't do really do isolated builds in CI (but the buildfarm does, https://build.ros2.org/job/Hdev__beluga__ubuntu_jammy_amd64/7/console#console-section-17).

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)
