### PR TITLE
Drop ament_lint_auto dependencies

### DIFF
--- a/beluga_benchmark/CMakeLists.txt
+++ b/beluga_benchmark/CMakeLists.txt
@@ -36,11 +36,6 @@ if(ROS_VERSION EQUAL 2)
   install(DIRECTORY scripts/profiling scripts/benchmarking
                     USE_SOURCE_PERMISSIONS DESTINATION lib/${PROJECT_NAME})
 
-  if(BUILD_TESTING)
-    find_package(ament_lint_auto REQUIRED)
-    ament_lint_auto_find_test_dependencies()
-  endif()
-
   ament_package()
 elseif(ROS_VERSION EQUAL 1)
   install(CODE "message(STATUS 'Nothing to be done')")


### PR DESCRIPTION
### Proposed changes

Alternative to #369. No other package besides `beluga_benchmark` uses `ament_lint`. We use `pre-commit` hooks instead. This patch removes the dependency altogether. 

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x]  Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)
