### PR TITLE
Ensure we exercise random state generation every time

### DIFF
--- a/beluga/test/beluga/algorithm/test_amcl_core.cpp
+++ b/beluga/test/beluga/algorithm/test_amcl_core.cpp
@@ -168,9 +168,10 @@ TEST(TestAmclCore, TestRandomParticlesInserting) {
   auto params = beluga::AmclParams{};
   params.min_particles = 2;
   params.max_particles = 100;
+  params.alpha_slow = 0.0;
+  params.alpha_fast = 100.0;  // Ensure we exercise random state generation
   auto amcl = make_amcl(params);
   amcl.initialize(Sophus::SE2d{Sophus::SO2d{}, Eigen::Vector2d{1, 1}}, (Eigen::Vector3d::Ones()).asDiagonal());
-  // This exercises the random state generation.
   for (int i = 0; i < 30; ++i) {
     amcl.force_update();
     amcl.update(kDummyControl, kDummyMeasurement);


### PR DESCRIPTION
### Proposed changes

This fixes a bug in a test where we only sometimes would exercise random state generation, causing line coverage inconsistencies between PRs and the main branch.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

This fixes the -0.09% coverage difference we occasionally see in PRs and master merge runs.
![Screenshot from 2024-05-17 17-10-11](https://github.com/Ekumen-OS/beluga/assets/33042669/8c49e775-fbe5-4585-8346-deb18969918d)
