### PR TITLE
Enable beluga_amcl ROS 2 nodes' autostart

### DIFF
--- a/beluga_amcl/docs/ros2-reference.md
+++ b/beluga_amcl/docs/ros2-reference.md
@@ -190,6 +190,16 @@ Also available as a standalone `amcl_node` executable.
 : Maximum distance, in meters, to do obstacle inflation on map used in the `likelihood_field` model.
 : Defaults to `2.0`.
 
+##### Misc Parameters
+
+`autostart` _(`boolean`)_
+: Whether the node should configure and activate itself or not. Avoids the need for a lifecycle manager.
+: Defaults to `false`.
+
+`autostart_delay` _(`float`)_
+: Delay, in seconds, to wait before initiating an autostart sequence. Also the retry period when the sequence fails.
+: Defaults to `0.0`.
+
 ### Published topics
 
 `particle_cloud`

--- a/beluga_amcl/include/beluga_amcl/amcl_node.hpp
+++ b/beluga_amcl/include/beluga_amcl/amcl_node.hpp
@@ -90,6 +90,9 @@ class AmclNode : public rclcpp_lifecycle::LifecycleNode {
   /// Callback for periodic particle cloud updates.
   void timer_callback();
 
+  /// Callback for node to configure and activate itself.
+  void autostart_callback();
+
   /// Callback for laser scan updates.
   void laser_callback(sensor_msgs::msg::LaserScan::ConstSharedPtr);
 
@@ -134,6 +137,9 @@ class AmclNode : public rclcpp_lifecycle::LifecycleNode {
 
   /// Timer for periodic particle cloud updates.
   rclcpp::TimerBase::SharedPtr timer_;
+
+  /// Timer for node to configure and activate itself.
+  rclcpp::TimerBase::SharedPtr autostart_timer_;
 
   /// Particle cloud publisher.
   rclcpp_lifecycle::LifecyclePublisher<nav2_msgs::msg::ParticleCloud>::SharedPtr particle_cloud_pub_;

--- a/beluga_amcl/include/beluga_amcl/ndt_amcl_node.hpp
+++ b/beluga_amcl/include/beluga_amcl/ndt_amcl_node.hpp
@@ -136,6 +136,9 @@ class NdtAmclNode : public rclcpp_lifecycle::LifecycleNode {
   /// Callback for periodic particle cloud updates.
   void timer_callback();
 
+  /// Callback for node to configure and activate itself.
+  void autostart_callback();
+
   /// Callback for laser scan updates.
   void laser_callback(sensor_msgs::msg::LaserScan::ConstSharedPtr);
 
@@ -157,6 +160,8 @@ class NdtAmclNode : public rclcpp_lifecycle::LifecycleNode {
   std::unique_ptr<bond::Bond> bond_;
   /// Timer for periodic particle cloud updates.
   rclcpp::TimerBase::SharedPtr timer_;
+  /// Timer for node to configure and activate itself.
+  rclcpp::TimerBase::SharedPtr autostart_timer_;
 
   /// Particle cloud publisher.
   rclcpp_lifecycle::LifecyclePublisher<nav2_msgs::msg::ParticleCloud>::SharedPtr particle_cloud_pub_;

--- a/beluga_amcl/include/beluga_amcl/ros2_common.hpp
+++ b/beluga_amcl/include/beluga_amcl/ros2_common.hpp
@@ -392,6 +392,18 @@ inline void declare_common_params(rclcpp_lifecycle::LifecycleNode& node) {
     descriptor.description = "Execution policy used to process particles [seq, par].";
     node.declare_parameter("execution_policy", "seq", descriptor);
   }
+
+  {
+    auto descriptor = rcl_interfaces::msg::ParameterDescriptor();
+    descriptor.description = "Whether the node should configure and activate itself or not.";
+    node.declare_parameter("autostart", false, descriptor);
+  }
+
+  {
+    auto descriptor = rcl_interfaces::msg::ParameterDescriptor();
+    descriptor.description = "Delay, in seconds, before autostarting if autostarting.";
+    node.declare_parameter("autostart_delay", 0.0, descriptor);
+  }
 }
 
 /// Helper struct to hold a SE2 state and its weight.

--- a/beluga_amcl/src/ndt_amcl_node.cpp
+++ b/beluga_amcl/src/ndt_amcl_node.cpp
@@ -84,12 +84,34 @@ NdtAmclNode::NdtAmclNode(const rclcpp::NodeOptions& options)
     descriptor.floating_point_range[0].step = 0;
     declare_parameter("d2", rclcpp::ParameterValue(1.0), descriptor);
   }
+
+  if (get_parameter("autostart").as_bool()) {
+    auto autostart_delay = std::chrono::duration<double>(get_parameter("autostart_delay").as_double());
+    autostart_timer_ = create_wall_timer(autostart_delay, std::bind(&NdtAmclNode::autostart_callback, this));
+  }
 }
 
 NdtAmclNode::~NdtAmclNode() {
   RCLCPP_INFO(get_logger(), "Destroying");
   // In case this lifecycle node wasn't properly shut down, do it here
   on_shutdown(get_current_state());
+}
+
+void NdtAmclNode::autostart_callback() {
+  using lifecycle_msgs::msg::State;
+  auto current_state = configure();
+  if (current_state.id() != State::PRIMARY_STATE_INACTIVE) {
+    RCLCPP_WARN(get_logger(), "Failed to auto configure, shutting down");
+    shutdown();
+  }
+  RCLCPP_WARN(get_logger(), "Auto configured successfully");
+  current_state = activate();
+  if (current_state.id() != State::PRIMARY_STATE_ACTIVE) {
+    RCLCPP_WARN(get_logger(), "Failed to auto activate, shutting down");
+    shutdown();
+  }
+  RCLCPP_INFO(get_logger(), "Auto activated successfully");
+  autostart_timer_->cancel();
 }
 
 NdtAmclNode::CallbackReturn NdtAmclNode::on_configure(const rclcpp_lifecycle::State&) {

--- a/beluga_amcl/test/test_amcl_node.cpp
+++ b/beluga_amcl/test/test_amcl_node.cpp
@@ -104,7 +104,12 @@ class BaseNodeFixture : public T {
   std::shared_ptr<beluga_amcl::testing::TesterNode> tester_node_;
 };
 
-class TestLifecycle : public BaseNodeFixture<::testing::Test> {};
+class TestLifecycle : public ::testing::Test {
+ public:
+  void SetUp() override { rclcpp::init(0, nullptr); }
+
+  void TearDown() override { rclcpp::shutdown(); }
+};
 
 TEST_F(TestLifecycle, FullSpin) {
   using lifecycle_msgs::msg::State;
@@ -170,10 +175,12 @@ TEST_F(TestLifecycle, DestroyWhenInactive) {
   ASSERT_EQ(node->configure().id(), State::PRIMARY_STATE_INACTIVE);
 }
 
-TEST_F(TestLifecycle, DestroyWhenUnconfigured) {
+TEST_F(TestLifecycle, AutoStart) {
   using lifecycle_msgs::msg::State;
-  auto node = std::make_shared<beluga_amcl::AmclNode>();
-  ASSERT_EQ(node->get_current_state().id(), State::PRIMARY_STATE_UNCONFIGURED);
+  auto node =
+      std::make_shared<beluga_amcl::AmclNode>(rclcpp::NodeOptions{}.append_parameter_override("autostart", true));
+  spin_until([&] { return node->get_current_state().id() == State::PRIMARY_STATE_ACTIVE; }, 100ms, node);
+  ASSERT_EQ(node->get_current_state().id(), State::PRIMARY_STATE_ACTIVE);
 }
 
 class TestInitializationWithModel


### PR DESCRIPTION
### Proposed changes

This patch adds an `autostart` feature for `beluga_amcl` nodes to configure and activate themselves on demand, providing for systems that lack (or avoid) lifecycle management. It is also a escape hatch for Beluga to be usable in ROS 2 without explicitly providing a `nav2_lifecycle_manager` substitute.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)
