### PR TITLE
Restore particle cloud visualization using markers

### DIFF
--- a/beluga/include/beluga/algorithm/spatial_hash.hpp
+++ b/beluga/include/beluga/algorithm/spatial_hash.hpp
@@ -146,9 +146,8 @@ class spatial_hash<Tuple<Types...>, std::enable_if_t<(std::is_arithmetic_v<Types
 template <>
 class spatial_hash<Sophus::SE2d, void> {
  public:
-  /// Constructs a spatial hasher from an `std::array` of doubles.
+  /// Constructs a spatial hasher given per-coordinate resolutions.
   /**
-   *
    * \param x_clustering_resolution Clustering resolution for the X axis, in meters.
    * \param y_clustering_resolution Clustering resolution for the Y axis, in meters.
    * \param theta_clustering_resolution Clustering resolution for the Theta axis, in radians.
@@ -158,6 +157,14 @@ class spatial_hash<Sophus::SE2d, void> {
       double y_clustering_resolution,
       double theta_clustering_resolution)
       : underlying_hasher_{{x_clustering_resolution, y_clustering_resolution, theta_clustering_resolution}} {};
+
+  /// Constructs a spatial hasher given per-group resolutions.
+  /**
+   * \param linear_clustering_resolution Clustering resolution for translational coordinates, in meters.
+   * \param angular_clustering_resolution Clustering resolution for rotational coordinates, in radians.
+   */
+  explicit spatial_hash(double linear_clustering_resolution, double angular_clustering_resolution)
+      : spatial_hash(linear_clustering_resolution, linear_clustering_resolution, angular_clustering_resolution){};
 
   /// Default constructor
   spatial_hash() = default;

--- a/beluga_amcl/docs/ros2-reference.md
+++ b/beluga_amcl/docs/ros2-reference.md
@@ -195,6 +195,9 @@ Also available as a standalone `amcl_node` executable.
 `particle_cloud`
 : Estimated pose distribution published as `geometry_msgs/msg/PoseArray` messages, using a sensor data QoS policy. It will only be published if subscribers are found.
 
+`particle_markers`
+: Estimated pose distribution visualization published as `visualization_msgs/msg/MarkerArray` messages, using a system default QoS policy. Each particle is depicted using an arrow. Each arrow is colored and scaled according to the weight of the corresponding state in the distribution. Large, bright red arrows represent the most likely states, whereas small, dim purple arrows represent the least likely states. The rest lie in between. It will only be published if subscribers are found.
+
 `pose`
 : Mean and covariance of the estimated pose distribution published as `geometry_msgs/msg/PoseWithCovarianceStamped` messages (assumed Gaussian), using a system default QoS policy.
 

--- a/beluga_amcl/include/beluga_amcl/amcl_node.hpp
+++ b/beluga_amcl/include/beluga_amcl/amcl_node.hpp
@@ -32,6 +32,7 @@
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
 #include <std_srvs/srv/empty.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
 
 #include <beluga/beluga.hpp>
 #include <beluga_ros/amcl.hpp>
@@ -137,6 +138,9 @@ class AmclNode : public rclcpp_lifecycle::LifecycleNode {
 
   /// Particle cloud publisher.
   rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::PoseArray>::SharedPtr particle_cloud_pub_;
+  /// Particle markers publisher.
+  rclcpp_lifecycle::LifecyclePublisher<visualization_msgs::msg::MarkerArray>::SharedPtr particle_markers_pub_;
+
   /// Estimated pose publisher.
   rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pose_pub_;
 

--- a/beluga_amcl/test/test_amcl_node.cpp
+++ b/beluga_amcl/test/test_amcl_node.cpp
@@ -71,6 +71,12 @@ class BaseNodeFixture : public T {
         [this] { return tester_node_->latest_particle_cloud().has_value(); }, 1000ms, amcl_node_, tester_node_);
   }
 
+  bool wait_for_particle_markers() {
+    tester_node_->create_particle_markers_subscriber();
+    return spin_until(
+        [this] { return tester_node_->latest_particle_markers().has_value(); }, 1000ms, amcl_node_, tester_node_);
+  }
+
   bool request_global_localization() {
     if (!tester_node_->wait_for_global_localization_service(500ms)) {
       return false;
@@ -610,8 +616,16 @@ TEST_F(TestNode, IsPublishingParticleCloud) {
   amcl_node_->activate();
   tester_node_->publish_map();
   ASSERT_TRUE(wait_for_initialization());
-  tester_node_->create_particle_cloud_subscriber();
   ASSERT_TRUE(wait_for_particle_cloud());
+}
+
+TEST_F(TestNode, IsPublishingParticleMarkers) {
+  amcl_node_->set_parameter(rclcpp::Parameter{"set_initial_pose", true});
+  amcl_node_->configure();
+  amcl_node_->activate();
+  tester_node_->publish_map();
+  ASSERT_TRUE(wait_for_initialization());
+  ASSERT_TRUE(wait_for_particle_markers());
 }
 
 TEST_F(TestNode, LaserScanWithNoOdomToBase) {

--- a/beluga_amcl/test/test_utils/node_testing.hpp
+++ b/beluga_amcl/test/test_utils/node_testing.hpp
@@ -86,6 +86,18 @@ class TesterNode : public rclcpp::Node {
 
   const auto& latest_particle_cloud() const { return latest_particle_cloud_; }
 
+  void create_particle_markers_subscriber() {
+    particle_markers_subscriber_ = create_subscription<visualization_msgs::msg::MarkerArray>(
+        "particle_markers", rclcpp::SystemDefaultsQoS(),
+        std::bind(&TesterNode::particle_markers_callback, this, std::placeholders::_1));
+  }
+
+  void particle_markers_callback(visualization_msgs::msg::MarkerArray::SharedPtr message) {
+    latest_particle_markers_ = *message;
+  }
+
+  const auto& latest_particle_markers() const { return latest_particle_markers_; }
+
   static auto make_dummy_map() {
     auto map = nav_msgs::msg::OccupancyGrid{};
     map.header.frame_id = "map";
@@ -235,9 +247,11 @@ class TesterNode : public rclcpp::Node {
 
   SubscriberPtr<geometry_msgs::msg::PoseWithCovarianceStamped> pose_subscriber_;
   SubscriberPtr<geometry_msgs::msg::PoseArray> particle_cloud_subscriber_;
+  SubscriberPtr<visualization_msgs::msg::MarkerArray> particle_markers_subscriber_;
 
   std::optional<geometry_msgs::msg::PoseWithCovarianceStamped> latest_pose_;
   std::optional<geometry_msgs::msg::PoseArray> latest_particle_cloud_;
+  std::optional<visualization_msgs::msg::MarkerArray> latest_particle_markers_;
 
   std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
   std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;

--- a/beluga_ros/cmake/ament.cmake
+++ b/beluga_ros/cmake/ament.cmake
@@ -18,9 +18,11 @@ find_package(beluga REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
+find_package(visualization_msgs REQUIRED)
 
 ament_python_install_package(
   ${PROJECT_NAME}
@@ -41,9 +43,11 @@ ament_target_dependencies(
   INTERFACE geometry_msgs
             nav_msgs
             sensor_msgs
+            std_msgs
             tf2
             tf2_eigen
-            tf2_geometry_msgs)
+            tf2_geometry_msgs
+            visualization_msgs)
 target_compile_definitions(beluga_ros INTERFACE BELUGA_ROS_VERSION=2)
 target_compile_features(beluga_ros INTERFACE cxx_std_17)
 
@@ -52,9 +56,11 @@ ament_export_dependencies(
   geometry_msgs
   nav_msgs
   sensor_msgs
+  std_msgs
   tf2
   tf2_eigen
-  tf2_geometry_msgs)
+  tf2_geometry_msgs
+  visualization_msgs)
 ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_definitions(BELUGA_ROS_VERSION=2)
 ament_export_targets(beluga_ros HAS_LIBRARY_TARGET)

--- a/beluga_ros/cmake/catkin.cmake
+++ b/beluga_ros/cmake/catkin.cmake
@@ -17,17 +17,21 @@ find_package(
   catkin REQUIRED
   COMPONENTS nav_msgs
              sensor_msgs
+             std_msgs
              tf2
              tf2_eigen
-             tf2_geometry_msgs)
+             tf2_geometry_msgs
+             visualization_msgs)
 
 catkin_package(
   CATKIN_DEPENDS
     nav_msgs
     sensor_msgs
+    std_msgs
     tf2
     tf2_eigen
     tf2_geometry_msgs
+    visualization_msgs
   DEPENDS beluga
   INCLUDE_DIRS include
   CFG_EXTRAS ${PROJECT_NAME}-extras.cmake.in)

--- a/beluga_ros/docs/_doxygen/beluga_ros-main.md
+++ b/beluga_ros/docs/_doxygen/beluga_ros-main.md
@@ -27,4 +27,6 @@ Thin, Beluga-compatible wrappers for typical ROS data structures (usually messag
 
 | | |
 |-|-|
+| [particle_cloud.hpp](@ref particle_cloud.hpp) | APIs for particle cloud I/O over ROS interfaces. |
+| [tf2_eigen.hpp](@ref tf2_eigen.hpp) | tf2 message conversion API overloads for Eigen types. |
 | [tf2_sophus.hpp](@ref tf2_sophus.hpp) | tf2 message conversion API overloads for Sophus types. |

--- a/beluga_ros/include/beluga_ros/beluga_ros.hpp
+++ b/beluga_ros/include/beluga_ros/beluga_ros.hpp
@@ -28,6 +28,8 @@
 #include <beluga_ros/amcl.hpp>
 #include <beluga_ros/laser_scan.hpp>
 #include <beluga_ros/occupancy_grid.hpp>
+#include <beluga_ros/particle_cloud.hpp>
+#include <beluga_ros/tf2_eigen.hpp>
 #include <beluga_ros/tf2_sophus.hpp>
 
 #endif

--- a/beluga_ros/include/beluga_ros/messages.hpp
+++ b/beluga_ros/include/beluga_ros/messages.hpp
@@ -112,7 +112,7 @@ Message& stamp_message(std::string_view frame_id, detail::Time timestamp, Messag
   return message;
 }
 
-beluga_ros::msg::MarkerArray&
+inline beluga_ros::msg::MarkerArray&
 stamp_message(std::string_view frame_id, detail::Time timestamp, beluga_ros::msg::MarkerArray& message) {
   for (auto& marker : message.markers) {
     stamp_message(frame_id, timestamp, marker);

--- a/beluga_ros/include/beluga_ros/messages.hpp
+++ b/beluga_ros/include/beluga_ros/messages.hpp
@@ -102,7 +102,7 @@ using Time = ros::Time;
 /**
  * \param frame_id Frame ID to stamp the message with.
  * \param timestamp Time to stamp the message at.
- * \param[out] message Message to be assigned.
+ * \param[out] message Message to be stamped.
  * \tparam Message A message type with a header.
  */
 template <class Message>
@@ -112,6 +112,12 @@ Message& stamp_message(std::string_view frame_id, detail::Time timestamp, Messag
   return message;
 }
 
+/// Stamp all markers in a marker array message with a frame ID and timestamp.
+/**
+ * \param frame_id Frame ID to stamp markers with.
+ * \param timestamp Time to stamp markers at.
+ * \param[out] message Message to be stamped.
+ */
 inline beluga_ros::msg::MarkerArray&
 stamp_message(std::string_view frame_id, detail::Time timestamp, beluga_ros::msg::MarkerArray& message) {
   for (auto& marker : message.markers) {

--- a/beluga_ros/include/beluga_ros/messages.hpp
+++ b/beluga_ros/include/beluga_ros/messages.hpp
@@ -16,19 +16,27 @@
 #define BELUGA_ROS_MESSAGES_HPP
 
 #if BELUGA_ROS_VERSION == 2
+#include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/pose_array.hpp>
 #include <geometry_msgs/msg/transform.hpp>
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
+#include <std_msgs/msg/color_rgba.hpp>
+#include <visualization_msgs/msg/marker.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
 
 #include <rclcpp/time.hpp>
 #elif BELUGA_ROS_VERSION == 1
+#include <geometry_msgs/Point.h>
 #include <geometry_msgs/Pose.h>
 #include <geometry_msgs/PoseArray.h>
 #include <geometry_msgs/Transform.h>
 #include <nav_msgs/OccupancyGrid.h>
 #include <sensor_msgs/LaserScan.h>
+#include <std_msgs/ColorRGBA.h>
+#include <visualization_msgs/Marker.h>
+#include <visualization_msgs/MarkerArray.h>
 
 #include <ros/time.h>
 #else
@@ -42,20 +50,28 @@ namespace msg {
 
 #if BELUGA_ROS_VERSION == 2
 
+using ColorRGBA = std_msgs::msg::ColorRGBA;
 using LaserScan = sensor_msgs::msg::LaserScan;
 using LaserScanConstSharedPtr = LaserScan::ConstSharedPtr;
+using Marker = visualization_msgs::msg::Marker;
+using MarkerArray = visualization_msgs::msg::MarkerArray;
 using OccupancyGrid = nav_msgs::msg::OccupancyGrid;
 using OccupancyGridConstSharedPtr = OccupancyGrid::ConstSharedPtr;
+using Point = geometry_msgs::msg::Point;
 using Pose = geometry_msgs::msg::Pose;
 using PoseArray = geometry_msgs::msg::PoseArray;
 using Transform = geometry_msgs::msg::Transform;
 
 #elif BELUGA_ROS_VERSION == 1
 
+using ColorRGBA = std_msgs::ColorRGBA;
 using LaserScan = sensor_msgs::LaserScan;
 using LaserScanConstSharedPtr = LaserScan::ConstPtr;
+using Marker = visualization_msgs::Marker;
+using MarkerArray = visualization_msgs::MarkerArray;
 using OccupancyGrid = nav_msgs::OccupancyGrid;
 using OccupancyGridConstSharedPtr = OccupancyGrid::ConstPtr;
+using Point = geometry_msgs::Point;
 using Pose = geometry_msgs::Pose;
 using PoseArray = geometry_msgs::PoseArray;
 using Transform = geometry_msgs::Transform;
@@ -93,6 +109,14 @@ template <class Message>
 Message& stamp_message(std::string_view frame_id, detail::Time timestamp, Message& message) {
   message.header.frame_id = frame_id;
   message.header.stamp = timestamp;
+  return message;
+}
+
+beluga_ros::msg::MarkerArray&
+stamp_message(std::string_view frame_id, detail::Time timestamp, beluga_ros::msg::MarkerArray& message) {
+  for (auto& marker : message.markers) {
+    stamp_message(frame_id, timestamp, marker);
+  }
   return message;
 }
 

--- a/beluga_ros/include/beluga_ros/particle_cloud.hpp
+++ b/beluga_ros/include/beluga_ros/particle_cloud.hpp
@@ -87,8 +87,8 @@ struct almost_equal_to<Sophus::SE2<Scalar>> {
            (abs(atan(tan(a.so2().log() - b.so2().log()))) < angular_resolution);
   }
 
-  const Scalar linear_resolution;
-  const Scalar angular_resolution;
+  const Scalar linear_resolution;   ///< Resolution for translational coordinates, in meters.
+  const Scalar angular_resolution;  ///< Resolution for rotational coordinates, in radians.
 };
 
 }  // namespace detail

--- a/beluga_ros/include/beluga_ros/particle_cloud.hpp
+++ b/beluga_ros/include/beluga_ros/particle_cloud.hpp
@@ -49,17 +49,17 @@ namespace detail {
 /**
  * Assumes both saturation and value to be 1.
  */
-beluga_ros::msg::ColorRGBA alphaHueToRGBA(float hue, float alpha) {
+inline beluga_ros::msg::ColorRGBA alphaHueToRGBA(float hue, float alpha) {
   beluga_ros::msg::ColorRGBA message;
   // https://en.wikipedia.org/wiki/HSL_and_HSV#HSV_to_RGB_alternative
   // specialized for V = S = 1 and using single precision floats because
   // that is what the color message expects.
-  const auto kr = std::fmod(5.0f + hue / 60.0f, 6.0f);
-  const auto kg = std::fmod(3.0f + hue / 60.0f, 6.0f);
-  const auto kb = std::fmod(1.0f + hue / 60.0f, 6.0f);
-  message.r = 1.0f - 1.0f * std::max(0.0f, std::min({kr, 4.0f - kr, 1.0f}));
-  message.g = 1.0f - 1.0f * std::max(0.0f, std::min({kg, 4.0f - kg, 1.0f}));
-  message.b = 1.0f - 1.0f * std::max(0.0f, std::min({kb, 4.0f - kb, 1.0f}));
+  const auto kr = std::fmod(5.0F + hue / 60.0F, 6.0F);
+  const auto kg = std::fmod(3.0F + hue / 60.0F, 6.0F);
+  const auto kb = std::fmod(1.0F + hue / 60.0F, 6.0F);
+  message.r = 1.0F - 1.0F * std::max(0.0F, std::min({kr, 4.0F - kr, 1.0F}));
+  message.g = 1.0F - 1.0F * std::max(0.0F, std::min({kg, 4.0F - kg, 1.0F}));
+  message.b = 1.0F - 1.0F * std::max(0.0F, std::min({kb, 4.0F - kb, 1.0F}));
   message.a = alpha;
   return message;
 }
@@ -189,18 +189,18 @@ beluga_ros::msg::MarkerArray& assign_particle_cloud(
   // There are no arrow list markers yet (https://github.com/ros2/rviz/pull/972)
   // so we replicate them using a line list for arrow bodies and a triangle list
   // for arrow heads.
-  const auto kArrowBodyLength = Scalar{0.5};
-  const auto kArrowHeadLength = Scalar{0.1};
-  const auto kArrowHeadWidth = kArrowHeadLength / Scalar{5.0};
-  const auto kArrowLength = kArrowBodyLength + kArrowHeadLength;
+  constexpr auto kArrowBodyLength = Scalar{0.5};
+  constexpr auto kArrowHeadLength = Scalar{0.1};
+  constexpr auto kArrowHeadWidth = kArrowHeadLength / Scalar{5.0};
+  constexpr auto kArrowLength = kArrowBodyLength + kArrowHeadLength;
 
   using Translation = typename State::TranslationType;
-  const auto kArrowBodyBase = Translation{};
-  const auto kArrowHeadTip = kArrowLength * Translation::UnitX();
-  const auto kArrowHeadBase = kArrowBodyLength * Translation::UnitX();
-  const auto kArrowHeadRightCorner =
+  const auto arrow_body_base = Translation{};
+  const auto arrow_head_tip = kArrowLength * Translation::UnitX();
+  const auto arrow_head_base = kArrowBodyLength * Translation::UnitX();
+  const auto arrow_head_right_corner =
       kArrowBodyLength * Translation::UnitX() - (kArrowHeadWidth / Scalar{2.0}) * Translation::UnitY();
-  const auto kArrowHeadLeftCorner =
+  const auto arrow_head_left_corner =
       kArrowBodyLength * Translation::UnitX() + (kArrowHeadWidth / Scalar{2.0}) * Translation::UnitY();
 
   message.markers.reserve(2);
@@ -244,13 +244,13 @@ beluga_ros::msg::MarkerArray& assign_particle_cloud(
         static_cast<float>((1.0 - scale_factor) * 270.0), static_cast<float>(0.25 + 0.75 * scale_factor));
 
     // linearly scale arrow sizes using particle weights too
-    arrow_bodies.points.push_back(tf2::toMsg(state * (scale_factor * kArrowBodyBase)));
-    arrow_bodies.points.push_back(tf2::toMsg(state * (scale_factor * kArrowHeadBase)));
+    arrow_bodies.points.push_back(tf2::toMsg(state * (scale_factor * arrow_body_base)));
+    arrow_bodies.points.push_back(tf2::toMsg(state * (scale_factor * arrow_head_base)));
     arrow_bodies.colors.insert(arrow_bodies.colors.end(), 2, vertex_color);
 
-    arrow_heads.points.push_back(tf2::toMsg(state * (scale_factor * kArrowHeadLeftCorner)));
-    arrow_heads.points.push_back(tf2::toMsg(state * (scale_factor * kArrowHeadRightCorner)));
-    arrow_heads.points.push_back(tf2::toMsg(state * (scale_factor * kArrowHeadTip)));
+    arrow_heads.points.push_back(tf2::toMsg(state * (scale_factor * arrow_head_left_corner)));
+    arrow_heads.points.push_back(tf2::toMsg(state * (scale_factor * arrow_head_right_corner)));
+    arrow_heads.points.push_back(tf2::toMsg(state * (scale_factor * arrow_head_tip)));
 
     arrow_heads.colors.insert(arrow_heads.colors.end(), 3, vertex_color);
   }

--- a/beluga_ros/include/beluga_ros/particle_cloud.hpp
+++ b/beluga_ros/include/beluga_ros/particle_cloud.hpp
@@ -15,6 +15,8 @@
 #ifndef BELUGA_ROS_PARTICLE_CLOUD_HPP
 #define BELUGA_ROS_PARTICLE_CLOUD_HPP
 
+#include <cmath>
+#include <map>
 #include <memory>
 #include <type_traits>
 
@@ -25,9 +27,13 @@
 #include <sophus/se3.hpp>
 #include <sophus/types.hpp>
 
+#include <beluga/algorithm/spatial_hash.hpp>
 #include <beluga/primitives.hpp>
 #include <beluga/views/sample.hpp>
+#include <beluga/views/zip.hpp>
+
 #include <beluga_ros/messages.hpp>
+#include <beluga_ros/tf2_eigen.hpp>
 #include <beluga_ros/tf2_sophus.hpp>
 
 /**
@@ -36,6 +42,56 @@
  */
 
 namespace beluga_ros {
+
+namespace detail {
+
+/// Make an RGBA color based on hue alone.
+/**
+ * Assumes both saturation and value to be 1.
+ */
+beluga_ros::msg::ColorRGBA alphaHueToRGBA(float hue, float alpha) {
+  beluga_ros::msg::ColorRGBA message;
+  // https://en.wikipedia.org/wiki/HSL_and_HSV#HSV_to_RGB_alternative
+  // specialized for V = S = 1 and using single precision floats because
+  // that is what the color message expects.
+  const auto kr = std::fmod(5.0f + hue / 60.0f, 6.0f);
+  const auto kg = std::fmod(3.0f + hue / 60.0f, 6.0f);
+  const auto kb = std::fmod(1.0f + hue / 60.0f, 6.0f);
+  message.r = 1.0f - 1.0f * std::max(0.0f, std::min({kr, 4.0f - kr, 1.0f}));
+  message.g = 1.0f - 1.0f * std::max(0.0f, std::min({kg, 4.0f - kg, 1.0f}));
+  message.b = 1.0f - 1.0f * std::max(0.0f, std::min({kb, 4.0f - kb, 1.0f}));
+  message.a = alpha;
+  return message;
+}
+
+/// std::equal_to equivalent for near equality operations.
+template <class T>
+struct almost_equal_to;
+
+/// std::equal_to equivalent specialized for SE(2) types, with user resolutions.
+template <typename Scalar>
+struct almost_equal_to<Sophus::SE2<Scalar>> {
+  /// Constructs near equality functor.
+  /**
+   * \param _linear_resolution Resolution for translational coordinates, in meters.
+   * \param _angular_resolution Resolution for rotational coordinates, in radians.
+   */
+  explicit almost_equal_to(Scalar _linear_resolution, Scalar _angular_resolution)
+      : linear_resolution(_linear_resolution), angular_resolution(_angular_resolution) {}
+
+  /// Compares `a` and `b` for near equality.
+  bool operator()(const Sophus::SE2<Scalar>& a, const Sophus::SE2<Scalar>& b) const {
+    using std::abs, std::atan, std::tan;
+    return (abs(a.translation().x() - b.translation().x()) < linear_resolution) &&
+           (abs(a.translation().y() - b.translation().y()) < linear_resolution) &&
+           (abs(atan(tan(a.so2().log() - b.so2().log()))) < angular_resolution);
+  }
+
+  const Scalar linear_resolution;
+  const Scalar angular_resolution;
+};
+
+}  // namespace detail
 
 /// Assign a pose distribution to a particle cloud message.
 /**
@@ -76,7 +132,150 @@ assign_particle_cloud(Particles&& particles, std::size_t size, beluga_ros::msg::
 template <class Particles, class Message>
 Message& assign_particle_cloud(Particles&& particles, Message& message) {
   static_assert(ranges::sized_range<decltype(particles)>);
-  return assign_particle_cloud(particles, ranges::size(particles), message);
+  return assign_particle_cloud(std::forward<Particles>(particles), ranges::size(particles), message);
+}
+
+/// Assign a pose distribution to a markers message for visualization.
+/**
+ * \param particles Pose distribution, as a particle cloud itself.
+ * \param linear_resolution Linear resolution, in meters, for visualization.
+ * \param angular_resolution Angular resolution, in radians, for visualization.
+ * \param[out] message Markers message to be assigned.
+ * \tparam Particles A sized range type whose value type satisfies \ref ParticlePage "Particle" named requirements.
+ */
+template <
+    class Particles,
+    class Particle = ranges::range_value_t<Particles>,
+    class State = typename beluga::state_t<Particle>,
+    class Weight = typename beluga::weight_t<Particle>,
+    class Scalar = typename State::Scalar,
+    typename = std::enable_if_t<std::is_same_v<State, typename Sophus::SE2<Scalar>>>>
+beluga_ros::msg::MarkerArray& assign_particle_cloud(
+    Particles&& particles,
+    Scalar linear_resolution,
+    Scalar angular_resolution,
+    beluga_ros::msg::MarkerArray& message) {
+  // Particle weights from the filter may or may not be representative of the
+  // true distribution. If we resampled, they are not, and there will be multiple copies
+  // of the most likely candidates, all with unit weight. In this case the number of copies
+  // is a proxy for the prob density at each candidate. If we did not resample before updating
+  // the estimation and publishing this message (which can happen if the resample interval
+  // is set to something other than 1), then all particles are expected to be different
+  // and their weights are proportional to the prob density at each candidate.
+  //
+  // Only the combination of both the state distribution and the candidate weights together
+  // provide information about the probability density at each candidate.
+  auto max_bin_weight = Weight{1e-3};
+  auto states = beluga::views::states(particles);
+  auto weights = beluga::views::weights(particles);
+  using StateHistogram = std::unordered_map<State, Weight, beluga::spatial_hash<State>, detail::almost_equal_to<State>>;
+  auto histogram = StateHistogram{
+      10U, beluga::spatial_hash<State>{linear_resolution, angular_resolution},
+      detail::almost_equal_to<State>{linear_resolution, angular_resolution}};
+  for (const auto& [state, weight] : beluga::views::zip(states, weights)) {
+    auto& bin_weight = histogram[state];
+    bin_weight += weight;
+    if (bin_weight > max_bin_weight) {
+      max_bin_weight = bin_weight;
+    }
+  }
+
+  message.markers.clear();
+
+  if (histogram.empty()) {
+    return message;
+  }
+
+  // There are no arrow list markers yet (https://github.com/ros2/rviz/pull/972)
+  // so we replicate them using a line list for arrow bodies and a triangle list
+  // for arrow heads.
+  const auto kArrowBodyLength = Scalar{0.5};
+  const auto kArrowHeadLength = Scalar{0.1};
+  const auto kArrowHeadWidth = kArrowHeadLength / Scalar{5.0};
+  const auto kArrowLength = kArrowBodyLength + kArrowHeadLength;
+
+  using Translation = typename State::TranslationType;
+  const auto kArrowBodyBase = Translation{};
+  const auto kArrowHeadTip = kArrowLength * Translation::UnitX();
+  const auto kArrowHeadBase = kArrowBodyLength * Translation::UnitX();
+  const auto kArrowHeadRightCorner =
+      kArrowBodyLength * Translation::UnitX() - (kArrowHeadWidth / Scalar{2.0}) * Translation::UnitY();
+  const auto kArrowHeadLeftCorner =
+      kArrowBodyLength * Translation::UnitX() + (kArrowHeadWidth / Scalar{2.0}) * Translation::UnitY();
+
+  message.markers.reserve(2);
+  auto& arrow_bodies = message.markers.emplace_back();
+  arrow_bodies.id = 0;
+  arrow_bodies.ns = "bodies";
+  arrow_bodies.color.a = 1.0;
+  arrow_bodies.pose.orientation.w = 1.0;
+  arrow_bodies.lifetime.sec = 1;
+  arrow_bodies.type = beluga_ros::msg::Marker::LINE_LIST;
+  arrow_bodies.action = beluga_ros::msg::Marker::ADD;
+  arrow_bodies.points.reserve(histogram.size() * 2);  // 2 vertices per arrow body
+  arrow_bodies.colors.reserve(histogram.size() * 2);
+
+  auto& arrow_heads = message.markers.emplace_back();
+  arrow_heads.id = 1;
+  arrow_heads.ns = "heads";
+  arrow_heads.scale.x = 1.0;
+  arrow_heads.scale.y = 1.0;
+  arrow_heads.scale.z = 1.0;
+  arrow_heads.color.a = 1.0;
+  arrow_heads.pose.orientation.w = 1.0;
+  arrow_heads.lifetime.sec = 1;
+  arrow_heads.type = beluga_ros::msg::Marker::TRIANGLE_LIST;
+  arrow_heads.action = beluga_ros::msg::Marker::ADD;
+  arrow_heads.points.reserve(histogram.size() * 3);  // 3 vertices per arrow head
+  arrow_heads.colors.reserve(histogram.size() * 3);
+
+  auto min_scale_factor = Weight{1.0};
+  for (const auto& [state, weight] : histogram) {
+    // fix markers scale ratio to ensure they can still be seen
+    using std::max;
+    const auto scale_factor = max(weight / max_bin_weight, 1e-1);  // or 1:10
+    if (scale_factor < min_scale_factor) {
+      min_scale_factor = scale_factor;
+    }
+
+    // use an inverted rainbow scale of decreasing opacity: bright red
+    // for the most likely state and dim purple for the least likely one
+    const auto vertex_color = detail::alphaHueToRGBA(
+        static_cast<float>((1.0 - scale_factor) * 270.0), static_cast<float>(0.25 + 0.75 * scale_factor));
+
+    // linearly scale arrow sizes using particle weights too
+    arrow_bodies.points.push_back(tf2::toMsg(state * (scale_factor * kArrowBodyBase)));
+    arrow_bodies.points.push_back(tf2::toMsg(state * (scale_factor * kArrowHeadBase)));
+    arrow_bodies.colors.insert(arrow_bodies.colors.end(), 2, vertex_color);
+
+    arrow_heads.points.push_back(tf2::toMsg(state * (scale_factor * kArrowHeadLeftCorner)));
+    arrow_heads.points.push_back(tf2::toMsg(state * (scale_factor * kArrowHeadRightCorner)));
+    arrow_heads.points.push_back(tf2::toMsg(state * (scale_factor * kArrowHeadTip)));
+
+    arrow_heads.colors.insert(arrow_heads.colors.end(), 3, vertex_color);
+  }
+
+  arrow_bodies.scale.x = static_cast<double>(min_scale_factor * kArrowHeadWidth) * 0.8;
+
+  return message;
+}
+
+/// Assign a pose distribution to a markers message for visualization with suitable resolutions.
+/**
+ * \param particles Pose distribution, as a particle cloud itself.
+ * \param[out] message Markers message to be assigned.
+ * \tparam Particles A sized range type whose value type satisfies \ref ParticlePage "Particle" named requirements.
+ */
+template <
+    class Particles,
+    class Particle = ranges::range_value_t<Particles>,
+    class State = typename beluga::state_t<Particle>,
+    class Scalar = typename State::Scalar>
+beluga_ros::msg::MarkerArray& assign_particle_cloud(Particles&& particles, beluga_ros::msg::MarkerArray& message) {
+  constexpr auto kDefaultLinearResolution = Scalar{1e-3};   // ie. 1 mm
+  constexpr auto kDefaultAngularResolution = Scalar{1e-3};  // ie. 0.05 degrees
+  return assign_particle_cloud(
+      std::forward<Particles>(particles), kDefaultLinearResolution, kDefaultAngularResolution, message);
 }
 
 }  // namespace beluga_ros

--- a/beluga_ros/include/beluga_ros/tf2_eigen.hpp
+++ b/beluga_ros/include/beluga_ros/tf2_eigen.hpp
@@ -1,0 +1,55 @@
+// Copyright 2024 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BELUGA_ROS_TF2_EIGEN_HPP
+#define BELUGA_ROS_TF2_EIGEN_HPP
+
+#if BELUGA_ROS_VERSION == 2
+#include <tf2_eigen/tf2_eigen.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#elif BELUGA_ROS_VERSION == 1
+#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#error BELUGA_ROS_VERSION is not defined or invalid
+#endif
+
+#include <beluga_ros/messages.hpp>
+
+#include <Eigen/Core>
+
+/**
+ * \file
+ * \brief Message conversion API overloads for `Eigen` types.
+ */
+
+/// `tf2` namespace extension for message conversion overload resolution.
+namespace tf2 {
+
+/// Converts an Eigen Vector2 type to a Point message.
+/**
+ * \param in The Eigen Vector2 element to convert.
+ * \return The converted Point message.
+ */
+template <class Scalar>
+inline beluga_ros::msg::Point toMsg(const Eigen::Vector2<Scalar>& in) {
+  beluga_ros::msg::Point out;
+  out.x = static_cast<double>(in.x());
+  out.y = static_cast<double>(in.y());
+  return out;
+}
+
+}  // namespace tf2
+
+#endif  // BELUGA_ROS_TF2_EIGEN_HPP

--- a/beluga_ros/include/beluga_ros/tf2_eigen.hpp
+++ b/beluga_ros/include/beluga_ros/tf2_eigen.hpp
@@ -43,7 +43,7 @@ namespace tf2 {
  * \return The converted Point message.
  */
 template <class Scalar>
-inline beluga_ros::msg::Point toMsg(const Eigen::Vector2<Scalar>& in) {
+inline beluga_ros::msg::Point toMsg(const Eigen::Matrix<Scalar, 2, 1>& in) {
   beluga_ros::msg::Point out;
   out.x = static_cast<double>(in.x());
   out.y = static_cast<double>(in.y());

--- a/beluga_ros/package.xml
+++ b/beluga_ros/package.xml
@@ -20,10 +20,12 @@
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
+  <depend>visualization_msgs</depend>
 
   <test_depend condition="$ROS_VERSION == 1">rostest</test_depend>
   <test_depend condition="$ROS_VERSION == 2">ament_cmake_gmock</test_depend>

--- a/beluga_ros/test/test_messages.cpp
+++ b/beluga_ros/test/test_messages.cpp
@@ -18,11 +18,15 @@
 namespace {
 
 TEST(TestMessages, Instantiation) {
-  [[maybe_unused]] auto msg1 = beluga_ros::msg::LaserScan{};
-  [[maybe_unused]] auto msg2 = beluga_ros::msg::OccupancyGrid{};
-  [[maybe_unused]] auto msg3 = beluga_ros::msg::Pose{};
-  [[maybe_unused]] auto msg4 = beluga_ros::msg::PoseArray{};
-  [[maybe_unused]] auto msg5 = beluga_ros::msg::Transform{};
+  [[maybe_unused]] auto msg1 = beluga_ros::msg::ColorRGBA{};
+  [[maybe_unused]] auto msg2 = beluga_ros::msg::LaserScan{};
+  [[maybe_unused]] auto msg3 = beluga_ros::msg::Marker{};
+  [[maybe_unused]] auto msg4 = beluga_ros::msg::MarkerArray{};
+  [[maybe_unused]] auto msg5 = beluga_ros::msg::OccupancyGrid{};
+  [[maybe_unused]] auto msg6 = beluga_ros::msg::Point{};
+  [[maybe_unused]] auto msg7 = beluga_ros::msg::Pose{};
+  [[maybe_unused]] auto msg8 = beluga_ros::msg::PoseArray{};
+  [[maybe_unused]] auto msg9 = beluga_ros::msg::Transform{};
 }
 
 TEST(TestMessages, Stamping) {
@@ -30,6 +34,16 @@ TEST(TestMessages, Stamping) {
   beluga_ros::stamp_message("some_frame", {5, 0}, message);
   EXPECT_EQ(message.header.frame_id, "some_frame");
   EXPECT_EQ(message.header.stamp.sec, 5);
+}
+
+TEST(TestMessages, StampingMany) {
+  auto message = beluga_ros::msg::MarkerArray{};
+  message.markers.insert(message.markers.end(), 5U, beluga_ros::msg::Marker{});
+  beluga_ros::stamp_message("some_frame", {5, 0}, message);
+  for (const auto& marker : message.markers) {
+    EXPECT_EQ(marker.header.frame_id, "some_frame");
+    EXPECT_EQ(marker.header.stamp.sec, 5);
+  }
 }
 
 }  // namespace

--- a/beluga_ros/test/test_particle_cloud.cpp
+++ b/beluga_ros/test/test_particle_cloud.cpp
@@ -80,4 +80,25 @@ TEST(TestParticleCloud, AssignMatchingEmpty) {
   EXPECT_EQ(message.poses.size(), 0U);
 }
 
+TEST(TestParticleCloud, AssignMarkers) {
+  using Constants = Sophus::Constants<double>;
+  const auto particles = std::vector{
+      std::make_tuple(Sophus::SE2d{Sophus::SO2d{}, Eigen::Vector2d{1.0, 0.0}}, beluga::Weight(0.25)),
+      std::make_tuple(Sophus::SE2d{Sophus::SO2d{}, Eigen::Vector2d{1.0, 0.0}}, beluga::Weight(0.25)),
+      std::make_tuple(Sophus::SE2d{Sophus::SO2d{Constants::pi()}, Eigen::Vector2d{0.0, -1.0}}, beluga::Weight(0.5)),
+  };
+  auto message = beluga_ros::msg::MarkerArray{};
+  beluga_ros::assign_particle_cloud(particles, message);
+  ASSERT_EQ(message.markers.size(), 2U);
+  EXPECT_EQ(message.markers[0].points.size(), 2 * 2);  // 2 arrows, 2 vertices each
+  EXPECT_EQ(message.markers[1].points.size(), 3 * 2);  // 2 arrows, 3 vertices each
+}
+
+TEST(TestParticleCloud, AssignNoMarkers) {
+  const auto particles = std::vector<std::tuple<Sophus::SE2d, beluga::Weight>>{};
+  auto message = beluga_ros::msg::MarkerArray{};
+  beluga_ros::assign_particle_cloud(particles, message);
+  EXPECT_EQ(message.markers.size(), 0U);
+}
+
 }  // namespace

--- a/beluga_ros/test/test_particle_cloud.cpp
+++ b/beluga_ros/test/test_particle_cloud.cpp
@@ -83,9 +83,9 @@ TEST(TestParticleCloud, AssignMatchingEmpty) {
 TEST(TestParticleCloud, AssignMarkers) {
   using Constants = Sophus::Constants<double>;
   const auto particles = std::vector{
+      std::make_tuple(Sophus::SE2d{Sophus::SO2d{}, Eigen::Vector2d{1.0, 0.0}}, beluga::Weight(0.35)),
       std::make_tuple(Sophus::SE2d{Sophus::SO2d{}, Eigen::Vector2d{1.0, 0.0}}, beluga::Weight(0.25)),
-      std::make_tuple(Sophus::SE2d{Sophus::SO2d{}, Eigen::Vector2d{1.0, 0.0}}, beluga::Weight(0.25)),
-      std::make_tuple(Sophus::SE2d{Sophus::SO2d{Constants::pi()}, Eigen::Vector2d{0.0, -1.0}}, beluga::Weight(0.5)),
+      std::make_tuple(Sophus::SE2d{Sophus::SO2d{Constants::pi()}, Eigen::Vector2d{0.0, -1.0}}, beluga::Weight(0.4)),
   };
   auto message = beluga_ros::msg::MarkerArray{};
   beluga_ros::assign_particle_cloud(particles, message);


### PR DESCRIPTION
### Proposed changes

Follow-up to #372. As the title reads, this restores the functionality we had with `nav2_msgs/ParticleCloud` using `visualization_msgs/MarkerArray` instead.

https://github.com/Ekumen-OS/beluga/assets/13500507/9b4e84b8-0b27-40cd-a052-63f1ef91dadb

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)