### PR TITLE
Rewrite `make_from_state` as a function object

### DIFF
--- a/beluga/test/beluga/views/test_sample.cpp
+++ b/beluga/test/beluga/views/test_sample.cpp
@@ -25,6 +25,7 @@
 #include <range/v3/algorithm/find.hpp>
 #include <range/v3/range/access.hpp>
 #include <range/v3/range/concepts.hpp>
+#include <range/v3/range/conversion.hpp>
 #include <range/v3/range/dangling.hpp>
 #include <range/v3/range/primitives.hpp>
 #include <range/v3/view/const.hpp>
@@ -87,7 +88,9 @@ TEST(SampleView, DiscreteDistributionSingleElement) {
 
 TEST(SampleView, DiscreteDistributionSingleElementFromParticleRange) {
   auto input = std::array{std::make_tuple(5, beluga::Weight(5.0))};
-  auto output = input | beluga::views::sample | ranges::views::take_exactly(20);
+  // NOTE: We convert to std::vector because `sample` does not produce a forward range,
+  // and thus does not support iterating over the whole sequence twice.
+  auto output = input | beluga::views::sample | ranges::views::take_exactly(20) | ranges::to<std::vector>;
   ASSERT_EQ(ranges::count(output | beluga::views::states, 5), 20);
   ASSERT_EQ(ranges::count(output | beluga::views::weights, beluga::Weight(1.0)), 20);
 }


### PR DESCRIPTION
### Proposed changes

This change improves compatibility with older GCC versions (9.3) that struggle to deduce the type of instantiated template functions when they are passed as arguments.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

Minimal examples that checks compatibility with GCC 9.3:
Before: https://godbolt.org/z/b1EzfKa75
After: https://godbolt.org/z/9eYzWhEqK
