### PR TITLE
Use `no-gnu-zero-variadic-macro-arguments` only with `clang-tidy`

### DIFF
--- a/beluga/CMakeLists.txt
+++ b/beluga/CMakeLists.txt
@@ -33,8 +33,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
               -Wconversion
               -Werror
               -Wextra
-              -Wpedantic
-              -Wno-gnu-zero-variadic-macro-arguments)
+              -Wpedantic)
 endif()
 
 find_package(Eigen3 REQUIRED NO_MODULE)

--- a/beluga/test/beluga/sensor/test_bearing_sensor_model.cpp
+++ b/beluga/test/beluga/sensor/test_bearing_sensor_model.cpp
@@ -79,7 +79,7 @@ struct BearingSensorModelTests : public ::testing::Test {};
 
 using BearingSensorModelTestsTypes = ::testing::Types<Sensor2D, Sensor3D>;
 
-TYPED_TEST_SUITE(BearingSensorModelTests, BearingSensorModelTestsTypes);
+TYPED_TEST_SUITE(BearingSensorModelTests, BearingSensorModelTestsTypes, );
 
 TYPED_TEST(BearingSensorModelTests, SmokeTest) {
   auto sensor_model =

--- a/beluga/test/beluga/sensor/test_landmark_sensor_model.cpp
+++ b/beluga/test/beluga/sensor/test_landmark_sensor_model.cpp
@@ -71,7 +71,7 @@ struct LandmarkSensorModelTests : public ::testing::Test {};
 
 using LandmarkSensorModelTestsTypes = ::testing::Types<Sensor2D, Sensor3D>;
 
-TYPED_TEST_SUITE(LandmarkSensorModelTests, LandmarkSensorModelTestsTypes);
+TYPED_TEST_SUITE(LandmarkSensorModelTests, LandmarkSensorModelTestsTypes, );
 
 TYPED_TEST(LandmarkSensorModelTests, BullsEyeDetection) {
   // test case where the landmark is exactly where we expected it

--- a/tools/run-clang-tidy.sh
+++ b/tools/run-clang-tidy.sh
@@ -28,4 +28,13 @@ fi
 
 source /opt/ros/${ROS_DISTRO}/setup.sh
 colcon build --packages-up-to ${ROS_PACKAGES} --event-handlers=console_cohesion+ --symlink-install --mixin ccache
-echo ${ROS_PACKAGES} | xargs -n1 echo | xargs -I{} run-clang-tidy -j 4 -fix -p ./build/{} ${PWD}/src/.*
+echo ${ROS_PACKAGES} |
+    xargs -n1 echo |
+    # NOTE: `-Wno-gnu-zero-variadic-macro-arguments` is needed due to
+    # https://github.com/google/googletest/issues/2650, fixed in 1.11 but not backported to 1.10.
+    xargs -I{} run-clang-tidy \
+        -j=4 \
+        -fix \
+        -extra-arg='-Wno-gnu-zero-variadic-macro-arguments' \
+        -p=./build/{} \
+        ${PWD}/src/.*


### PR DESCRIPTION
### Proposed changes

This allows running clang-tidy with googletest 1.10 and avoids the unrecognized argument error in GCC 9.4 on the armhf platform.

Closes #389.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

Attempt to fix https://build.ros.org/job/Nbin_ufhf_uFhf__beluga__ubuntu_focal_armhf__binary/9/consoleFull.
