### PR TITLE
Add SO3 and SE3 support for multivariate normal distribution

### DIFF
--- a/beluga/include/beluga/random/multivariate_distribution_traits.hpp
+++ b/beluga/include/beluga/random/multivariate_distribution_traits.hpp
@@ -17,6 +17,8 @@
 
 #include <Eigen/Core>
 #include <sophus/se2.hpp>
+#include <sophus/se3.hpp>
+#include <sophus/so3.hpp>
 
 /**
  * \file
@@ -107,6 +109,58 @@ struct multivariate_distribution_traits<T, std::enable_if_t<std::is_base_of_v<So
   /// Convert from vector to result representation.
   [[nodiscard]] static constexpr result_type from_vector(const vector_type& v) {
     return {Sophus::SO2<scalar_type>::exp(v.z()), v.head(2)};
+  }
+};
+
+/// Specialization for types derived from Sophus::SO3Base.
+template <class T>
+struct multivariate_distribution_traits<T, std::enable_if_t<std::is_base_of_v<Sophus::SO3Base<T>, T>>> {
+  /// The scalar type.
+  using scalar_type = typename T::Scalar;
+
+  /// The result type representation.
+  using result_type = Sophus::SO3<scalar_type>;
+
+  /// The vector type.
+  using vector_type = typename Eigen::Matrix<scalar_type, 3, 1>;
+
+  /// The covariance matrix type.
+  using covariance_type = typename Eigen::Matrix<scalar_type, 3, 3>;
+
+  /// Convert from result to vector representation.
+  [[nodiscard]] static constexpr vector_type to_vector(const result_type& t) { return t.log(); }
+
+  /// Convert from vector to result representation.
+  [[nodiscard]] static constexpr result_type from_vector(const vector_type& v) {
+    return Sophus::SO3<scalar_type>::exp(v);
+  }
+};
+
+/// Specialization for types derived from Sophus::SE3Base.
+template <class T>
+struct multivariate_distribution_traits<T, std::enable_if_t<std::is_base_of_v<Sophus::SE3Base<T>, T>>> {
+  /// The scalar type.
+  using scalar_type = typename T::Scalar;
+
+  /// The result type representation.
+  using result_type = Sophus::SE3<scalar_type>;
+
+  /// The vector type.
+  using vector_type = typename Eigen::Matrix<scalar_type, 6, 1>;
+
+  /// The covariance matrix type.
+  using covariance_type = typename Eigen::Matrix<scalar_type, 6, 6>;
+
+  /// Convert from result to vector representation.
+  [[nodiscard]] static constexpr vector_type to_vector(const result_type& t) {
+    vector_type v;
+    v << t.translation(), t.so3().log();
+    return v;
+  }
+
+  /// Convert from vector to result representation.
+  [[nodiscard]] static constexpr result_type from_vector(const vector_type& v) {
+    return result_type{Sophus::SO3<scalar_type>::exp(v.tail(3)), v.head(3)};
   }
 };
 

--- a/beluga/include/beluga/random/multivariate_distribution_traits.hpp
+++ b/beluga/include/beluga/random/multivariate_distribution_traits.hpp
@@ -132,6 +132,10 @@ struct multivariate_distribution_traits<T, std::enable_if_t<std::is_base_of_v<So
 
   /// Convert from vector to result representation.
   [[nodiscard]] static constexpr result_type from_vector(const vector_type& v) {
+    // Projecting a Gaussian through the exponential map is not exactly correct.
+    // Rotations in Lie groups don't have infinite support, making the term 'normal' distribution incorrect.
+    // This approach follows the SO2/SE2 method, facing similar issues in 3D.
+    // For small covariances, the resulting rotations in SO3 approximate a normal distribution.
     return Sophus::SO3<scalar_type>::exp(v);
   }
 };
@@ -160,6 +164,10 @@ struct multivariate_distribution_traits<T, std::enable_if_t<std::is_base_of_v<So
 
   /// Convert from vector to result representation.
   [[nodiscard]] static constexpr result_type from_vector(const vector_type& v) {
+    // Projecting a Gaussian through the exponential map is not exactly correct.
+    // Rotations in Lie groups don't have infinite support, making the term 'normal' distribution incorrect.
+    // This approach follows the SO2/SE2 method, facing similar issues in 3D.
+    // For small covariances, the resulting rotations in SO3 approximate a normal distribution.
     return result_type{Sophus::SO3<scalar_type>::exp(v.tail(3)), v.head(3)};
   }
 };

--- a/beluga/test/beluga/random/test_multivariate_normal_distribution.cpp
+++ b/beluga/test/beluga/random/test_multivariate_normal_distribution.cpp
@@ -128,4 +128,27 @@ TEST(MultivariateNormalDistribution, SE2Element) {
   ASSERT_NEAR(mean.translation()(1), expected_mean.translation()(1), kTolerance);
 }
 
+TEST(MultivariateNormalDistribution, SO3Element) {
+  auto generator = std::mt19937{std::random_device()()};
+  auto expected_mean = Sophus::SO3d::exp(Eigen::Vector3d{0.5, 1.0, 1.5});
+  auto distribution = beluga::MultivariateNormalDistribution{expected_mean, Eigen::Matrix3d::Zero()};
+  auto mean = distribution(generator);
+  ASSERT_NEAR(mean.log()(0), expected_mean.log()(0), 0.001);
+  ASSERT_NEAR(mean.log()(1), expected_mean.log()(1), 0.001);
+  ASSERT_NEAR(mean.log()(2), expected_mean.log()(2), 0.001);
+}
+
+TEST(MultivariateNormalDistribution, SE3Element) {
+  auto generator = std::mt19937{std::random_device()()};
+  auto expected_mean = Sophus::SE3d{Sophus::SO3d::exp(Eigen::Vector3d{0.5, 1.0, 1.5}), Eigen::Vector3d{1.0, 2.0, 3.0}};
+  auto distribution = beluga::MultivariateNormalDistribution{expected_mean, Eigen::Matrix<double, 6, 6>::Zero()};
+  auto mean = distribution(generator);
+  ASSERT_NEAR(mean.log()(0), expected_mean.log()(0), 0.001);
+  ASSERT_NEAR(mean.log()(1), expected_mean.log()(1), 0.001);
+  ASSERT_NEAR(mean.log()(2), expected_mean.log()(2), 0.001);
+  ASSERT_NEAR(mean.translation()(0), expected_mean.translation()(0), 0.001);
+  ASSERT_NEAR(mean.translation()(1), expected_mean.translation()(1), 0.001);
+  ASSERT_NEAR(mean.translation()(2), expected_mean.translation()(2), 0.001);
+}
+
 }  // namespace


### PR DESCRIPTION
### Proposed changes
Adds support for SE3 and SO3 elements in multivariate normal distribution.
Closes #398. 

# NOTE:
Rotations in Lie groups don't have infinite support, and thus the term 'normal' distribution is inherently incorrect.
This approach just follows the `SO2/SE2` approach which faces the same problems as the 3D case.

See some analysis below on how the resulting rotations in SO3 distribute close to normally  for reasonably small covariances:

The plot below shows KDE histograms and Q-Q plots for a diagonal covariance matrix of 
```
{1e-2, 1e-2, 1e-2}
```
and drawing 1000 samples using the approach that was implemented in this PR.

![image](https://github.com/Ekumen-OS/beluga/assets/53626539/30923cf0-5d6e-4e6a-b8aa-8c14b4ff190f)

Running the [shapiro](https://en.wikipedia.org/wiki/Shapiro%E2%80%93Wilk_test) test shows that the rotation components of the samples seem drawn from a normal distribution with a `p-value` of 0.03.

Note the difference with a very big covariance matrix of 10 in all axes.
![image](https://github.com/Ekumen-OS/beluga/assets/53626539/4e7257e9-e296-4702-bc27-3408070496a6)

This setup fails the shapiro test completely.

All of this to say, that expanding to SE3 has the same caveats as the SE2 version, and thus this seems like a reasonable approach to generating monomodal distributions in SO3 and SO2 when under reasonably controlled situations (reasonable covariances).

Also, this previous dicussion is worth taking a look:
https://github.com/Ekumen-OS/beluga/pull/298#discussion_r1468925250

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)

