### PR TITLE
Add planar 3D support for `DifferentialDriveModel`

### DIFF
--- a/beluga/include/beluga/3d_embedding.hpp
+++ b/beluga/include/beluga/3d_embedding.hpp
@@ -1,0 +1,36 @@
+// Copyright 2024 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BELUGA_3D_EMBEDDING_HPP
+#define BELUGA_3D_EMBEDDING_HPP
+
+#include <sophus/se2.hpp>
+#include <sophus/se3.hpp>
+
+namespace beluga {
+
+/// Transforms a SE3 transform into a SE2 transform, by flattening the Z axis.
+inline Sophus::SE2d To2d(const Sophus::SE3d& tf) {
+  return Sophus::SE2d{tf.angleZ(), tf.translation().head<2>()};
+}
+
+/// Embed a SE2 transform into 3D space with zero Z translation and only rotation about the Z axis.
+inline Sophus::SE3d To3d(const Sophus::SE2d& tf) {
+  return Sophus::SE3d{
+      Sophus::SO3d::rotZ(tf.so2().log()), Eigen::Vector3d{tf.translation().x(), tf.translation().y(), 0.0}};
+}
+
+}  // namespace beluga
+
+#endif

--- a/beluga/include/beluga/motion/stationary_model.hpp
+++ b/beluga/include/beluga/motion/stationary_model.hpp
@@ -15,10 +15,8 @@
 #ifndef BELUGA_MOTION_STATIONARY_MODEL_HPP
 #define BELUGA_MOTION_STATIONARY_MODEL_HPP
 
-#include <optional>
 #include <random>
 #include <tuple>
-#include <type_traits>
 
 #include <beluga/type_traits/tuple_traits.hpp>
 

--- a/beluga/test/beluga/CMakeLists.txt
+++ b/beluga/test/beluga/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(
   sensor/test_landmark_sensor_model.cpp
   sensor/test_likelihood_field_model.cpp
   sensor/test_ndt_model.cpp
+  test_3d_embedding.cpp
   test_primitives.cpp
   test_spatial_hash.cpp
   testing/test_sophus_matchers.cpp

--- a/beluga/test/beluga/test_3d_embedding.cpp
+++ b/beluga/test/beluga/test_3d_embedding.cpp
@@ -1,0 +1,70 @@
+// Copyright 2024 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <beluga/3d_embedding.hpp>
+#include <sophus/se2.hpp>
+#include <sophus/se3.hpp>
+
+using Sophus::SE2d;
+using Sophus::SE3d;
+using Sophus::SO2d;
+using Sophus::SO3d;
+namespace beluga {
+
+TEST(Embed3DTests, Se3ToSe2) {
+  {
+    const auto identity_2d = SE2d{};
+    const auto identity_3d = SE3d{};
+    ASSERT_TRUE(identity_2d.matrix().isApprox(To2d(identity_3d).matrix()));
+  }
+  {
+    const auto rotation_about_z_2d = SE2d::rot(0.5);
+    const auto rotation_about_z_3d = SE3d::rotZ(0.5);
+    ASSERT_TRUE(rotation_about_z_2d.matrix().isApprox(To2d(rotation_about_z_3d).matrix()));
+  }
+  {
+    const auto identity_2d = SE2d{};
+    const auto rotation_about_x_3d = SE3d::rotX(0.5);
+    ASSERT_TRUE(identity_2d.matrix().isApprox(To2d(rotation_about_x_3d).matrix()));
+  }
+  {
+    const auto identity_2d = SE2d{};
+    const auto rotation_about_y_3d = SE3d::rotY(0.5);
+    ASSERT_TRUE(identity_2d.matrix().isApprox(To2d(rotation_about_y_3d).matrix()));
+  }
+  {
+    const auto translation_3d = SE3d{Sophus::SO3d{}, Eigen::Vector3d{1, 2, 4}};
+    ASSERT_TRUE(To2d(translation_3d).translation().isApprox(Eigen::Vector2d{1, 2}));
+  }
+}
+
+TEST(Embed3DTests, Se2ToSe3) {
+  {
+    const auto identity_3d = SE3d{};
+    const auto identity_2d = SE2d{};
+    ASSERT_TRUE(To3d(identity_2d).matrix().isApprox(identity_3d.matrix()));
+  }
+  {
+    const auto rotation_about_z_3d = SE3d::rotZ(0.5);
+    const auto rotation_about_z_2d = SE2d::rot(0.5);
+    ASSERT_TRUE(To3d(rotation_about_z_2d).matrix().isApprox(rotation_about_z_3d.matrix()));
+  }
+  {
+    const auto translation_2d = SE2d{0, Eigen::Vector2d{1, 2}};
+    ASSERT_TRUE(To3d(translation_2d).translation().isApprox(Eigen::Vector3d{1, 2, 0}));
+  }
+}
+
+}  // namespace beluga

--- a/beluga_amcl/include/beluga_amcl/ndt_amcl_node.hpp
+++ b/beluga_amcl/include/beluga_amcl/ndt_amcl_node.hpp
@@ -80,15 +80,15 @@ using NdtAmcl = beluga::Amcl<
 using NdtAmclVariant = std::variant<
     NdtAmcl<beluga::StationaryModel, std::execution::parallel_policy>,            //
     NdtAmcl<beluga::StationaryModel, std::execution::sequenced_policy>,           //
-    NdtAmcl<beluga::DifferentialDriveModel, std::execution::parallel_policy>,     //
-    NdtAmcl<beluga::DifferentialDriveModel, std::execution::sequenced_policy>,    //
+    NdtAmcl<beluga::DifferentialDriveModel2d, std::execution::parallel_policy>,   //
+    NdtAmcl<beluga::DifferentialDriveModel2d, std::execution::sequenced_policy>,  //
     NdtAmcl<beluga::OmnidirectionalDriveModel, std::execution::parallel_policy>,  //
     NdtAmcl<beluga::OmnidirectionalDriveModel, std::execution::sequenced_policy>  //
     >;
 
 /// Supported motion models.
 using MotionModelVariant =
-    std::variant<beluga::DifferentialDriveModel, beluga::StationaryModel, beluga::OmnidirectionalDriveModel>;
+    std::variant<beluga::DifferentialDriveModel2d, beluga::StationaryModel, beluga::OmnidirectionalDriveModel>;
 
 /// Supported execution policies.
 using ExecutionPolicyVariant = std::variant<std::execution::sequenced_policy, std::execution::parallel_policy>;

--- a/beluga_ros/include/beluga_ros/amcl.hpp
+++ b/beluga_ros/include/beluga_ros/amcl.hpp
@@ -92,7 +92,7 @@ class Amcl {
 
   /// Motion model variant type for runtime selection support.
   using motion_model_variant = std::variant<
-      beluga::DifferentialDriveModel,     //
+      beluga::DifferentialDriveModel2d,   //
       beluga::OmnidirectionalDriveModel,  //
       beluga::StationaryModel>;
 

--- a/beluga_system_tests/test/test_system.cpp
+++ b/beluga_system_tests/test/test_system.cpp
@@ -157,7 +157,7 @@ void particle_filter_test(
 // ****************************************************************************
 // Motion model variants.
 // ****************************************************************************
-using MotionModel = std::variant<beluga::DifferentialDriveModel>;
+using MotionModel = std::variant<beluga::DifferentialDriveModel2d>;
 
 auto get_motion_models() {
   return std::vector<MotionModel>{


### PR DESCRIPTION
### Proposed changes
Provides functionality to use SE3d states for the Differential Drive model, by performing some Z flattening and using the underlying 2D motion model.
Closes #399 .

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)


### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)

