### PR TITLE
Change scalar `beluga::estimate()` to yield variance

### DIFF
--- a/beluga/include/beluga/algorithm/estimation.hpp
+++ b/beluga/include/beluga/algorithm/estimation.hpp
@@ -171,9 +171,9 @@ std::pair<Sophus::SE2<Scalar>, Sophus::Matrix3<Scalar>> estimate(Poses&& poses, 
   return std::pair{estimated_pose, covariance_matrix};
 }
 
-/// Computes mean and standard deviation of a range of weighted scalars.
+/// Computes mean and variance of a range of weighted scalars.
 /**
- * Given a range of scalars, computes the scalar mean and standard deviation.
+ * Given a range of scalars, computes the scalar mean and variance.
  *
  * \tparam Scalars A [sized range](https://en.cppreference.com/w/cpp/ranges/sized_range) type whose
  *  value type is `std::vector<Scalar>`.
@@ -182,7 +182,7 @@ std::pair<Sophus::SE2<Scalar>, Sophus::Matrix3<Scalar>> estimate(Poses&& poses, 
  * \tparam Scalar The scalar value type of the given range of Scalars.
  * \param scalars Range of scalars.
  * \param weights Range of weights.
- * \return The estimated mean and its standard deviation.
+ * \return The estimated mean and variance.
  */
 template <
     class Scalars,
@@ -207,10 +207,10 @@ std::pair<Scalar, Scalar> estimate(Scalars&& scalars, Weights&& weights) {
   const auto number_of_non_zero_weights =
       static_cast<Scalar>(ranges::count_if(weights_view, [&](auto weight) { return weight > 0; }));
 
-  const Scalar weighted_sd =
-      std::sqrt(weighted_squared_deviations * number_of_non_zero_weights / (number_of_non_zero_weights - 1));
+  const Scalar weighted_variance =
+      weighted_squared_deviations * number_of_non_zero_weights / (number_of_non_zero_weights - 1);
 
-  return std::pair{weighted_mean, weighted_sd};
+  return std::pair{weighted_mean, weighted_variance};
 }
 
 /// Returns a pair consisting of the estimated mean pose and its covariance.

--- a/beluga/test/beluga/algorithm/test_estimation.cpp
+++ b/beluga/test/beluga/algorithm/test_estimation.cpp
@@ -229,26 +229,28 @@ TEST_F(PoseCovarianceEstimation, RandomWalkWithSmoothRotationAndNonUniformWeight
   ASSERT_THAT(covariance.col(2).eval(), Vector3Near({0.0000, 0.0000, 0.0855}, kTolerance));
 }
 
-struct MeanStandardDeviationEstimation : public testing::Test {};
+struct ScalarEstimation : public testing::Test {};
 
-TEST_F(MeanStandardDeviationEstimation, UniformWeightOverload) {
-  // Mean and standard deviation estimation with uniform weights.
+TEST_F(ScalarEstimation, UniformWeightOverload) {
+  // Mean and variance estimation with uniform weights.
   const auto states = std::vector{0.0, 1.0, 1.0, 2.0, 2.0, 3.0, 4.0, 4.0, 5.0, 5.0, 6.0, 7.0, 7.0, 8.0, 9.0};
   const auto weights = std::vector(states.size(), 1.0);
-  const auto estimation = beluga::estimate(states, weights);
+  const auto [mean, variance] = beluga::estimate(states, weights);
+  const auto standard_deviation = std::sqrt(variance);
   constexpr double kTolerance = 0.001;
-  ASSERT_NEAR(std::get<0>(estimation), 4.266, kTolerance);
-  ASSERT_NEAR(std::get<1>(estimation), 2.763, kTolerance);
+  ASSERT_NEAR(mean, 4.266, kTolerance);
+  ASSERT_NEAR(standard_deviation, 2.763, kTolerance);
 }
 
-TEST_F(MeanStandardDeviationEstimation, NonUniformWeightOverload) {
-  // Mean and standard deviation estimation with non-uniform weights.
+TEST_F(ScalarEstimation, NonUniformWeightOverload) {
+  // Mean and variance estimation with non-uniform weights.
   const auto states = std::vector{0.0, 1.0, 1.0, 2.0, 2.0, 3.0, 4.0, 4.0, 5.0, 5.0, 6.0, 7.0, 7.0, 8.0, 9.0};
   const auto weights = std::vector{0.1, 0.15, 0.15, 0.3, 0.3, 0.4, 0.8, 0.8, 0.4, 0.4, 0.35, 0.3, 0.3, 0.15, 0.1};
-  const auto estimation = beluga::estimate(states, weights);
+  const auto [mean, variance] = beluga::estimate(states, weights);
+  const auto standard_deviation = std::sqrt(variance);
   constexpr double kTolerance = 0.001;
-  ASSERT_NEAR(std::get<0>(estimation), 4.300, kTolerance);
-  ASSERT_NEAR(std::get<1>(estimation), 2.026, kTolerance);
+  ASSERT_NEAR(mean, 4.300, kTolerance);
+  ASSERT_NEAR(standard_deviation, 2.026, kTolerance);
 }
 
 }  // namespace


### PR DESCRIPTION
### Proposed changes

This isn't as much of a fix as it is a minor API contract correction for consistency with the rest. Every other `beluga::estimate` overload trades on variances, but the scalar one introduced in #340 didn't. This patch amends that.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)
