### PR TITLE
Polish `beluga_tutorial` nomenclature for consistency

### DIFF
--- a/beluga_tutorial/params/tutorial.yaml
+++ b/beluga_tutorial/params/tutorial.yaml
@@ -1,14 +1,13 @@
 map_size: 100 # Size of the map in [m]
-number_of_doors: 15
 number_of_particles: 300 # Fixed number of particles
 number_of_cycles: 100
 initial_position: 0.0 #[m]
-initial_position_sd: 20.0
+initial_position_sigma: 20.0
 dt: 1.0 #[s]
 velocity: 1.0 #[m/s]
-translation_sd: 1.0
+motion_model_sigma: 1.0 #[m/s]
 sensor_range: 3.0 # Sensor range of view in [m]
-sensor_model_sigma: 1.0
+sensor_model_sigma: 1.0 #[m]
 min_particle_weight: 0.08
 record_path: "./record.yaml"
 


### PR DESCRIPTION
### Proposed changes

Precisely what the title says. This patch updates `beluga_tutorial` comments and variable names to have a consistent nomenclature.

Depends on #405. 

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [x] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [ ] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)