### PR TITLE
Remove 'with' statement in CI workflow

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -62,8 +62,6 @@ jobs:
              export PIP_BREAK_SYSTEM_PACKAGES=1
              pip install pre-commit==2.20.0 \
              h5py==3.11.0
-        with:
-          cache: pip
 
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
### Proposed changes
Ci pipeline is broken in master because of a `with` clause in the wrong step. 
Why did this get through CI? @nahueespinosa FYI

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)

