### PR TITLE
Drop Ubuntu user from Noble containers

### DIFF
--- a/docker/images/jazzy/Dockerfile
+++ b/docker/images/jazzy/Dockerfile
@@ -67,6 +67,9 @@ RUN perf help || ( \
 ARG USER=developer
 ARG GROUP=ekumen
 
+# Drop ubuntu user to avoid fixuid clashes.
+RUN deluser ubuntu
+
 RUN addgroup --gid 1001 $GROUP \
   && adduser --uid 1001 --ingroup $GROUP --home /home/$USER --shell /bin/sh --disabled-password --gecos "" $USER \
   && adduser $USER sudo \

--- a/docker/images/rolling/Dockerfile
+++ b/docker/images/rolling/Dockerfile
@@ -68,6 +68,9 @@ RUN perf help || ( \
 ARG USER=developer
 ARG GROUP=ekumen
 
+# Drop ubuntu user to avoid fixuid clashes.
+RUN deluser ubuntu
+
 RUN addgroup --gid 1001 $GROUP \
   && adduser --uid 1001 --ingroup $GROUP --home /home/$USER --shell /bin/sh --disabled-password --gecos "" $USER \
   && adduser $USER sudo \


### PR DESCRIPTION
### Proposed changes

This patch removes the `ubuntu` user from Noble containers, in order to avoid `fixuid` from clashing with it. Other than system level users, there should only be a `developer` user in development containers.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [ ] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)
