### PR TITLE
Add a reminder in docs/installation: source the environment

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -103,6 +103,18 @@ colcon build --packages-up-to beluga_example --cmake-args -DBUILD_TESTING=OFF
 
 ::::
 
+After building, don't forget to source the environment:
+
+::::{tab-set}
+
+:::{tab-item} Ubuntu
+```bash
+source install/setup.bash
+```
+:::
+
+::::
+
 Alternatively, for ROS 1 distributions, you may use `catkin_make_isolated` instead:
 
 ::::{tab-set}

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -103,18 +103,6 @@ colcon build --packages-up-to beluga_example --cmake-args -DBUILD_TESTING=OFF
 
 ::::
 
-After building, don't forget to source the environment:
-
-::::{tab-set}
-
-:::{tab-item} Ubuntu
-```bash
-source install/setup.bash
-```
-:::
-
-::::
-
 Alternatively, for ROS 1 distributions, you may use `catkin_make_isolated` instead:
 
 ::::{tab-set}
@@ -122,6 +110,24 @@ Alternatively, for ROS 1 distributions, you may use `catkin_make_isolated` inste
 :::{tab-item} Ubuntu
 ```bash
 catkin_make_isolated --only-pkg-with-deps beluga_example --install --cmake-args -DBUILD_TESTING=OFF
+```
+:::
+
+::::
+
+After building, don't forget to source the environment:
+
+::::{tab-set}
+
+:::{tab-item} ROS 2
+```bash
+source install/setup.bash
+```
+:::
+
+:::{tab-item} ROS 1
+```bash
+source devel/setup.bash
 ```
 :::
 


### PR DESCRIPTION
### Proposed changes

I added a little reminder about sourcing the environment after building the workspace in docs/installation.md.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [x] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [ ] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] All commits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

I noticed that `DEVELOPING.md` is not in the documentation webpage. Is there any reason for this? If not, I could add it.