### PR TITLE
Fix memory usage problem in 2D likelihood sensor model

### DIFF
--- a/beluga/test/beluga/sensor/test_likelihood_field_model.cpp
+++ b/beluga/test/beluga/sensor/test_likelihood_field_model.cpp
@@ -54,13 +54,9 @@ TEST(LikelihoodFieldModel, LikelihoodField) {
   const auto params = beluga::LikelihoodFieldModelParam{2.0, 20.0, 0.5, 0.5, 0.2};
   auto sensor_model = UUT{params, grid};
 
-  // the likelihood field model includes an optimization that stores the likelihood elevated to the cube
-  auto expected_cubed_likelihood =
-      expected_likelihood_field | ranges::views::transform([](auto v) { return v * v * v; }) | ranges::to<std::vector>;
-
   ASSERT_THAT(
       sensor_model.likelihood_field().data(),
-      testing::Pointwise(testing::DoubleNear(0.003), expected_cubed_likelihood));
+      testing::Pointwise(testing::DoubleNear(0.003), expected_likelihood_field));
 }
 
 TEST(LikelihoodFieldModel, ImportanceWeight) {


### PR DESCRIPTION
### Proposed changes

Initially, this changes likelihood storage from double to float, inspired by https://github.com/ros-navigation/navigation2/pull/4426 . 

More importantly, this fixes a bug in the `make_likelihood_field()` function which causes memory footprint to go through the roof for large maps.

Basically, because we applied the `max_obstacle_distance` threshold **before** calculating the distance map,  for distances larger than  `max_obstacle_distance`  the priority queue in `nearest_obstacle_distance_map()` was processing  the map in a random fashion instead of the "advancing wavefront" that the algorithm is meant to do. This caused the priority queue length to be at least as large as the map itself  and even larger for some maps.

This change does not affect either the accuracy or the average CPU usage.

##### Before 

6000x6000 pixels map @ 0.05 cm/px (300m x 300m)

![Screenshot from 2024-09-23 09-45-21](https://github.com/user-attachments/assets/0afb3683-9a30-4bab-b64d-c471afa60a9a)

##### After

Same 6000x6000 pixels map @ 0.05 cm/px (300m x 300m)

![Screenshot from 2024-09-23 09-45-28](https://github.com/user-attachments/assets/100fc57a-65d5-4051-a7f0-8cc514d86187)

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 **Breaking change!** _Explain why a non-backwards compatible change is necessary or remove this line entirely if not applicable._

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

_Anything worth mentioning to the reviewers._
