### PR TITLE
Fix Beluga documentation style

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -142,6 +142,7 @@ jobs:
         with:
           name: docs
           path: ./docs/_build/html/
+          include-hidden-files: true
           retention-days: 7
 
   deploy-docs:


### PR DESCRIPTION
### Proposed changes

`actions/upload-artifact` 4.4.0 wrecked our documentation, as it silently stopped uploading hidden files by default :man_facepalming:. This patch amends this.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [x] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [ ] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)