### PR TITLE
Rewrite take_evenly view

### DIFF
--- a/beluga/test/beluga/views/test_take_evenly.cpp
+++ b/beluga/test/beluga/views/test_take_evenly.cpp
@@ -15,84 +15,160 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <list>
 #include <vector>
 
 #include <range/v3/range/conversion.hpp>
 #include <range/v3/view/iota.hpp>
+#include <range/v3/view/reverse.hpp>
 
 #include "beluga/views/take_evenly.hpp"
 
 namespace {
 
+TEST(TakeEvenlyView, ConceptChecksFromContiguousRange) {
+  auto input = std::array{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  auto output = beluga::views::take_evenly(input, 2);
+
+  static_assert(ranges::common_range<decltype(input)>);
+  static_assert(!ranges::common_range<decltype(output)>);
+
+  static_assert(!ranges::viewable_range<decltype(input)>);
+  static_assert(ranges::viewable_range<decltype(output)>);
+
+  static_assert(ranges::forward_range<decltype(input)>);
+  static_assert(ranges::forward_range<decltype(output)>);
+
+  static_assert(ranges::sized_range<decltype(input)>);
+  static_assert(ranges::sized_range<decltype(output)>);
+
+  static_assert(ranges::bidirectional_range<decltype(input)>);
+  static_assert(ranges::bidirectional_range<decltype(output)>);
+
+  static_assert(ranges::random_access_range<decltype(input)>);
+  static_assert(ranges::random_access_range<decltype(output)>);
+
+  static_assert(ranges::contiguous_range<decltype(input)>);
+  static_assert(!ranges::contiguous_range<decltype(output)>);
+
+  static_assert(ranges::range<decltype(output)>);
+  static_assert(ranges::semiregular<decltype(output)>);
+  static_assert(ranges::enable_view<decltype(output)>);
+}
+
+TEST(TakeEvenlyView, ConceptChecksFromBidirectionalRange) {
+  auto input = std::list{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  auto output = beluga::views::take_evenly(input, 2);
+
+  static_assert(ranges::forward_range<decltype(input)>);
+  static_assert(ranges::forward_range<decltype(output)>);
+
+  static_assert(ranges::bidirectional_range<decltype(input)>);
+  static_assert(ranges::bidirectional_range<decltype(output)>);
+
+  static_assert(!ranges::random_access_range<decltype(input)>);
+  static_assert(!ranges::random_access_range<decltype(output)>);
+}
+
 TEST(TakeEvenlyView, NoElementsTakeZero) {
   const auto input = std::vector<int>{};
-  const auto output = input | beluga::views::take_evenly(0) | ranges::to<std::vector>;
+  auto output = input | beluga::views::take_evenly(0);
   ASSERT_EQ(output.size(), 0);
+  ASSERT_EQ(ranges::to<std::vector>(output).size(), 0);
 }
 
 TEST(TakeEvenlyView, NoElements) {
   const auto input = std::vector<int>{};
-  const auto output = input | beluga::views::take_evenly(1) | ranges::to<std::vector>;
+  auto output = input | beluga::views::take_evenly(1);
   ASSERT_EQ(output.size(), 0);
+  ASSERT_EQ(ranges::to<std::vector>(output).size(), 0);
 }
 
 TEST(TakeEvenlyView, TakeZero) {
   const auto input = std::vector<int>{1, 2, 3, 4};
-  const auto output = input | beluga::views::take_evenly(0) | ranges::to<std::vector>;
+  auto output = input | beluga::views::take_evenly(0);
   ASSERT_EQ(output.size(), 0);
+  ASSERT_EQ(ranges::to<std::vector>(output).size(), 0);
 }
 
 TEST(TakeEvenlyView, TakeOne) {
   const auto input = std::vector<int>{1, 2, 3, 4};
-  const auto output = input | beluga::views::take_evenly(1) | ranges::to<std::vector>;
-  ASSERT_THAT(output, testing::ElementsAre(1));
+  auto output = input | beluga::views::take_evenly(1);
+  ASSERT_EQ(output.size(), 1);
+  ASSERT_THAT(ranges::to<std::vector>(output), testing::ElementsAre(1));
 }
 
 TEST(TakeEvenlyView, TakeAll) {
   const auto input = std::vector<int>{1, 2, 3, 4};
-  const auto output = input | beluga::views::take_evenly(10) | ranges::to<std::vector>;
-  ASSERT_THAT(output, testing::ElementsAre(1, 2, 3, 4));
+  auto output = input | beluga::views::take_evenly(10);
+  ASSERT_EQ(output.size(), 4);
+  ASSERT_THAT(ranges::to<std::vector>(output), testing::ElementsAre(1, 2, 3, 4));
 }
 
 TEST(TakeEvenlyView, TakeTwoFromFour) {
   const auto input = std::vector<int>{1, 2, 3, 4};
-  const auto output = input | beluga::views::take_evenly(2) | ranges::to<std::vector>;
-  ASSERT_THAT(output, testing::ElementsAre(1, 4));
+  auto output = input | beluga::views::take_evenly(2);
+  ASSERT_EQ(output.size(), 2);
+  ASSERT_THAT(ranges::to<std::vector>(output), testing::ElementsAre(1, 4));
 }
 
 TEST(TakeEvenlyView, TakeThreeFromFive) {
   const auto input = std::vector<int>{1, 2, 3, 4, 5};
-  const auto output = input | beluga::views::take_evenly(3) | ranges::to<std::vector>;
-  ASSERT_THAT(output, testing::ElementsAre(1, 3, 5));
+  auto output = input | beluga::views::take_evenly(3);
+  ASSERT_EQ(output.size(), 3);
+  ASSERT_THAT(ranges::to<std::vector>(output), testing::ElementsAre(1, 3, 5));
 }
 
 TEST(TakeEvenlyView, TakeThreeFromSix) {
   const auto input = std::vector<int>{1, 2, 3, 4, 5, 6};
-  const auto output = input | beluga::views::take_evenly(3) | ranges::to<std::vector>;
-  ASSERT_THAT(output, testing::ElementsAre(1, 4, 6));
+  auto output = input | beluga::views::take_evenly(3);
+  ASSERT_EQ(output.size(), 3);
+  ASSERT_THAT(ranges::to<std::vector>(output), testing::ElementsAre(1, 4, 6));
 }
 
 TEST(TakeEvenlyView, TakeThreeFromNine) {
   const auto input = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9};
-  const auto output = input | beluga::views::take_evenly(3) | ranges::to<std::vector>;
-  ASSERT_THAT(output, testing::ElementsAre(1, 5, 9));
+  auto output = input | beluga::views::take_evenly(3);
+  ASSERT_EQ(output.size(), 3);
+  ASSERT_THAT(ranges::to<std::vector>(output), testing::ElementsAre(1, 5, 9));
 }
 
 TEST(TakeEvenlyView, TakeThreeFromFour) {
   const auto input = std::vector<int>{1, 2, 3, 4};
-  const auto output = input | beluga::views::take_evenly(3) | ranges::to<std::vector>;
-  ASSERT_THAT(output, testing::ElementsAre(1, 3, 4));
+  auto output = input | beluga::views::take_evenly(3);
+  ASSERT_EQ(output.size(), 3);
+  ASSERT_THAT(ranges::to<std::vector>(output), testing::ElementsAre(1, 3, 4));
 }
 
 TEST(TakeEvenlyView, TakeSixFromTen) {
   const auto input = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  const auto output = input | beluga::views::take_evenly(6) | ranges::to<std::vector>;
-  ASSERT_THAT(output, testing::ElementsAre(1, 3, 5, 7, 9, 10));
+  auto output = input | beluga::views::take_evenly(6);
+  ASSERT_EQ(output.size(), 6);
+  ASSERT_THAT(ranges::to<std::vector>(output), testing::ElementsAre(1, 3, 5, 7, 9, 10));
 }
 
 TEST(TakeEvenlyView, TakeFromGenerator) {
-  const auto output = ranges::views::iota(1, 6) | beluga::views::take_evenly(3) | ranges::to<std::vector>;
-  ASSERT_THAT(output, testing::ElementsAre(1, 3, 5));
+  auto output = ranges::views::iota(1, 6) | beluga::views::take_evenly(3);
+  ASSERT_EQ(output.size(), 3);
+  ASSERT_THAT(ranges::to<std::vector>(output), testing::ElementsAre(1, 3, 5));
+}
+
+TEST(TakeEvenlyView, RandomAccess) {
+  const auto input = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9};
+  auto output = input | beluga::views::take_evenly(3);
+  ASSERT_EQ(output.size(), 3);
+  ASSERT_EQ(output[0], 1);
+  ASSERT_EQ(output[1], 5);
+  ASSERT_EQ(output[2], 9);
+}
+
+TEST(TakeEvenlyView, RandomAccessReverse) {
+  const auto input = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9};
+  auto output = input | beluga::views::take_evenly(3) | ranges::views::reverse;
+  ASSERT_EQ(output.size(), 3);
+  ASSERT_EQ(output[0], 9);
+  ASSERT_EQ(output[1], 5);
+  ASSERT_EQ(output[2], 1);
 }
 
 }  // namespace

--- a/beluga/test/beluga/views/test_take_evenly.cpp
+++ b/beluga/test/beluga/views/test_take_evenly.cpp
@@ -27,8 +27,8 @@
 namespace {
 
 TEST(TakeEvenlyView, ConceptChecksFromContiguousRange) {
-  auto input = std::array{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  auto output = beluga::views::take_evenly(input, 2);
+  const auto input = std::array{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  const auto output = beluga::views::take_evenly(input, 2);
 
   static_assert(ranges::common_range<decltype(input)>);
   static_assert(!ranges::common_range<decltype(output)>);
@@ -52,13 +52,12 @@ TEST(TakeEvenlyView, ConceptChecksFromContiguousRange) {
   static_assert(!ranges::contiguous_range<decltype(output)>);
 
   static_assert(ranges::range<decltype(output)>);
-  static_assert(ranges::semiregular<decltype(output)>);
   static_assert(ranges::enable_view<decltype(output)>);
 }
 
 TEST(TakeEvenlyView, ConceptChecksFromBidirectionalRange) {
-  auto input = std::list{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  auto output = beluga::views::take_evenly(input, 2);
+  const auto input = std::list{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  const auto output = beluga::views::take_evenly(input, 2);
 
   static_assert(ranges::forward_range<decltype(input)>);
   static_assert(ranges::forward_range<decltype(output)>);
@@ -72,21 +71,21 @@ TEST(TakeEvenlyView, ConceptChecksFromBidirectionalRange) {
 
 TEST(TakeEvenlyView, NoElementsTakeZero) {
   const auto input = std::vector<int>{};
-  auto output = input | beluga::views::take_evenly(0);
+  const auto output = input | beluga::views::take_evenly(0);
   ASSERT_EQ(output.size(), 0);
   ASSERT_EQ(ranges::to<std::vector>(output).size(), 0);
 }
 
 TEST(TakeEvenlyView, NoElements) {
   const auto input = std::vector<int>{};
-  auto output = input | beluga::views::take_evenly(1);
+  const auto output = input | beluga::views::take_evenly(1);
   ASSERT_EQ(output.size(), 0);
   ASSERT_EQ(ranges::to<std::vector>(output).size(), 0);
 }
 
 TEST(TakeEvenlyView, TakeZero) {
   const auto input = std::vector<int>{1, 2, 3, 4};
-  auto output = input | beluga::views::take_evenly(0);
+  const auto output = input | beluga::views::take_evenly(0);
   ASSERT_EQ(output.size(), 0);
   ASSERT_EQ(ranges::to<std::vector>(output).size(), 0);
 }
@@ -100,49 +99,49 @@ TEST(TakeEvenlyView, TakeOne) {
 
 TEST(TakeEvenlyView, TakeAll) {
   const auto input = std::vector<int>{1, 2, 3, 4};
-  auto output = input | beluga::views::take_evenly(10);
+  const auto output = input | beluga::views::take_evenly(10);
   ASSERT_EQ(output.size(), 4);
   ASSERT_THAT(ranges::to<std::vector>(output), testing::ElementsAre(1, 2, 3, 4));
 }
 
 TEST(TakeEvenlyView, TakeTwoFromFour) {
   const auto input = std::vector<int>{1, 2, 3, 4};
-  auto output = input | beluga::views::take_evenly(2);
+  const auto output = input | beluga::views::take_evenly(2);
   ASSERT_EQ(output.size(), 2);
   ASSERT_THAT(ranges::to<std::vector>(output), testing::ElementsAre(1, 4));
 }
 
 TEST(TakeEvenlyView, TakeThreeFromFive) {
   const auto input = std::vector<int>{1, 2, 3, 4, 5};
-  auto output = input | beluga::views::take_evenly(3);
+  const auto output = input | beluga::views::take_evenly(3);
   ASSERT_EQ(output.size(), 3);
   ASSERT_THAT(ranges::to<std::vector>(output), testing::ElementsAre(1, 3, 5));
 }
 
 TEST(TakeEvenlyView, TakeThreeFromSix) {
   const auto input = std::vector<int>{1, 2, 3, 4, 5, 6};
-  auto output = input | beluga::views::take_evenly(3);
+  const auto output = input | beluga::views::take_evenly(3);
   ASSERT_EQ(output.size(), 3);
   ASSERT_THAT(ranges::to<std::vector>(output), testing::ElementsAre(1, 4, 6));
 }
 
 TEST(TakeEvenlyView, TakeThreeFromNine) {
   const auto input = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9};
-  auto output = input | beluga::views::take_evenly(3);
+  const auto output = input | beluga::views::take_evenly(3);
   ASSERT_EQ(output.size(), 3);
   ASSERT_THAT(ranges::to<std::vector>(output), testing::ElementsAre(1, 5, 9));
 }
 
 TEST(TakeEvenlyView, TakeThreeFromFour) {
   const auto input = std::vector<int>{1, 2, 3, 4};
-  auto output = input | beluga::views::take_evenly(3);
+  const auto output = input | beluga::views::take_evenly(3);
   ASSERT_EQ(output.size(), 3);
   ASSERT_THAT(ranges::to<std::vector>(output), testing::ElementsAre(1, 3, 4));
 }
 
 TEST(TakeEvenlyView, TakeSixFromTen) {
   const auto input = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  auto output = input | beluga::views::take_evenly(6);
+  const auto output = input | beluga::views::take_evenly(6);
   ASSERT_EQ(output.size(), 6);
   ASSERT_THAT(ranges::to<std::vector>(output), testing::ElementsAre(1, 3, 5, 7, 9, 10));
 }
@@ -155,7 +154,7 @@ TEST(TakeEvenlyView, TakeFromGenerator) {
 
 TEST(TakeEvenlyView, RandomAccess) {
   const auto input = std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9};
-  auto output = input | beluga::views::take_evenly(3);
+  const auto output = input | beluga::views::take_evenly(3);
   ASSERT_EQ(output.size(), 3);
   ASSERT_EQ(output[0], 1);
   ASSERT_EQ(output[1], 5);


### PR DESCRIPTION
### Proposed changes

Avoids using a range pipeline to implement the take_evenly view which is not great for compile times.
This implementation also makes it a random access view when the underlying range is random access.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)