### PR TITLE
Clean up NDT implementation and examples

### DIFF
--- a/beluga/include/beluga/algorithm.hpp
+++ b/beluga/include/beluga/algorithm.hpp
@@ -20,6 +20,7 @@
  * \brief Includes all beluga algorithms.
  */
 
+#include <beluga/algorithm/amcl_core.hpp>
 #include <beluga/algorithm/cluster_based_estimation.hpp>
 #include <beluga/algorithm/distance_map.hpp>
 #include <beluga/algorithm/effective_sample_size.hpp>

--- a/beluga/include/beluga/sensor/data/ndt_cell.hpp
+++ b/beluga/include/beluga/sensor/data/ndt_cell.hpp
@@ -33,7 +33,7 @@ namespace beluga {
 
 /// Representation for a cell of a N dimensional NDT cell.
 template <int NDim, typename Scalar = double>
-struct NDTCell {
+struct NdtCell {
   static_assert(std::is_floating_point_v<Scalar>, "Scalar template parameter should be a floating point.");
   /// Number of dimensions of the cell's translation.
   static constexpr int num_dim = NDim;
@@ -46,7 +46,7 @@ struct NDTCell {
 
   /// Get the L2 likelihood at measurement, scaled by d1 and d2. It assumes the measurement is pre-transformed
   /// into the same frame as this cell instance.
-  [[nodiscard]] double likelihood_at(const NDTCell& measurement, double d1 = 1.0, double d2 = 1.0) const {
+  [[nodiscard]] double likelihood_at(const NdtCell& measurement, double d1 = 1.0, double d2 = 1.0) const {
     const Eigen::Vector<Scalar, NDim> error = measurement.mean - mean;
     const double rhs =
         std::exp((-d2 / 2.0) * error.transpose() * (measurement.covariance + covariance).inverse() * error);
@@ -54,36 +54,36 @@ struct NDTCell {
   }
 
   /// Ostream overload mostly for debugging purposes.
-  friend std::ostream& operator<<(std::ostream& os, const NDTCell& cell) {
+  friend std::ostream& operator<<(std::ostream& os, const NdtCell& cell) {
     os << "Mean \n" << cell.mean.transpose() << " \n\nCovariance: \n" << cell.covariance;
     return os;
   }
 
   /// Transform the normal distribution according to tf, both mean and covariance.
-  friend NDTCell operator*(const Sophus::SE2<scalar_type>& tf, const NDTCell& ndt_cell) {
+  friend NdtCell operator*(const Sophus::SE2<scalar_type>& tf, const NdtCell& ndt_cell) {
     static_assert(num_dim == 2, "Cannot transform a non 2D NDT Cell with a SE2 transform.");
     const Eigen::Vector2d uij = tf * ndt_cell.mean;
     const Eigen::Matrix2Xd cov = tf.so2().matrix() * ndt_cell.covariance * tf.so2().matrix().transpose();
-    return NDTCell{uij, cov};
+    return NdtCell{uij, cov};
   }
 
   /// Transform the normal distribution according to tf, both mean and covariance.
-  friend NDTCell operator*(const Sophus::SE3<scalar_type>& tf, const NDTCell& ndt_cell) {
+  friend NdtCell operator*(const Sophus::SE3<scalar_type>& tf, const NdtCell& ndt_cell) {
     static_assert(num_dim == 3, "Cannot transform a non 3D NDT Cell with a SE3 transform.");
     const Eigen::Vector3d uij = tf * ndt_cell.mean;
     const Eigen::Matrix3Xd cov = tf.so3().matrix() * ndt_cell.covariance * tf.so3().matrix().transpose();
-    return NDTCell{uij, cov};
+    return NdtCell{uij, cov};
   }
 };
 
 /// Convenience alias for a 2D NDT cell with double representation.
-using NDTCell2d = NDTCell<2, double>;
+using NdtCell2d = NdtCell<2, double>;
 /// Convenience alias for a 2D NDT cell with float representation.
-using NDTCell2f = NDTCell<2, float>;
+using NdtCell2f = NdtCell<2, float>;
 /// Convenience alias for a 3D NDT cell with double representation.
-using NDTCell3d = NDTCell<3, double>;
+using NdtCell3d = NdtCell<3, double>;
 /// Convenience alias for a 3D NDT cell with float representation.
-using NDTCell3f = NDTCell<3, float>;
+using NdtCell3f = NdtCell<3, float>;
 
 }  // namespace beluga
 

--- a/beluga/test/beluga/sensor/data/test_ndt_cell.cpp
+++ b/beluga/test/beluga/sensor/data/test_ndt_cell.cpp
@@ -32,23 +32,23 @@ Eigen::Matrix2Xd get_diagonal_covariance(double x_var = 0.5, double y_var = 0.8)
 
 }  // namespace
 
-TEST(NDTCellTests, Product) {
+TEST(NdtCellTests, Product) {
   {
-    const NDTCell2d cell{Eigen::Vector2d{1, 2}, get_diagonal_covariance()};
+    const NdtCell2d cell{Eigen::Vector2d{1, 2}, get_diagonal_covariance()};
     const Sophus::SE2d tf{};
     const auto transformed = tf * cell;
     ASSERT_TRUE(cell.mean.isApprox(transformed.mean));
     ASSERT_TRUE(cell.covariance.isApprox(transformed.covariance));
   }
   {
-    const NDTCell2d cell{Eigen::Vector2d{1, 2}, get_diagonal_covariance()};
+    const NdtCell2d cell{Eigen::Vector2d{1, 2}, get_diagonal_covariance()};
     const Sophus::SE2d tf{Sophus::SO2d{}, Eigen::Vector2d{1, 2}};
     const auto transformed = tf * cell;
     ASSERT_TRUE(cell.mean.isApprox(transformed.mean - Eigen::Vector2d{1, 2}));
     ASSERT_TRUE(cell.covariance.isApprox(transformed.covariance));
   }
   {
-    const NDTCell2d cell{Eigen::Vector2d{1, 2}, get_diagonal_covariance()};
+    const NdtCell2d cell{Eigen::Vector2d{1, 2}, get_diagonal_covariance()};
     const Sophus::SE2d tf{Sophus::SO2d{Sophus::Constants<double>::pi() / 2}, Eigen::Vector2d::Zero()};
 
     Eigen::Matrix<double, 2, 2> expected_transformed_cov;
@@ -62,8 +62,8 @@ TEST(NDTCellTests, Product) {
   }
 }
 
-TEST(NDTCellTests, Ostream) {
-  const NDTCell2d cell{Eigen::Vector2d{1, 2}, get_diagonal_covariance()};
+TEST(NdtCellTests, Ostream) {
+  const NdtCell2d cell{Eigen::Vector2d{1, 2}, get_diagonal_covariance()};
   std::stringstream ss;
   ss << cell;
   ASSERT_GT(ss.str().size(), 0);

--- a/beluga/test/beluga/sensor/test_ndt_model.cpp
+++ b/beluga/test/beluga/sensor/test_ndt_model.cpp
@@ -34,19 +34,19 @@ Eigen::Matrix2Xd get_diagonal_covariance_2d(double x_var = 0.5, double y_var = 0
   return Eigen::Vector2d{x_var, y_var}.asDiagonal();
 }
 
-using sparse_grid_2d_t = SparseValueGrid2<std::unordered_map<Eigen::Vector2i, NDTCell2d, detail::CellHasher<2>>>;
-using sparse_grid_3d_t = SparseValueGrid3<std::unordered_map<Eigen::Vector3i, NDTCell3d, detail::CellHasher<3>>>;
+using sparse_grid_2d_t = SparseValueGrid2<std::unordered_map<Eigen::Vector2i, NdtCell2d, detail::CellHasher<2>>>;
+using sparse_grid_3d_t = SparseValueGrid3<std::unordered_map<Eigen::Vector3i, NdtCell3d, detail::CellHasher<3>>>;
 }  // namespace
 
-TEST(NDTSensorModel2DTests, CanConstruct) {
-  NDTSensorModel{NDTModelParam2d{}, sparse_grid_2d_t{}};
+TEST(NdtSensorModel2DTests, CanConstruct) {
+  NdtSensorModel{NdtModelParam2d{}, sparse_grid_2d_t{}};
 }
 
-TEST(NDTSensorModel2DTests, MinLikelihood) {
+TEST(NdtSensorModel2DTests, MinLikelihood) {
   constexpr double kMinimumLikelihood = 1e-6;
 
-  const NDTModelParam2d param{kMinimumLikelihood};
-  const NDTSensorModel model{param, sparse_grid_2d_t{}};
+  const NdtModelParam2d param{kMinimumLikelihood};
+  const NdtSensorModel model{param, sparse_grid_2d_t{}};
 
   for (const auto& val : {
            Eigen::Vector2d{0.1, 0.1},
@@ -63,7 +63,7 @@ TEST(NDTSensorModel2DTests, MinLikelihood) {
   }
 }
 
-TEST(NDTSensorModel2DTests, Likelihoood) {
+TEST(NdtSensorModel2DTests, Likelihoood) {
   typename sparse_grid_2d_t::map_type map;
   {
     Eigen::Array<double, 2, 2> cov;
@@ -72,7 +72,7 @@ TEST(NDTSensorModel2DTests, Likelihoood) {
            0.0, 0.3;
     // clang-format on
     const Eigen::Vector2d mean(0.5, 0.5);
-    map[Eigen::Vector2i(0, 0)] = NDTCell2d{mean, cov};
+    map[Eigen::Vector2i(0, 0)] = NdtCell2d{mean, cov};
   }
   {
     Eigen::Array<double, 2, 2> cov;
@@ -81,13 +81,13 @@ TEST(NDTSensorModel2DTests, Likelihoood) {
            0.0, 0.5;
     // clang-format on
     const Eigen::Vector2d mean(1.5, 1.5);
-    map[Eigen::Vector2i(1, 1)] = NDTCell2d{mean, cov};
+    map[Eigen::Vector2i(1, 1)] = NdtCell2d{mean, cov};
   }
   sparse_grid_2d_t grid{std::move(map), 1.0};
 
   constexpr double kMinimumLikelihood = 1e-6;
-  const NDTModelParam2d param{kMinimumLikelihood};
-  const NDTSensorModel model{param, std::move(grid)};
+  const NdtModelParam2d param{kMinimumLikelihood};
+  const NdtSensorModel model{param, std::move(grid)};
 
   EXPECT_DOUBLE_EQ(model.likelihood_at({{0.5, 0.5}, get_diagonal_covariance_2d()}), 1.3678794411714423);
   EXPECT_DOUBLE_EQ(model.likelihood_at({{0.8, 0.5}, get_diagonal_covariance_2d()}), 1.4307317817730123);
@@ -98,7 +98,7 @@ TEST(NDTSensorModel2DTests, Likelihoood) {
   EXPECT_DOUBLE_EQ(model.likelihood_at({{1.5, 1.8}, get_diagonal_covariance_2d()}), 1.1669230426687498);
 }
 
-TEST(NDTSensorModel2DTests, FitPoints) {
+TEST(NdtSensorModel2DTests, FitPoints) {
   {
     const std::vector meas{
         Eigen::Vector2d{0.1, 0.2}, Eigen::Vector2d{0.1, 0.2}, Eigen::Vector2d{0.1, 0.2},
@@ -121,7 +121,7 @@ TEST(NDTSensorModel2DTests, FitPoints) {
   }
 }
 
-TEST(NDTSensorModel2DTests, ToCellsNotEnoughPointsInCell) {
+TEST(NdtSensorModel2DTests, ToCellsNotEnoughPointsInCell) {
   constexpr double kMapResolution = 0.5;
   const std::vector map_data{
       Eigen::Vector2d{0.1, 0.2},
@@ -132,7 +132,7 @@ TEST(NDTSensorModel2DTests, ToCellsNotEnoughPointsInCell) {
   ASSERT_EQ(cells.size(), 0UL);
 }
 
-TEST(NDTSensorModel3DTests, ToCellsNotEnoughPointsInCell) {
+TEST(NdtSensorModel3DTests, ToCellsNotEnoughPointsInCell) {
   constexpr double kMapResolution = 0.5;
   const std::vector map_data{
       Eigen::Vector3d{0.1, 0.2, 0.0},
@@ -143,7 +143,7 @@ TEST(NDTSensorModel3DTests, ToCellsNotEnoughPointsInCell) {
   ASSERT_EQ(cells.size(), 0UL);
 }
 
-TEST(NDTSensorModel3DTests, FitPoints) {
+TEST(NdtSensorModel3DTests, FitPoints) {
   {
     const std::vector meas{
         Eigen::Vector3d{0.1, 0.2, 0.3}, Eigen::Vector3d{0.1, 0.2, 0.3}, Eigen::Vector3d{0.1, 0.2, 0.3},
@@ -167,7 +167,7 @@ TEST(NDTSensorModel3DTests, FitPoints) {
   }
 }
 
-TEST(NDTSensorModel3DTests, SensorModel) {
+TEST(NdtSensorModel3DTests, SensorModel) {
   constexpr double kMapResolution = 0.5;
   const std::vector map_data{
       Eigen::Vector3d{0.1, 0.2, 0.0},  Eigen::Vector3d{0.112, 0.22, 0.1}, Eigen::Vector3d{0.15, 0.23, 0.1},
@@ -182,7 +182,7 @@ TEST(NDTSensorModel3DTests, SensorModel) {
   }
 
   std::vector perfect_measurement = map_data;
-  const NDTSensorModel model{{}, sparse_grid_3d_t{map_cells_data, kMapResolution}};
+  const NdtSensorModel model{{}, sparse_grid_3d_t{map_cells_data, kMapResolution}};
   auto state_weighing_fn = model(std::move(perfect_measurement));
 
   {
@@ -210,7 +210,7 @@ TEST(NDTSensorModel3DTests, SensorModel) {
   ASSERT_DOUBLE_EQ(state_weighing_fn(Sophus::SE3d{Sophus::SO3d{}, Eigen::Vector3d{0, 0, 1.0}}), 1.0);
 }
 
-TEST(NDTSensorModel2DTests, SensorModel) {
+TEST(NdtSensorModel2DTests, SensorModel) {
   constexpr double kMapResolution = 0.5;
   const std::vector map_data{
       Eigen::Vector2d{0.1, 0.2},  Eigen::Vector2d{0.112, 0.22}, Eigen::Vector2d{0.15, 0.23},
@@ -223,7 +223,7 @@ TEST(NDTSensorModel2DTests, SensorModel) {
     map_cells_data[(cell.mean.array() / kMapResolution).cast<int>()] = cell;
   }
   std::vector perfect_measurement = map_data;
-  const NDTSensorModel model{{}, sparse_grid_2d_t{map_cells_data, kMapResolution}};
+  const NdtSensorModel model{{}, sparse_grid_2d_t{map_cells_data, kMapResolution}};
   auto state_weighing_fn = model(std::move(perfect_measurement));
   // This is a perfect hit, so we should expect weight to be 1 + num_cells == 2.
   ASSERT_DOUBLE_EQ(state_weighing_fn(Sophus::SE2d{}), 2);
@@ -235,20 +235,20 @@ TEST(NDTSensorModel2DTests, SensorModel) {
   ASSERT_DOUBLE_EQ(state_weighing_fn(Sophus::SE2d{Sophus::SO2d{}, Eigen::Vector2d{-10, -10}}), 1.0);
 }
 
-TEST(NDTSensorModel2DTests, LoadFromHDF5HappyPath) {
+TEST(NdtSensorModel2DTests, LoadFromHDF5HappyPath) {
   const auto ndt_map_representation = io::load_from_hdf5<sparse_grid_2d_t>("./test_data/turtlebot3_world.hdf5");
   ASSERT_EQ(ndt_map_representation.size(), 30UL);
 }
 
-TEST(NDTSensorModel2DTests, LoadFromHDF5NonExistingFile) {
+TEST(NdtSensorModel2DTests, LoadFromHDF5NonExistingFile) {
   ASSERT_THROW(io::load_from_hdf5<sparse_grid_2d_t>("bad_file.hdf5"), std::invalid_argument);
 }
 
-TEST(NDTSensorModel3DTests, LoadFromHDF5NonExistingFile) {
+TEST(NdtSensorModel3DTests, LoadFromHDF5NonExistingFile) {
   ASSERT_THROW(io::load_from_hdf5<sparse_grid_3d_t>("bad_file.hdf5"), std::invalid_argument);
 }
 
-TEST(NDTSensorModel3DTests, LoadFromHDF5HappyPath) {
+TEST(NdtSensorModel3DTests, LoadFromHDF5HappyPath) {
   const auto ndt_map_representation = io::load_from_hdf5<sparse_grid_3d_t>("./test_data/sample_3d_ndt_map.hdf5");
   ASSERT_EQ(ndt_map_representation.size(), 398);
 }

--- a/beluga_amcl/include/beluga_amcl/amcl_node.hpp
+++ b/beluga_amcl/include/beluga_amcl/amcl_node.hpp
@@ -19,28 +19,17 @@
 #include <optional>
 #include <utility>
 
+#include <tf2_ros/message_filter.h>
+
+#include <std_srvs/srv/empty.hpp>
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcpp"
 #include <message_filters/subscriber.h>
 #pragma GCC diagnostic pop
 
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/message_filter.h>
-#include <tf2_ros/transform_broadcaster.h>
-#include <tf2_ros/transform_listener.h>
-#include <bondcpp/bond.hpp>
-#include <rclcpp_lifecycle/lifecycle_node.hpp>
-
-#include <geometry_msgs/msg/pose_array.hpp>
-#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
-#include <nav_msgs/msg/occupancy_grid.hpp>
-#include <sensor_msgs/msg/laser_scan.hpp>
-#include <std_srvs/srv/empty.hpp>
-#include <visualization_msgs/msg/marker_array.hpp>
-
-#include <beluga/beluga.hpp>
+#include <beluga_amcl/ros2_common.hpp>
 #include <beluga_ros/amcl.hpp>
-#include "beluga_amcl/ros2_common.hpp"
 
 /**
  * \file

--- a/beluga_amcl/include/beluga_amcl/ndt_amcl_node.hpp
+++ b/beluga_amcl/include/beluga_amcl/ndt_amcl_node.hpp
@@ -15,47 +15,26 @@
 #ifndef BELUGA_AMCL_NDT_AMCL_NODE_HPP
 #define BELUGA_AMCL_NDT_AMCL_NODE_HPP
 
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/message_filter.h>
-#include <tf2_ros/transform_broadcaster.h>
-#include <tf2_ros/transform_listener.h>
-
-#include <beluga/beluga.hpp>
-#include <beluga/motion/differential_drive_model.hpp>
-#include <beluga/motion/omnidirectional_drive_model.hpp>
-#include <beluga/motion/stationary_model.hpp>
-#include <beluga/primitives.hpp>
-#include <beluga/sensor/data/ndt_cell.hpp>
-#include <beluga/sensor/data/sparse_value_grid.hpp>
-#include <beluga/sensor/ndt_sensor_model.hpp>
-
-#include <execution>
 #include <functional>
 #include <optional>
-#include <rclcpp/callback_group.hpp>
-#include <rclcpp/subscription_options.hpp>
-#include <sophus/se2.hpp>
 #include <tuple>
-#include <variant>
 
-#include <Eigen/src/Core/Matrix.h>
-#include <H5Cpp.h>
+#include <tf2_ros/message_filter.h>
 
-#include <beluga/algorithm/amcl_core.hpp>
-#include <bondcpp/bond.hpp>
-#include <geometry_msgs/msg/pose_array.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
-#include <rclcpp_lifecycle/lifecycle_node.hpp>
-#include <sensor_msgs/msg/laser_scan.hpp>
-#include <std_srvs/srv/empty.hpp>
-
-#include <beluga_ros/laser_scan.hpp>
-#include "beluga_amcl/ros2_common.hpp"
+#include <sophus/types.hpp>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcpp"
 #include <message_filters/subscriber.h>
 #pragma GCC diagnostic pop
+
+#include <beluga/algorithm/amcl_core.hpp>
+#include <beluga/motion/differential_drive_model.hpp>
+#include <beluga/sensor/data/sparse_value_grid.hpp>
+#include <beluga/sensor/ndt_sensor_model.hpp>
+#include <beluga_amcl/ros2_common.hpp>
+#include <beluga_ros/laser_scan.hpp>
 
 /**
  * \file
@@ -65,39 +44,14 @@
 namespace beluga_amcl {
 
 /// Underlying map representation for the NDT sensor model.
-using NDTMapRepresentation =
-    beluga::SparseValueGrid2<std::unordered_map<Eigen::Vector2i, beluga::NDTCell2d, beluga::detail::CellHasher<2>>>;
+using NdtMap =
+    beluga::SparseValueGrid2<std::unordered_map<Eigen::Vector2i, beluga::NdtCell2d, beluga::detail::CellHasher<2>>>;
 
-/// Type of a particle-dependent random state generator.
-using RandomStateGenerator = std::function<std::function<beluga::NDTSensorModel<NDTMapRepresentation>::state_type()>(
-    const beluga::TupleVector<std::tuple<beluga::NDTSensorModel<NDTMapRepresentation>::state_type, beluga::Weight>>)>;
-
-/// Partial specialization of the core AMCL pipeline for convinience.
-template <class MotionModel, class ExecutionPolicy>
+/// Instantiatiation of the core AMCL pipeline with the NDT sensor model.
 using NdtAmcl = beluga::Amcl<
-    MotionModel,
-    beluga::NDTSensorModel<NDTMapRepresentation>,
-    RandomStateGenerator,
-    beluga::Weight,
-    std::tuple<typename beluga::NDTSensorModel<NDTMapRepresentation>::state_type, beluga::Weight>,
-    ExecutionPolicy>;
-
-/// All combinations of supported NDT AMCL variants.
-using NdtAmclVariant = std::variant<
-    NdtAmcl<beluga::StationaryModel, std::execution::parallel_policy>,            //
-    NdtAmcl<beluga::StationaryModel, std::execution::sequenced_policy>,           //
-    NdtAmcl<beluga::DifferentialDriveModel2d, std::execution::parallel_policy>,   //
-    NdtAmcl<beluga::DifferentialDriveModel2d, std::execution::sequenced_policy>,  //
-    NdtAmcl<beluga::OmnidirectionalDriveModel, std::execution::parallel_policy>,  //
-    NdtAmcl<beluga::OmnidirectionalDriveModel, std::execution::sequenced_policy>  //
-    >;
-
-/// Supported motion models.
-using MotionModelVariant =
-    std::variant<beluga::DifferentialDriveModel2d, beluga::StationaryModel, beluga::OmnidirectionalDriveModel>;
-
-/// Supported execution policies.
-using ExecutionPolicyVariant = std::variant<std::execution::sequenced_policy, std::execution::parallel_policy>;
+    beluga::DifferentialDriveModel2d,  //
+    beluga::NdtSensorModel<NdtMap>,    //
+    std::tuple<Sophus::SE2d, beluga::Weight>>;
 
 /// 2D NDT AMCL as a ROS 2 composable lifecycle node.
 class NdtAmclNode : public BaseAMCLNode {
@@ -119,13 +73,13 @@ class NdtAmclNode : public BaseAMCLNode {
   auto get_initial_estimate() const -> std::optional<std::pair<Sophus::SE2d, Eigen::Matrix3d>>;
 
   /// Get motion model as per current parametrization.
-  auto get_motion_model() const -> MotionModelVariant;
+  auto get_motion_model() const -> beluga::DifferentialDriveModel2d;
 
   /// Get sensor model as per current parametrization.
-  beluga::NDTSensorModel<NDTMapRepresentation> get_sensor_model() const;
+  auto get_sensor_model() const -> beluga::NdtSensorModel<NdtMap>;
 
   /// Instantiate particle filter given an initial occupancy grid map and the current parametrization.
-  auto make_particle_filter() const -> std::unique_ptr<NdtAmclVariant>;
+  auto make_particle_filter() const -> std::unique_ptr<NdtAmcl>;
 
   /// Callback for periodic particle cloud updates.
   void do_periodic_timer_callback() override;
@@ -157,7 +111,7 @@ class NdtAmclNode : public BaseAMCLNode {
   message_filters::Connection laser_scan_connection_;
 
   /// Particle filter instance.
-  std::unique_ptr<NdtAmclVariant> particle_filter_ = nullptr;
+  std::unique_ptr<NdtAmcl> particle_filter_ = nullptr;
   /// Last known pose estimate, if any.
   std::optional<std::pair<Sophus::SE2d, Eigen::Matrix3d>> last_known_estimate_ = std::nullopt;
   /// Last known map to odom correction estimate, if any.

--- a/beluga_amcl/src/amcl_node.cpp
+++ b/beluga_amcl/src/amcl_node.cpp
@@ -13,61 +13,20 @@
 // limitations under the License.
 
 #include <chrono>
-#include <cstddef>
-#include <execution>
 #include <functional>
-#include <limits>
 #include <memory>
 #include <optional>
-#include <ratio>
 #include <stdexcept>
 #include <string>
-#include <string_view>
-#include <tuple>
 #include <utility>
-
-#include <tf2/convert.h>
-#include <tf2/exceptions.h>
-#include <tf2/time.h>
-
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/buffer_interface.h>
-#include <tf2_ros/create_timer_ros.h>
-#include <tf2_ros/message_filter.h>
-#include <tf2_ros/transform_broadcaster.h>
-#include <tf2_ros/transform_listener.h>
-
-#include <Eigen/Core>
-#include <sophus/se2.hpp>
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wcpp"
-#include <message_filters/subscriber.h>
-#pragma GCC diagnostic pop
+#include <vector>
 
 #include <rclcpp/version.h>
-#include <bondcpp/bond.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <rclcpp_lifecycle/lifecycle_node.hpp>
 
-#include <geometry_msgs/msg/pose_array.hpp>
-#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
-#include <lifecycle_msgs/msg/state.hpp>
-#include <nav_msgs/msg/occupancy_grid.hpp>
-#include <sensor_msgs/msg/laser_scan.hpp>
-#include <std_srvs/srv/empty.hpp>
-
-#include <beluga/motion/differential_drive_model.hpp>
-#include <beluga/motion/omnidirectional_drive_model.hpp>
-#include <beluga/motion/stationary_model.hpp>
-#include <beluga/sensor/beam_model.hpp>
-#include <beluga/sensor/likelihood_field_model.hpp>
-#include <beluga_ros/amcl.hpp>
-#include <beluga_ros/messages.hpp>
+#include <beluga_amcl/amcl_node.hpp>
 #include <beluga_ros/particle_cloud.hpp>
 #include <beluga_ros/tf2_sophus.hpp>
-#include "beluga_amcl/amcl_node.hpp"
-#include "beluga_amcl/ros2_common.hpp"
 
 namespace beluga_amcl {
 

--- a/beluga_amcl/src/ndt_amcl_node.cpp
+++ b/beluga_amcl/src/ndt_amcl_node.cpp
@@ -134,7 +134,7 @@ auto NdtAmclNode::get_initial_estimate() const -> std::optional<std::pair<Sophus
 
 auto NdtAmclNode::get_motion_model() const -> beluga::DifferentialDriveModel2d {
   const auto name = get_parameter("robot_model_type").as_string();
-  if (name == kDifferentialModelName || name == kNav2DifferentialModelName) {
+  if (name == kDifferentialModelName) {
     auto params = beluga::DifferentialDriveModelParam{};
     params.rotation_noise_from_rotation = get_parameter("alpha1").as_double();
     params.rotation_noise_from_translation = get_parameter("alpha2").as_double();

--- a/beluga_amcl/src/ndt_amcl_node_3d.cpp
+++ b/beluga_amcl/src/ndt_amcl_node_3d.cpp
@@ -174,7 +174,7 @@ auto NdtAmclNode3D::get_initial_estimate() const -> std::optional<std::pair<Soph
 
 auto NdtAmclNode3D::get_motion_model() const -> beluga::DifferentialDriveModel3d {
   const auto name = get_parameter("robot_model_type").as_string();
-  if (name == kDifferentialModelName || name == kNav2DifferentialModelName) {
+  if (name == kDifferentialModelName) {
     auto params = beluga::DifferentialDriveModelParam{};
     params.rotation_noise_from_rotation = get_parameter("alpha1").as_double();
     params.rotation_noise_from_translation = get_parameter("alpha2").as_double();

--- a/beluga_amcl/test/test_ndt_amcl_3d_node.cpp
+++ b/beluga_amcl/test/test_ndt_amcl_3d_node.cpp
@@ -206,7 +206,7 @@ TEST_P(TestInitializationWithModel, ParticleCount) {
 
   ASSERT_TRUE(wait_for_initialization());
 
-  std::visit([](const auto& pf) { ASSERT_EQ(pf.particles().size(), 10UL); }, *ndt_amcl_node_->particle_filter());
+  ASSERT_EQ(ndt_amcl_node_->particle_filter()->particles().size(), 10UL);
 }
 
 class TestNode : public BaseNodeFixture<::testing::Test> {};
@@ -370,26 +370,6 @@ TEST_F(TestNode, InvalidMotionModel) {
   ndt_amcl_node_->configure();
   ndt_amcl_node_->activate();
   ASSERT_FALSE(wait_for_initialization());
-}
-TEST_F(TestNode, InvalidExecutionPolicy) {
-  ndt_amcl_node_->set_parameter(rclcpp::Parameter{"execution_policy", "non_existing_policy"});
-  ndt_amcl_node_->configure();
-  ndt_amcl_node_->activate();
-  ASSERT_FALSE(wait_for_initialization());
-}
-
-TEST_F(TestNode, SequentialExecutionPolicy) {
-  ndt_amcl_node_->set_parameter(rclcpp::Parameter{"execution_policy", "seq"});
-  ndt_amcl_node_->configure();
-  ndt_amcl_node_->activate();
-  ASSERT_TRUE(wait_for_initialization());
-}
-
-TEST_F(TestNode, ParallelExecutionPolicy) {
-  ndt_amcl_node_->set_parameter(rclcpp::Parameter{"execution_policy", "par"});
-  ndt_amcl_node_->configure();
-  ndt_amcl_node_->activate();
-  ASSERT_TRUE(wait_for_initialization());
 }
 
 TEST_F(TestNode, InitialPoseBeforeInitialize) {

--- a/beluga_amcl/test/test_ndt_amcl_node.cpp
+++ b/beluga_amcl/test/test_ndt_amcl_node.cpp
@@ -184,10 +184,7 @@ TEST_F(TestLifecycle, AutoStart) {
 
 class TestInitializationWithModel : public BaseNodeFixture<::testing::TestWithParam<const char*>> {};
 
-INSTANTIATE_TEST_SUITE_P(
-    Models,
-    TestInitializationWithModel,
-    testing::Values("differential_drive", "omnidirectional_drive", "stationary"));
+INSTANTIATE_TEST_SUITE_P(Models, TestInitializationWithModel, testing::Values("differential_drive"));
 
 TEST_P(TestInitializationWithModel, ParticleCount) {
   const auto* const motion_model = GetParam();
@@ -201,13 +198,8 @@ TEST_P(TestInitializationWithModel, ParticleCount) {
   ndt_amcl_node_->activate();
 
   ASSERT_TRUE(wait_for_initialization());
-
-  std::visit(
-      [](const auto& pf) {
-        ASSERT_GE(pf.particles().size(), 10UL);
-        ASSERT_LE(pf.particles().size(), 30UL);
-      },
-      *ndt_amcl_node_->particle_filter());
+  ASSERT_GE(ndt_amcl_node_->particle_filter()->particles().size(), 10UL);
+  ASSERT_LE(ndt_amcl_node_->particle_filter()->particles().size(), 30UL);
 }
 
 class TestNode : public BaseNodeFixture<::testing::Test> {};
@@ -364,26 +356,6 @@ TEST_F(TestNode, InvalidMotionModel) {
   ndt_amcl_node_->configure();
   ndt_amcl_node_->activate();
   ASSERT_FALSE(wait_for_initialization());
-}
-TEST_F(TestNode, InvalidExecutionPolicy) {
-  ndt_amcl_node_->set_parameter(rclcpp::Parameter{"execution_policy", "non_existing_policy"});
-  ndt_amcl_node_->configure();
-  ndt_amcl_node_->activate();
-  ASSERT_FALSE(wait_for_initialization());
-}
-
-TEST_F(TestNode, SequentialExecutionPolicy) {
-  ndt_amcl_node_->set_parameter(rclcpp::Parameter{"execution_policy", "seq"});
-  ndt_amcl_node_->configure();
-  ndt_amcl_node_->activate();
-  ASSERT_TRUE(wait_for_initialization());
-}
-
-TEST_F(TestNode, ParallelExecutionPolicy) {
-  ndt_amcl_node_->set_parameter(rclcpp::Parameter{"execution_policy", "par"});
-  ndt_amcl_node_->configure();
-  ndt_amcl_node_->activate();
-  ASSERT_TRUE(wait_for_initialization());
 }
 
 TEST_F(TestNode, InitialPoseBeforeInitialize) {

--- a/beluga_amcl/test/test_utils/node_testing.hpp
+++ b/beluga_amcl/test/test_utils/node_testing.hpp
@@ -149,6 +149,13 @@ class TesterNode : public rclcpp::Node {
     auto scan = sensor_msgs::msg::LaserScan{};
     scan.header.stamp = timestamp;
     scan.header.frame_id = "laser";
+    scan.angle_min = -1.57F;
+    scan.angle_max = 1.57F;
+    scan.angle_increment = 1.57F;
+    scan.time_increment = 0.0F;
+
+    scan.ranges.resize(1);
+    scan.intensities.resize(1);
 
     auto transform_base = geometry_msgs::msg::TransformStamped{};
     transform_base.header.stamp = timestamp;
@@ -175,8 +182,12 @@ class TesterNode : public rclcpp::Node {
     sensor_msgs::PointCloud2Modifier modifier(scan);
 
     modifier.setPointCloud2Fields(
-        3, "x", 1, sensor_msgs::msg::PointField::FLOAT32, "y", 1, sensor_msgs::msg::PointField::FLOAT32, "z", 1,
-        sensor_msgs::msg::PointField::FLOAT32);
+        3,                                              //
+        "x", 1, sensor_msgs::msg::PointField::FLOAT32,  //
+        "y", 1, sensor_msgs::msg::PointField::FLOAT32,  //
+        "z", 1, sensor_msgs::msg::PointField::FLOAT32);
+
+    modifier.resize(1);
 
     auto transform_base = geometry_msgs::msg::TransformStamped{};
     transform_base.header.stamp = timestamp;

--- a/beluga_example/params/default_ndt.ros2.yaml
+++ b/beluga_example/params/default_ndt.ros2.yaml
@@ -1,7 +1,7 @@
 ndt_amcl:
   ros__parameters:
     # Odometry motion model type.
-    robot_model_type: nav2_amcl::DifferentialMotionModel
+    robot_model_type: differential_drive
     # Expected process noise in odometry’s rotation estimate from rotation.
     alpha1: 0.002
     # Expected process noise in odometry’s rotation estimate from translation.

--- a/beluga_example/params/default_ndt.ros2.yaml
+++ b/beluga_example/params/default_ndt.ros2.yaml
@@ -35,14 +35,6 @@ ndt_amcl:
     # Upper standard normal quantile for the probability that the error in the
     # estimated distribution is less than pf_err.
     pf_z: 3.0
-    # Fast exponential filter constant, used to filter the average particles weights.
-    # Random particles are added if the fast filter result is larger than the slow filter result
-    # allowing the particle filter to recover from a bad approximation.
-    recovery_alpha_fast: 0.1
-    # Slow exponential filter constant, used to filter the average particles weights.
-    # Random particles are added if the fast filter result is larger than the slow filter result
-    # allowing the particle filter to recover from a bad approximation.
-    recovery_alpha_slow: 0.001
     # Resample will happen after the amount of updates specified here happen.
     resample_interval: 1
     # Minimum angle difference from last resample for resampling to happen again.
@@ -57,9 +49,6 @@ ndt_amcl:
     tf_broadcast: true
     # Transform tolerance allowed.
     transform_tolerance: 1.0
-    # Execution policy used to apply the motion update and importance weight steps.
-    # Valid options: "seq", "par".
-    execution_policy: seq
     # Whether to set initial pose based on parameters.
     # When enabled, particles will be initialized with the specified pose coordinates and covariance.
     set_initial_pose: true

--- a/beluga_example/params/default_ndt_3d.ros2.yaml
+++ b/beluga_example/params/default_ndt_3d.ros2.yaml
@@ -35,14 +35,6 @@ ndt_amcl:
     # Upper standard normal quantile for the probability that the error in the
     # estimated distribution is less than pf_err.
     pf_z: 3.0
-    # Fast exponential filter constant, used to filter the average particles weights.
-    # Random particles are added if the fast filter result is larger than the slow filter result
-    # allowing the particle filter to recover from a bad approximation.
-    recovery_alpha_fast: 0.1
-    # Slow exponential filter constant, used to filter the average particles weights.
-    # Random particles are added if the fast filter result is larger than the slow filter result
-    # allowing the particle filter to recover from a bad approximation.
-    recovery_alpha_slow: 0.001
     # Resample will happen after the amount of updates specified here happen.
     resample_interval: 1
     # Minimum angle difference from last resample for resampling to happen again.
@@ -57,9 +49,6 @@ ndt_amcl:
     tf_broadcast: true
     # Transform tolerance allowed.
     transform_tolerance: 1.0
-    # Execution policy used to apply the motion update and importance weight steps.
-    # Valid options: "seq", "par".
-    execution_policy: par
     # Whether to set initial pose based on parameters.
     # When enabled, particles will be initialized with the specified pose coordinates and covariance.
     set_initial_pose: true

--- a/beluga_ros/src/amcl.cpp
+++ b/beluga_ros/src/amcl.cpp
@@ -82,7 +82,7 @@ auto Amcl::update(Sophus::SE2d base_pose_in_odom, beluga_ros::LaserScan laser_sc
     auto random_state = ranges::compose(beluga::make_from_state<particle_type>, std::ref(map_distribution_));
 
     if (random_state_probability > 0.0) {
-      random_probability_estimator_.reset();
+      random_probability_estimator_.reset();  // LCOV_EXCL_LINE
     }
 
     particles_ |= beluga::views::sample |


### PR DESCRIPTION
### Proposed changes

Simplifies the NDT localization nodes by reducing the number of supported features, specifically the available motion models and the recovery strategy configuration. This change eliminates the need for static dispatch and `std::visit`, easing some pressure on the compiler. Additionally, it cleans up header file inclusions.

Closes #424, since it removes the recovery strategy from the core AMCL pipeline.
Related to #385, since it reduces memory usage during compilation.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)
