### PR TITLE
Add almost_equal_to in SE3

### DIFF
--- a/beluga_ros/include/beluga_ros/particle_cloud.hpp
+++ b/beluga_ros/include/beluga_ros/particle_cloud.hpp
@@ -82,9 +82,9 @@ struct almost_equal_to<Sophus::SE2<Scalar>> {
   /// Compares `a` and `b` for near equality.
   bool operator()(const Sophus::SE2<Scalar>& a, const Sophus::SE2<Scalar>& b) const {
     using std::abs;
-    return (abs(a.translation().x() - b.translation().x()) < linear_resolution) &&
-           (abs(a.translation().y() - b.translation().y()) < linear_resolution) &&
-           (abs((a * b.inverse()).log().z()) < angular_resolution);
+    const Sophus::SE2<Scalar> diff = a * b.inverse();
+    return (abs(diff.translation().x()) < linear_resolution) && (abs(diff.translation().y()) < linear_resolution) &&
+           (abs(diff.so2().log()) < angular_resolution);
   }
 
   const Scalar linear_resolution;   ///< Resolution for translational coordinates, in meters.
@@ -105,12 +105,10 @@ struct almost_equal_to<Sophus::SE3<Scalar>> {
   /// Compares `a` and `b` for near equality.
   bool operator()(const Sophus::SE3<Scalar>& a, const Sophus::SE3<Scalar>& b) const {
     using std::abs;
-    const Eigen::Vector<Scalar, 6> angles = (a * b.inverse()).log();
-    return (abs(a.translation().x() - b.translation().x()) < linear_resolution) &&
-           (abs(a.translation().y() - b.translation().y()) < linear_resolution) &&
-           (abs(a.translation().z() - b.translation().z()) < linear_resolution) &&
-           (abs(angles[3]) < angular_resolution) && (abs(angles[4]) < angular_resolution) &&
-           (abs(angles[5]) < angular_resolution);
+    const Sophus::SE3<Scalar> diff = a * b.inverse();
+    return (abs(diff.translation().x()) < linear_resolution) && (abs(diff.translation().y()) < linear_resolution) &&
+           (abs(diff.translation().z()) < linear_resolution) && (abs(diff.so3().angleX()) < angular_resolution) &&
+           (abs(diff.so3().angleY()) < angular_resolution) && (abs(diff.so3().angleZ()) < angular_resolution);
   }
 
   const Scalar linear_resolution;   ///< Resolution for translational coordinates, in meters.

--- a/beluga_ros/include/beluga_ros/particle_cloud.hpp
+++ b/beluga_ros/include/beluga_ros/particle_cloud.hpp
@@ -81,10 +81,10 @@ struct almost_equal_to<Sophus::SE2<Scalar>> {
 
   /// Compares `a` and `b` for near equality.
   bool operator()(const Sophus::SE2<Scalar>& a, const Sophus::SE2<Scalar>& b) const {
-    using std::abs, std::atan, std::tan;
+    using std::abs;
     return (abs(a.translation().x() - b.translation().x()) < linear_resolution) &&
            (abs(a.translation().y() - b.translation().y()) < linear_resolution) &&
-           (abs(atan(tan(a.so2().log() - b.so2().log()))) < angular_resolution);
+           (abs((a * b.inverse()).log().x()) < angular_resolution);
   }
 
   const Scalar linear_resolution;   ///< Resolution for translational coordinates, in meters.
@@ -104,13 +104,13 @@ struct almost_equal_to<Sophus::SE3<Scalar>> {
 
   /// Compares `a` and `b` for near equality.
   bool operator()(const Sophus::SE3<Scalar>& a, const Sophus::SE3<Scalar>& b) const {
-    using std::abs, std::atan, std::tan;
-    const Eigen::Vector3<Scalar> angles = a.so3().log() - b.so3().log();
+    using std::abs;
+    const Eigen::Vector3<Scalar> angles = (a * b.inverse()).log();
     return (abs(a.translation().x() - b.translation().x()) < linear_resolution) &&
            (abs(a.translation().y() - b.translation().y()) < linear_resolution) &&
            (abs(a.translation().z() - b.translation().z()) < linear_resolution) &&
-           (abs(atan(tan(angles.x()))) < angular_resolution) && (abs(atan(tan(angles.y()))) < angular_resolution) &&
-           (abs(atan(tan(angles.z()))) < angular_resolution);
+           (abs(angles.x()) < angular_resolution) && (abs(angles.y()) < angular_resolution) &&
+           (abs(angles.z()) < angular_resolution);
   }
 
   const Scalar linear_resolution;   ///< Resolution for translational coordinates, in meters.

--- a/beluga_ros/include/beluga_ros/particle_cloud.hpp
+++ b/beluga_ros/include/beluga_ros/particle_cloud.hpp
@@ -84,7 +84,7 @@ struct almost_equal_to<Sophus::SE2<Scalar>> {
     using std::abs;
     return (abs(a.translation().x() - b.translation().x()) < linear_resolution) &&
            (abs(a.translation().y() - b.translation().y()) < linear_resolution) &&
-           (abs((a * b.inverse()).log().x()) < angular_resolution);
+           (abs((a * b.inverse()).log().z()) < angular_resolution);
   }
 
   const Scalar linear_resolution;   ///< Resolution for translational coordinates, in meters.
@@ -105,12 +105,12 @@ struct almost_equal_to<Sophus::SE3<Scalar>> {
   /// Compares `a` and `b` for near equality.
   bool operator()(const Sophus::SE3<Scalar>& a, const Sophus::SE3<Scalar>& b) const {
     using std::abs;
-    const Eigen::Vector3<Scalar> angles = (a * b.inverse()).log();
+    const Eigen::Vector<Scalar, 6> angles = (a * b.inverse()).log();
     return (abs(a.translation().x() - b.translation().x()) < linear_resolution) &&
            (abs(a.translation().y() - b.translation().y()) < linear_resolution) &&
            (abs(a.translation().z() - b.translation().z()) < linear_resolution) &&
-           (abs(angles.x()) < angular_resolution) && (abs(angles.y()) < angular_resolution) &&
-           (abs(angles.z()) < angular_resolution);
+           (abs(angles[3]) < angular_resolution) && (abs(angles[4]) < angular_resolution) &&
+           (abs(angles[5]) < angular_resolution);
   }
 
   const Scalar linear_resolution;   ///< Resolution for translational coordinates, in meters.

--- a/beluga_ros/test/test_particle_cloud.cpp
+++ b/beluga_ros/test/test_particle_cloud.cpp
@@ -23,6 +23,7 @@
 
 #include <sophus/common.hpp>
 #include <sophus/se2.hpp>
+#include <sophus/se3.hpp>
 
 #include "beluga/primitives.hpp"
 #include "beluga_ros/messages.hpp"
@@ -48,13 +49,44 @@ TEST(TestParticleCloud, Assign) {
     EXPECT_DOUBLE_EQ(pose.position.z, 0.0);
     EXPECT_DOUBLE_EQ(pose.orientation.x, 0.0);
     EXPECT_DOUBLE_EQ(pose.orientation.y, 0.0);
-    EXPECT_DOUBLE_EQ(pose.orientation.x, 0.0);
-    EXPECT_DOUBLE_EQ(pose.orientation.y, 0.0);
     EXPECT_DOUBLE_EQ(std::abs(pose.orientation.z), std::sin(Constants::pi() / 4.0));
     EXPECT_DOUBLE_EQ(pose.orientation.w, std::cos(Constants::pi() / 4.0));
   }
-  const auto num_particles_in_upper_half_xy_plane =
+  const auto num_particles_in_upper_half_xz_plane =
       ranges::count_if(message.poses, [](const auto& pose) { return pose.position.y > 0.0; });
+  const double upper_half_xz_plane_weight =
+      static_cast<double>(num_particles_in_upper_half_xz_plane) / static_cast<double>(message.poses.size());
+  EXPECT_NEAR(upper_half_xz_plane_weight, 0.5, kSampleSize * 0.01);  // allow 1% deviations
+}
+
+TEST(TestParticleCloud3, Assign) {
+  const auto particles = std::vector{
+      std::make_tuple(
+          Sophus::SE3d{
+              Sophus::SO3d{Eigen::Quaternion<double>{0.8497105, 0.0, 0.3728217, 0.3728217}},
+              Eigen::Vector3d{0.0, 0.0, 1.0}},
+          beluga::Weight(0.5)),
+      std::make_tuple(
+          Sophus::SE3d{
+              Sophus::SO3d{Eigen::Quaternion<double>{0.8497105, 0.0, -0.3728217, 0.3728217}},
+              Eigen::Vector3d{0.0, 0.0, -1.0}},
+          beluga::Weight(0.5)),
+  };
+  constexpr std::size_t kSampleSize = 1000U;
+  auto message = beluga_ros::msg::PoseArray{};
+  beluga_ros::assign_particle_cloud(particles, kSampleSize, message);
+  EXPECT_EQ(message.poses.size(), kSampleSize);
+  for (const auto& pose : message.poses) {
+    EXPECT_DOUBLE_EQ(pose.position.x, 0.0);
+    EXPECT_DOUBLE_EQ(pose.position.y, 0.0);
+    EXPECT_DOUBLE_EQ(std::abs(pose.position.z), 1.0);
+    EXPECT_DOUBLE_EQ(pose.orientation.x, 0.0);
+    EXPECT_NEAR(std::abs(pose.orientation.y), 0.3728217, 0.001);
+    EXPECT_NEAR(pose.orientation.z, 0.3728217, 0.001);
+    EXPECT_NEAR(pose.orientation.w, 0.8497105, 0.001);
+  }
+  const auto num_particles_in_upper_half_xy_plane =
+      ranges::count_if(message.poses, [](const auto& pose) { return pose.position.z > 0.0; });
   const double upper_half_xy_plane_weight =
       static_cast<double>(num_particles_in_upper_half_xy_plane) / static_cast<double>(message.poses.size());
   EXPECT_NEAR(upper_half_xy_plane_weight, 0.5, kSampleSize * 0.01);  // allow 1% deviations
@@ -63,6 +95,15 @@ TEST(TestParticleCloud, Assign) {
 TEST(TestParticleCloud, AssignNone) {
   const auto particles = std::vector{
       std::make_tuple(Sophus::SE2d{}, beluga::Weight(1.0)),
+  };
+  auto message = beluga_ros::msg::PoseArray{};
+  beluga_ros::assign_particle_cloud(particles, 0U, message);
+  EXPECT_EQ(message.poses.size(), 0U);
+}
+
+TEST(TestParticleCloud3, AssignNone) {
+  const auto particles = std::vector{
+      std::make_tuple(Sophus::SE3d{}, beluga::Weight(1.0)),
   };
   auto message = beluga_ros::msg::PoseArray{};
   beluga_ros::assign_particle_cloud(particles, 0U, message);
@@ -78,8 +119,24 @@ TEST(TestParticleCloud, AssignMatchingDistribution) {
   EXPECT_EQ(message.poses.size(), particles.size());
 }
 
+TEST(TestParticleCloud3, AssignMatchingDistribution) {
+  const auto particles = std::vector{
+      std::make_tuple(Sophus::SE3d{}, beluga::Weight(1.0)),
+  };
+  auto message = beluga_ros::msg::PoseArray{};
+  beluga_ros::assign_particle_cloud(particles, message);
+  EXPECT_EQ(message.poses.size(), particles.size());
+}
+
 TEST(TestParticleCloud, AssignMatchingEmpty) {
   const auto particles = std::vector<std::tuple<Sophus::SE2d, beluga::Weight>>{};
+  auto message = beluga_ros::msg::PoseArray{};
+  beluga_ros::assign_particle_cloud(particles, message);
+  EXPECT_EQ(message.poses.size(), 0U);
+}
+
+TEST(TestParticleCloud3, AssignMatchingEmpty) {
+  const auto particles = std::vector<std::tuple<Sophus::SE3d, beluga::Weight>>{};
   auto message = beluga_ros::msg::PoseArray{};
   beluga_ros::assign_particle_cloud(particles, message);
   EXPECT_EQ(message.poses.size(), 0U);
@@ -99,10 +156,32 @@ TEST(TestParticleCloud, AssignMarkers) {
   EXPECT_EQ(message.markers[1].points.size(), 3 * 2);  // 2 arrows, 3 vertices each
 }
 
+TEST(TestParticleCloud3, AssignMarkers) {
+  const auto particles = std::vector{
+      std::make_tuple(Sophus::SE3d{Sophus::SO3d{}, Eigen::Vector3d{1.0, 0.0, 0.0}}, beluga::Weight(0.35)),
+      std::make_tuple(Sophus::SE3d{Sophus::SO3d{}, Eigen::Vector3d{1.0, 0.0, 0.0}}, beluga::Weight(0.25)),
+      std::make_tuple(
+          Sophus::SE3d{Sophus::SO3d{Eigen::Quaternion<double>{1.0, 0.0, 0.0, 0.0}}, Eigen::Vector3d{0.0, -1.0, 0.0}},
+          beluga::Weight(0.4)),
+  };
+  auto message = beluga_ros::msg::MarkerArray{};
+  // beluga_ros::assign_particle_cloud(particles, message);
+  ASSERT_EQ(message.markers.size(), 2U);
+  EXPECT_EQ(message.markers[0].points.size(), 2 * 2);  // 2 arrows, 2 vertices each
+  EXPECT_EQ(message.markers[1].points.size(), 3 * 2);  // 2 arrows, 3 vertices each
+}
+
 TEST(TestParticleCloud, AssignNoMarkers) {
   const auto particles = std::vector<std::tuple<Sophus::SE2d, beluga::Weight>>{};
   auto message = beluga_ros::msg::MarkerArray{};
   beluga_ros::assign_particle_cloud(particles, message);
+  EXPECT_EQ(message.markers.size(), 0U);
+}
+
+TEST(TestParticleCloud3, AssignNoMarkers) {
+  const auto particles = std::vector<std::tuple<Sophus::SE3d, beluga::Weight>>{};
+  auto message = beluga_ros::msg::MarkerArray{};
+  // beluga_ros::assign_particle_cloud(particles, message);
   EXPECT_EQ(message.markers.size(), 0U);
 }
 

--- a/beluga_ros/test/test_particle_cloud.cpp
+++ b/beluga_ros/test/test_particle_cloud.cpp
@@ -60,6 +60,7 @@ TEST(TestParticleCloud, Assign) {
 }
 
 TEST(TestParticleCloud3, Assign) {
+  constexpr double kTolerance = 0.001;
   const auto particles = std::vector{
       std::make_tuple(
           Sophus::SE3d{
@@ -81,9 +82,9 @@ TEST(TestParticleCloud3, Assign) {
     EXPECT_DOUBLE_EQ(pose.position.y, 0.0);
     EXPECT_DOUBLE_EQ(std::abs(pose.position.z), 1.0);
     EXPECT_DOUBLE_EQ(pose.orientation.x, 0.0);
-    EXPECT_NEAR(std::abs(pose.orientation.y), 0.3728217, 0.001);
-    EXPECT_NEAR(pose.orientation.z, 0.3728217, 0.001);
-    EXPECT_NEAR(pose.orientation.w, 0.8497105, 0.001);
+    EXPECT_NEAR(std::abs(pose.orientation.y), 0.3728217, kTolerance);
+    EXPECT_NEAR(pose.orientation.z, 0.3728217, kTolerance);
+    EXPECT_NEAR(pose.orientation.w, 0.8497105, kTolerance);
   }
   const auto num_particles_in_upper_half_xy_plane =
       ranges::count_if(message.poses, [](const auto& pose) { return pose.position.z > 0.0; });

--- a/beluga_ros/test/test_particle_cloud.cpp
+++ b/beluga_ros/test/test_particle_cloud.cpp
@@ -158,14 +158,14 @@ TEST(TestParticleCloud, AssignMarkers) {
 
 TEST(TestParticleCloud3, AssignMarkers) {
   const auto particles = std::vector{
-      std::make_tuple(Sophus::SE3d{Sophus::SO3d{}, Eigen::Vector3d{1.0, 0.0, 0.0}}, beluga::Weight(0.35)),
-      std::make_tuple(Sophus::SE3d{Sophus::SO3d{}, Eigen::Vector3d{1.0, 0.0, 0.0}}, beluga::Weight(0.25)),
+      std::make_tuple(Sophus::SE3d{Sophus::SO3d{}, Eigen::Vector3d{0.0, 0.0, 1.0}}, beluga::Weight(0.35)),
+      std::make_tuple(Sophus::SE3d{Sophus::SO3d{}, Eigen::Vector3d{0.0, 0.0, 1.0}}, beluga::Weight(0.25)),
       std::make_tuple(
-          Sophus::SE3d{Sophus::SO3d{Eigen::Quaternion<double>{1.0, 0.0, 0.0, 0.0}}, Eigen::Vector3d{0.0, -1.0, 0.0}},
+          Sophus::SE3d{Sophus::SO3d{Eigen::Quaternion<double>{1.0, 0.0, 0.0, 0.0}}, Eigen::Vector3d{0.0, 0.0, -1.0}},
           beluga::Weight(0.4)),
   };
   auto message = beluga_ros::msg::MarkerArray{};
-  // beluga_ros::assign_particle_cloud(particles, message);
+  beluga_ros::assign_particle_cloud(particles, message);
   ASSERT_EQ(message.markers.size(), 2U);
   EXPECT_EQ(message.markers[0].points.size(), 2 * 2);  // 2 arrows, 2 vertices each
   EXPECT_EQ(message.markers[1].points.size(), 3 * 2);  // 2 arrows, 3 vertices each
@@ -181,7 +181,7 @@ TEST(TestParticleCloud, AssignNoMarkers) {
 TEST(TestParticleCloud3, AssignNoMarkers) {
   const auto particles = std::vector<std::tuple<Sophus::SE3d, beluga::Weight>>{};
   auto message = beluga_ros::msg::MarkerArray{};
-  // beluga_ros::assign_particle_cloud(particles, message);
+  beluga_ros::assign_particle_cloud(particles, message);
   EXPECT_EQ(message.markers.size(), 0U);
 }
 


### PR DESCRIPTION
### Proposed changes

Expand the already implemented almost_equal_to function for comparisons of SE3 transformations.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)

### Additional comments
If this look good, I will proceed to create the tests.
