### PR TITLE
Fix link to DEVELOPING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,8 @@ All types of contributions are encouraged and valued. See the [Table of Contents
   - [Reporting Bugs](#reporting-bugs)
   - [Requesting Features](#requesting-features)
   - [Your First Code Contribution](#your-first-code-contribution)
+    - [A Primer On Project Workflow](#a-primer-on-project-workflow)
+    - [How Do I Submit a Good Code Contribution?](#how-do-i-submit-a-good-code-contribution)
 - [Styleguides](#styleguides)
 
 ## I Have a Question
@@ -121,7 +123,7 @@ This projects adopts a [feature branch workflow](https://about.gitlab.com/topics
    ```bash
    git checkout -b <your_username>/fix-issue-12345 main
    ```
-1. **Work on your contribution**. See [instructions](GETTING_STARTED.md) on how to get started with Beluga development.
+1. **Work on your contribution**. See [instructions](DEVELOPING.md) on how to get started with Beluga development.
 1. **Test your changes**. For bug fixes, make sure regression tests are included.
 1. **Document your changes as needed**. For new features, make sure added functionality is clearly documented.
 1. **Push the branch to your fork on GitHub**.


### PR DESCRIPTION
### Proposed changes

This PR just changes a broken link on the docs that was pointing to a `GETTING_STARTED.md` file that doesn't exist anymore. The Table of Content of the file was updated automatically when saving.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [x] 📚 Documentation (change which fixes or extends documentation)

💥 **Breaking change!** _Explain why a non-backwards compatible change is necessary or remove this line entirely if not applicable._

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [ ] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

_Anything worth mentioning to the reviewers._
