### PR TITLE
Bump upload and download artifact actions to v4

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -142,7 +142,7 @@ jobs:
         run: make -C docs html
 
       - name: Upload documentation artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs
           path: ./docs/_build/html/
@@ -169,7 +169,7 @@ jobs:
           git rm -rf .
 
       - name: Download documentation artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: docs
 


### PR DESCRIPTION
### Proposed changes

Version v3 has been deprecated.

Reference:
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)