### PR TITLE
Add 2D state type to likelihood field sensor model for beluga_vdb

### DIFF
--- a/beluga/include/beluga/3d_embedding.hpp
+++ b/beluga/include/beluga/3d_embedding.hpp
@@ -31,6 +31,11 @@ inline Sophus::SE3d To3d(const Sophus::SE2d& tf) {
       Sophus::SO3d::rotZ(tf.so2().log()), Eigen::Vector3d{tf.translation().x(), tf.translation().y(), 0.0}};
 }
 
+/// Workaround for algorithms that need to handle 2D and 3D poses.
+inline Sophus::SE3d To3d(const Sophus::SE3d& pose) {
+  return pose;
+}
+
 }  // namespace beluga
 
 #endif

--- a/beluga_vdb/include/beluga_vdb/sensor/vdb_likelihood_field_model.hpp
+++ b/beluga_vdb/include/beluga_vdb/sensor/vdb_likelihood_field_model.hpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <openvdb/openvdb.h>
+#include <beluga/3d_embedding.hpp>
 
 #include <Eigen/Core>
 
@@ -80,7 +81,8 @@ struct VDBLikelihoodFieldModelParam {
 template <typename GridT, typename PointCloud, class StateType = Sophus::SE3d>
 class VDBLikelihoodFieldModel {
   static_assert(
-      std::is_same_v<StateType, Sophus::SE2d> or std::is_same_v<StateType, Sophus::SE3d>,
+      std::is_same_v<StateType, Sophus::SE2<typename StateType::Scalar>> or
+          std::is_same_v<StateType, Sophus::SE3<typename StateType::Scalar>>,
       "VDB likelihood field sensor model only supports SE2 and SE3 state types.");
 
  public:
@@ -129,24 +131,39 @@ class VDBLikelihoodFieldModel {
    * \return a state weighting function satisfying \ref StateWeightingFunctionPage
    *  and borrowing a reference to this sensor model (and thus their lifetime are bound).
    */
+  template <typename T = state_type>
   [[nodiscard]] auto operator()(measurement_type&& measurement) const {
     // Transform each point from the sensor frame to the origin frame
     auto transformed_points = measurement.points() | ranges::views::transform([&](const auto& point) {
                                 return measurement.origin() * point.template cast<double>();
                               }) |
                               ranges::to<std::vector>();
-
     return [this, points = std::move(transformed_points)](const state_type& state) -> weight_type {
-      return ranges::accumulate(
-          points |  //
-              ranges::views::transform([this, &state](const auto& point) {
-                const Eigen::Vector3d point_in_state_frame = state * point;
-                const openvdb::math::Coord ijk = transform_.worldToIndexCellCentered(
-                    openvdb::math::Vec3d(point_in_state_frame.x(), point_in_state_frame.y(), point_in_state_frame.z()));
-                const auto distance = accessor_.isValueOn(ijk) ? accessor_.getValue(ijk) : background_;
-                return amplitude_ * std::exp(-(distance * distance) / two_squared_sigma_) + offset_;
-              }),
-          1.0, std::plus{});
+      if constexpr (std::is_same_v<T, Sophus::SE3d>) {
+        // Logic for Sophus::SE3d
+        return ranges::accumulate(
+            points | ranges::views::transform([this, &state](const auto& point) {
+              const Eigen::Vector3d point_in_state_frame = state * point;
+              const openvdb::math::Coord ijk = transform_.worldToIndexCellCentered(
+                  openvdb::math::Vec3d(point_in_state_frame.x(), point_in_state_frame.y(), point_in_state_frame.z()));
+              const auto distance = accessor_.isValueOn(ijk) ? accessor_.getValue(ijk) : background_;
+              return amplitude_ * std::exp(-(distance * distance) / two_squared_sigma_) + offset_;
+            }),
+            1.0, std::plus{});
+      } else if constexpr (std::is_same_v<T, Sophus::SE2d>) {
+        // Logic for Sophus::SE2d
+        return ranges::accumulate(
+            points | ranges::views::transform([this, &state](const auto& point) {
+              const Eigen::Vector3d point_in_state_frame = beluga::To3d(state) * point;
+              const openvdb::math::Coord ijk = transform_.worldToIndexCellCentered(
+                  openvdb::math::Vec3d(point_in_state_frame.x(), point_in_state_frame.y(), point_in_state_frame.z()));
+              const auto distance = accessor_.isValueOn(ijk) ? accessor_.getValue(ijk) : background_;
+              return amplitude_ * std::exp(-(distance * distance) / two_squared_sigma_) + offset_;
+            }),
+            1.0, std::plus{});
+      } else {
+        static_assert("Unsupported state_type");
+      }
     };
   }
 

--- a/beluga_vdb/test/beluga_vdb/CMakeLists.txt
+++ b/beluga_vdb/test/beluga_vdb/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(test_beluga_vdb sensor/test_likelihood_3d_field_model.cpp)
+add_executable(test_beluga_vdb sensor/test_vdb_likelihood_field_model.cpp)
 
 target_link_libraries(test_beluga_vdb PRIVATE ${PROJECT_NAME} beluga_vdb
                                               GTest::gmock_main)

--- a/beluga_vdb/test/beluga_vdb/sensor/test_vdb_likelihood_field_model.cpp
+++ b/beluga_vdb/test/beluga_vdb/sensor/test_vdb_likelihood_field_model.cpp
@@ -63,7 +63,7 @@ auto make_map(const double voxel_size, const std::vector<T>& world_points) {
   // Transform to levelset
   return openvdb::tools::topologyToLevelSet(*grid, kHalfWidth, kClosingSteps);
 }
-
+/*
 TEST(TestVDBLikelihoodFieldModel2, Point) {
   openvdb::initialize();
   // Parameters
@@ -269,5 +269,5 @@ TEST(TestVDBLikelihoodFieldModel3, Cube) {
   auto state_weighting_function_far = sensor_model(std::move(pointcloud_measurement_far));
   ASSERT_LT(state_weighting_function_far(Sophus::SE3d{}), 6.85);
 }
-
+*/
 }  // namespace

--- a/beluga_vdb/test/beluga_vdb/sensor/test_vdb_likelihood_field_model.cpp
+++ b/beluga_vdb/test/beluga_vdb/sensor/test_vdb_likelihood_field_model.cpp
@@ -63,7 +63,7 @@ auto make_map(const double voxel_size, const std::vector<T>& world_points) {
   // Transform to levelset
   return openvdb::tools::topologyToLevelSet(*grid, kHalfWidth, kClosingSteps);
 }
-/*
+
 TEST(TestVDBLikelihoodFieldModel2, Point) {
   openvdb::initialize();
   // Parameters
@@ -269,5 +269,5 @@ TEST(TestVDBLikelihoodFieldModel3, Cube) {
   auto state_weighting_function_far = sensor_model(std::move(pointcloud_measurement_far));
   ASSERT_LT(state_weighting_function_far(Sophus::SE3d{}), 6.85);
 }
-*/
+
 }  // namespace


### PR DESCRIPTION
### Proposed changes

Changed the StateType of the likelihood field sensor model in `beluga_vdb` to a template in order to be able to use it with 2D motion models. And avoid issues like [#478  Unscented transform assertion when using 2.5D covariance matrix](https://github.com/Ekumen-OS/beluga/issues/478)

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [X] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [X] Lint and unit tests (if any) pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] All commits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

I changed the name of the sensor from `LikelihoodFieldModel3` to `VDBLikelihoodFieldModel` because I think it might be confusing, since the model will accept 2D particles. 