### PR TITLE
Implement low-variance sampling algorithm

### DIFF
--- a/beluga/docs/_doxygen/beluga-main.md
+++ b/beluga/docs/_doxygen/beluga-main.md
@@ -41,6 +41,7 @@ They are lazily evaluated range adaptor objects compatible with the Range-v3 lib
 | [beluga::views::states](@ref views/particles.hpp) | Produces a view of the states of a range of particles |
 | [beluga::views::take_evenly](@ref views/take_evenly.hpp) | Returns a range consisting of `count` elements evenly spaced over the source range |
 | [beluga::views::take_while_kld](@ref views/take_while_kld.hpp) | Take elements from a range while the KLD condition is statisfied |
+| [beluga::views::low_variance_sample](@ref views/low_variance_sample.hpp) | Implements low variance resampling for a given range of particles |
 | [beluga::views::weights](@ref views/particles.hpp) | Produces a view of the weights of a range of particles |
 | [beluga::views::zip](@ref views/zip.hpp) | Given N ranges, return a new range where the Mth element is a tuple of the Mth elements of all N ranges |
 

--- a/beluga/docs/index.md
+++ b/beluga/docs/index.md
@@ -23,6 +23,7 @@ The current set of features includes:
   - Multinomial resampling from a particle range
   - [Adaptive KLD resampling][fox2001]
   - [Selective resampling][grisetti2007], on-motion resampling, and interval resampling policies
+  - Low Variance sampling
   - Support for sequential and parallel execution policies
   - Weighted mean and covariance statistics for pose estimation
 - Sensor models:

--- a/beluga/docs/index.md
+++ b/beluga/docs/index.md
@@ -23,7 +23,7 @@ The current set of features includes:
   - Multinomial resampling from a particle range
   - [Adaptive KLD resampling][fox2001]
   - [Selective resampling][grisetti2007], on-motion resampling, and interval resampling policies
-  - Low Variance sampling
+  - [Low Variance sampling][thrun2005]
   - Support for sequential and parallel execution policies
   - Weighted mean and covariance statistics for pose estimation
 - Sensor models:
@@ -45,3 +45,4 @@ Beluga is built on top of the following open source libraries:
 [aos_soa]: https://en.wikipedia.org/wiki/AoS_and_SoA
 [fox2001]: https://dl.acm.org/doi/10.5555/2980539.2980632
 [grisetti2007]: https://doi.org/10.1109/TRO.2006.889486
+[thrun2005]: https://books.google.com.ar/books?id=jtSMEAAAQBAJ

--- a/beluga/include/beluga/views.hpp
+++ b/beluga/include/beluga/views.hpp
@@ -16,6 +16,7 @@
 #define BELUGA_VIEWS_HPP
 
 #include <beluga/views/elements.hpp>
+#include <beluga/views/low_variance_sample.hpp>
 #include <beluga/views/particles.hpp>
 #include <beluga/views/random_intersperse.hpp>
 #include <beluga/views/sample.hpp>

--- a/beluga/include/beluga/views/low_variance_sample.hpp
+++ b/beluga/include/beluga/views/low_variance_sample.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Ekumen, Inc.
+// Copyright 2025 Ekumen, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@
 #include <range/v3/utility/random.hpp>
 #include <range/v3/view/common.hpp>
 #include <range/v3/view/generate.hpp>
+#include <range/v3/view/repeat.hpp>
+#include <range/v3/view/take.hpp>
 
 #include <beluga/type_traits/particle_traits.hpp>
 #include <beluga/views/particles.hpp>
@@ -33,7 +35,16 @@ namespace beluga::views {
 
 namespace detail {
 
-/// Implementation of the sample view.
+/// Implementation of the low variance sample view.
+/// This algorithm computes a single random number r in the range [0, 1/M) and then selects samples from
+/// according to this number but still with a probability proportional to the sample weight. This is
+/// done by drawing a random number r in the interval [0;M^-1]. Where M is the number of samples in the range.
+/// It selects the particles by repeadly adding the fixed amount M^(-1) to r and by choosing the particle that
+/// corresponds to to the resulting number.
+/// Where M is the number of samples in the range.
+/// [Based on] Sebastian Thrun, Wolfram Burgard, and Dieter Fox. 2005. Probabilistic Robotics (Intelligent Robotics
+/// and Autonomous Agents). The MIT Press.
+
 /**
  * \tparam Range A [random access](https://en.cppreference.com/w/cpp/ranges/random_access_range) and
  *  [sized](https://en.cppreference.com/w/cpp/ranges/sized_range) range.
@@ -77,41 +88,42 @@ struct low_variance_sample_view
     /// Construct a cursor from the parent view elements.
     constexpr explicit cursor(low_variance_sample_view* view)
         : view_(view),
-          range_begin_{ranges::begin(view_->range_)},
-          weights_begin_{ranges::begin(view_->weights_)},
-          M_{static_cast<long long>(ranges::size(view_->range_))},
+          range_begin_{ranges::begin(view_->range_)},  // Begin iterator of the range
+          it_{range_begin_},
+          weights_begin_{ranges::begin(view_->weights_)},          // Begin iterator of the weights
+          M_{static_cast<uint64_t>(ranges::size(view_->range_))},  // Number of particles to be sampled
           r_{std::uniform_real_distribution<double>(0.0, 1.0 / static_cast<double>(M_))(
-              *view_->engine_)},  // Generate r only once
-          m_{0},
-          i_{0},
-          c_{*weights_begin_} {}
+              *view_->engine_)},  // random number in [0, 1/M)
+          m_{0},                  // Current sample index
+          i_{0},                  // Current index in the range.
+          c_{*weights_begin_}     // Cumulative weight of the first particle
+    {}
 
     /// Access the current iterator.
-    [[nodiscard]] constexpr decltype(auto) read() const noexcept(noexcept(*range_begin_)) { return *it_; }
+    [[nodiscard]] constexpr decltype(auto) read() const noexcept(noexcept(*this->it_)) { return *it_; }
 
     /// Position the current iterator.
     constexpr void next() {
       ++m_;
+      // A number U in [0, 1] that points to exactly one particle in the range.
+      // Where the particle i satisfies with i=argmin_j \sum_1^j w^m >= U.
       const double U = r_ + (static_cast<double>(m_) - 1.0) / static_cast<double>(M_);
-      while (U > c_) {
+      while (i_ < M_ - 1 && U > c_) {
         ++i_;
         c_ += static_cast<double>(*std::next(weights_begin_, i_));  // weights_begin_[i_]
       }
       it_ = std::next(range_begin_, i_);  // range_begin_ + i_
     }
 
-    /// Returns true if the cursor is at the end of the range.
-    constexpr bool equal(const cursor& other) const noexcept { return m_ == other.M_; }
-
    private:
     low_variance_sample_view* view_;
     ranges::iterator_t<Range> range_begin_;
     ranges::iterator_t<Range> it_;
     ranges::iterator_t<Weights> weights_begin_;
-    long long M_;
+    uint64_t M_;
     double r_;
-    long long m_;
-    long long i_;
+    uint64_t m_;
+    uint64_t i_;
     double c_;
   };
 
@@ -155,18 +167,10 @@ struct low_variance_sample_base_fn {
              ranges::views::transform(beluga::make_from_state<ranges::range_value_t<Range>>);
     } else {
       // Generate uniform weights if no weights are provided.
-      auto uniform_weights =
-          ranges::views::repeat_n(1.0, ranges::size(range));  // Use 1.0 for double weights. Important.
+      auto uniform_weights = ranges::views::repeat(1.0) | ranges::views::take(ranges::size(range));
       return low_variance_sample_from_range(std::forward<Range>(range), uniform_weights, engine);
     }
   }
-
-  // /// Sample from random distributions.
-  // template <class Distribution, class URNG>
-  // constexpr auto low_variance_sample_from_distribution(Distribution distribution, URNG& engine) const {
-  //   return ranges::views::generate(
-  //       [distribution = std::move(distribution), &engine]() mutable { return distribution(engine); });
-  // }
 };
 
 /// Implementation detail for a sample range adaptor object.
@@ -185,12 +189,9 @@ struct low_variance_sample_fn : public low_variance_sample_base_fn {
     if constexpr (ranges::range<T> && ranges::range<U>) {
       auto& engine = ranges::detail::get_random_engine();
       return low_variance_sample_from_range(std::forward<T>(t), std::forward<U>(u), engine);
-      // } else if constexpr (is_random_distribution_v<T>) {
-      //   static_assert(std::is_lvalue_reference_v<U&&>);  // Assume U is a URNG
-      //   return low_variance_sample_from_distribution(std::forward<T>(t), u);
     } else {
       static_assert(ranges::range<T>);
-      static_assert(std::is_lvalue_reference_v<U&&>);  // Assume U is a URNG
+      static_assert(std::is_lvalue_reference_v<U&&>);
       return low_variance_sample_from_range(std::forward<T>(t), u);
     }
   }
@@ -201,11 +202,8 @@ struct low_variance_sample_fn : public low_variance_sample_base_fn {
     if constexpr (ranges::range<T>) {
       auto& engine = ranges::detail::get_random_engine();
       return low_variance_sample_from_range(std::forward<T>(t), engine);
-      // } else if constexpr (is_random_distribution_v<T>) {
-      //   auto& engine = ranges::detail::get_random_engine();
-      //   return low_variance_sample_from_distribution(std::forward<T>(t), engine);
     } else {
-      static_assert(std::is_lvalue_reference_v<T&&>);  // Assume T is a URNG
+      static_assert(std::is_lvalue_reference_v<T&&>);
       return ranges::make_view_closure(ranges::bind_back(low_variance_sample_fn{}, std::ref(t)));
     }
   }
@@ -219,27 +217,8 @@ struct low_variance_sample_fn : public low_variance_sample_base_fn {
 };
 
 }  // namespace detail
+/// \brief A view adaptor that samples elements from a range with replacement using low variance sampling.
 
-/// [Range adaptor object](https://en.cppreference.com/w/cpp/named_req/RangeAdaptorObject) that
-/// will randomly sample with replacement from an input range.
-/**
- * Unlike `std::views::sample`, this does not require a size parameter and the samples will be taken
- * from the population **with replacement**, making the sample values independent.
- * To use this, the input range must model the
- * [random_access_range](https://en.cppreference.com/w/cpp/ranges/random_access_range)
- * and [sized_range](https://en.cppreference.com/w/cpp/ranges/sized_range) concepts.
- *
- * This view implements multinomial resampling for a given range of particles.
- * The core idea is to draw random indices / iterators to the input particle range
- * from a [multinomial distribution](https://en.wikipedia.org/wiki/Multinomial_distribution)
- * parameterized after particle weights (and assumed uniform for non-weighted particle ranges).
- *
- * This view can also be used to convert any random distribution (a callable that takes a URNG as an
- * input argument) into an infinite view that generates values from that distribution.
- *
- * This view is not cheap to copy, so care must be taken when moving it around.
- * Range-v3 does not support move-only views at the time of this implementation.
- */
 inline constexpr ranges::views::view_closure<detail::low_variance_sample_fn> low_variance_sample;
 
 }  // namespace beluga::views

--- a/beluga/include/beluga/views/low_variance_sample.hpp
+++ b/beluga/include/beluga/views/low_variance_sample.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Ekumen, Inc.
+// Copyright 2024 Ekumen, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,106 +15,233 @@
 #ifndef BELUGA_VIEWS_LOW_VARIANCE_SAMPLE_HPP
 #define BELUGA_VIEWS_LOW_VARIANCE_SAMPLE_HPP
 
-#include <algorithm>
-#include <cmath>
-#include <iostream>
-#include <numeric>
 #include <random>
-#include <vector>
 
-#include <range/v3/all.hpp>
+#include <range/v3/utility/random.hpp>
+#include <range/v3/view/common.hpp>
+#include <range/v3/view/generate.hpp>
 
 #include <beluga/type_traits/particle_traits.hpp>
+#include <beluga/views/particles.hpp>
 
-namespace beluga {
+/**
+ * \file
+ * \brief Implementation of a sample (with replacement) range adaptor object.
+ */
 
-namespace views {
+namespace beluga::views {
 
 namespace detail {
 
-/// Implementation detail for a low_variance_sample range adaptor object.
-struct low_variance_sample_fn {
-  /// Overload that implements the low_variance_sample algorithm.
+/// Implementation of the sample view.
+/**
+ * \tparam Range A [random access](https://en.cppreference.com/w/cpp/ranges/random_access_range) and
+ *  [sized](https://en.cppreference.com/w/cpp/ranges/sized_range) range.
+ * \tparam Weights
+ * \tparam URNG A random number generator that satisfies the
+ *  [UniformRandomBitGenerator](https://en.cppreference.com/w/cpp/named_req/UniformRandomBitGenerator)
+ *  requirements.
+ */
+template <class Range, class Weights, class URNG = typename ranges::detail::default_random_engine>
+struct low_variance_sample_view
+    : public ranges::view_facade<low_variance_sample_view<Range, Weights, URNG>, ranges::infinite> {
+ public:
+  /// Default constructor.
+  low_variance_sample_view() = default;
+
+  /// Construct the view from an existing range.
   /**
-   * \tparam Range An [input range](https://en.cppreference.com/w/cpp/ranges/input_range) with particle states
-   * or weights.
-   * \param range Source range from where to sample elements.
-   * \param n The number of samples to take (M in the algorithm).
+   * \param range The range to be adapted.
+   * \param weights The weights associated with the elements in the range.
+   * \param engine The random number generator object.
    */
-  template <class Range, std::enable_if_t<ranges::input_range<Range>, int> = 0>
-  constexpr auto operator()(Range&& range, std::size_t n) const {
-    static_assert(ranges::input_range<Range>);
-
-    using RangeValue = ranges::range_value_t<Range>;
-    std::vector<double> weights;
-    std::vector<RangeValue> particles;  // Store particles for direct access
-
-    if constexpr (is_particle_range_v<Range>) {
-      weights.reserve(ranges::distance(range));
-      particles.reserve(ranges::distance(range));
-      ranges::for_each(range, [&](const RangeValue& particle) {
-        weights.push_back(beluga::weight(particle));
-        particles.push_back(particle);
-      });
-    } else {
-      weights = ranges::to<std::vector<double>>(range);
-      particles = ranges::to<std::vector<RangeValue>>(range);
-    }
-
-    const std::size_t num_particles = weights.size();
-    if (num_particles == 0 || n == 0) {
-      return ranges::empty(range);
-    }
-
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_real_distribution<> distrib(0.0, 1.0);
-    const double r = distrib(gen);
-    const double inv_n = 1.0 / static_cast<double>(n);
-    double c = weights[0];
-    std::size_t i = 0;
-    std::vector<RangeValue> resampled_particles;
-    resampled_particles.reserve(n);
-
-    for (std::size_t m = 1; m <= n; ++m) {
-      const double u = r + static_cast<double>(m - 1) * inv_n;
-      while (u > c) {
-        i++;
-        if (i < num_particles) {
-          c += weights[i];
-        } else {
-          i = num_particles - 1;
-          break;
-        }
-      }
-      resampled_particles.push_back(particles[i]);
-    }
-
-    return resampled_particles | ranges::views::common;
+  constexpr low_variance_sample_view(Range range, Weights weights, URNG& engine = ranges::detail::get_random_engine())
+      : range_{std::move(range)}, weights_{std::move(weights)}, engine_{std::addressof(engine)} {
+    assert(ranges::size(range) > 0);
   }
 
-  /// Overload that returns a view closure to compose with other views.
+ private:
+  // `ranges::range_access` needs access to the cursor members.
+  friend ranges::range_access;
+
+  static_assert(ranges::sized_range<Range>);
+  static_assert(ranges::random_access_range<Range>);
+  static_assert(ranges::input_range<Weights>);
+
+  /// Cursor class that handles the iteration logic.
+  struct cursor {
+   public:
+    /// Default constructor.
+    cursor() = default;
+
+    /// Construct a cursor from the parent view elements.
+    constexpr explicit cursor(low_variance_sample_view* view)
+        : view_(view),
+          range_begin_{ranges::begin(view_->range_)},
+          weights_begin_{ranges::begin(view_->weights_)},
+          M_{static_cast<long long>(ranges::size(view_->range_))},
+          r_{std::uniform_real_distribution<double>(0.0, 1.0 / static_cast<double>(M_))(
+              *view_->engine_)},  // Generate r only once
+          m_{0},
+          i_{0},
+          c_{*weights_begin_} {}
+
+    /// Access the current iterator.
+    [[nodiscard]] constexpr decltype(auto) read() const noexcept(noexcept(*range_begin_)) { return *it_; }
+
+    /// Position the current iterator.
+    constexpr void next() {
+      ++m_;
+      const double U = r_ + (static_cast<double>(m_) - 1.0) / static_cast<double>(M_);
+      while (U > c_) {
+        ++i_;
+        c_ += static_cast<double>(*std::next(weights_begin_, i_));  // weights_begin_[i_]
+      }
+      it_ = std::next(range_begin_, i_);  // range_begin_ + i_
+    }
+
+    /// Returns true if the cursor is at the end of the range.
+    constexpr bool equal(const cursor& other) const noexcept { return m_ == other.M_; }
+
+   private:
+    low_variance_sample_view* view_;
+    ranges::iterator_t<Range> range_begin_;
+    ranges::iterator_t<Range> it_;
+    ranges::iterator_t<Weights> weights_begin_;
+    long long M_;
+    double r_;
+    long long m_;
+    long long i_;
+    double c_;
+  };
+
+  /// Return the cursor for the begin iterator.
+  [[nodiscard]] constexpr auto begin_cursor() { return cursor{this}; }
+
+  /// Return an unreachable sentinel since this is an infinite range.
+  [[nodiscard]] constexpr auto end_cursor() const noexcept { return ranges::unreachable_sentinel_t{}; }
+
+  Range range_;
+  Weights weights_;
+  URNG* engine_;
+};
+
+/// Implementation detail for a low_variance_sample algorithm.
+struct low_variance_sample_base_fn {
+ protected:
+  /// Sample from weighted ranges.
+  template <class Range, class Weights, class URNG>
+  constexpr auto low_variance_sample_from_range(Range&& range, Weights&& weights, URNG& engine) const {
+    static_assert(ranges::sized_range<Range>);
+    static_assert(ranges::random_access_range<Range>);
+    static_assert(ranges::input_range<Weights>);
+    return low_variance_sample_view{ranges::views::all(std::forward<Range>(range)), std::move(weights), engine};
+  }
+
+  /// Sample from any range.
   /**
-   * \param n The number of samples to take.
+   * If the input range is a particle range, it will extract the weights and treat it as a weighted range.
+   * The new particles will all have a weight equal to 1, since, after resampling, the probability will be
+   * represented by the number of particles rather than their individual weight.
+   *
+   * If the input range is not a particle range, it will assume a uniform distribution.
    */
-  constexpr auto operator()(std::size_t n) const {
-    return ranges::make_view_closure(ranges::bind_back(low_variance_sample_fn{}, n));
+  template <class Range, class URNG>
+  constexpr auto low_variance_sample_from_range(Range&& range, URNG& engine) const {
+    static_assert(ranges::sized_range<Range>);
+    static_assert(ranges::random_access_range<Range>);
+    if constexpr (beluga::is_particle_range_v<Range>) {
+      return low_variance_sample_from_range(beluga::views::states(range), beluga::views::weights(range), engine) |
+             ranges::views::transform(beluga::make_from_state<ranges::range_value_t<Range>>);
+    } else {
+      // Generate uniform weights if no weights are provided.
+      auto uniform_weights =
+          ranges::views::repeat_n(1.0, ranges::size(range));  // Use 1.0 for double weights. Important.
+      return low_variance_sample_from_range(std::forward<Range>(range), uniform_weights, engine);
+    }
+  }
+
+  // /// Sample from random distributions.
+  // template <class Distribution, class URNG>
+  // constexpr auto low_variance_sample_from_distribution(Distribution distribution, URNG& engine) const {
+  //   return ranges::views::generate(
+  //       [distribution = std::move(distribution), &engine]() mutable { return distribution(engine); });
+  // }
+};
+
+/// Implementation detail for a sample range adaptor object.
+struct low_variance_sample_fn : public low_variance_sample_base_fn {
+  /// Overload that takes three arguments.
+  template <class T, class U, class V>
+  constexpr auto operator()(T&& t, U&& u, V& v) const {
+    static_assert(ranges::range<T>);
+    static_assert(ranges::range<U>);
+    return low_variance_sample_from_range(std::forward<T>(t), std::forward<U>(u), v);  // Assume V is a URNG
+  }
+
+  /// Overload that takes two arguments.
+  template <class T, class U>
+  constexpr auto operator()(T&& t, U&& u) const {
+    if constexpr (ranges::range<T> && ranges::range<U>) {
+      auto& engine = ranges::detail::get_random_engine();
+      return low_variance_sample_from_range(std::forward<T>(t), std::forward<U>(u), engine);
+      // } else if constexpr (is_random_distribution_v<T>) {
+      //   static_assert(std::is_lvalue_reference_v<U&&>);  // Assume U is a URNG
+      //   return low_variance_sample_from_distribution(std::forward<T>(t), u);
+    } else {
+      static_assert(ranges::range<T>);
+      static_assert(std::is_lvalue_reference_v<U&&>);  // Assume U is a URNG
+      return low_variance_sample_from_range(std::forward<T>(t), u);
+    }
+  }
+
+  /// Overload that takes one argument.
+  template <class T>
+  constexpr auto operator()(T&& t) const {
+    if constexpr (ranges::range<T>) {
+      auto& engine = ranges::detail::get_random_engine();
+      return low_variance_sample_from_range(std::forward<T>(t), engine);
+      // } else if constexpr (is_random_distribution_v<T>) {
+      //   auto& engine = ranges::detail::get_random_engine();
+      //   return low_variance_sample_from_distribution(std::forward<T>(t), engine);
+    } else {
+      static_assert(std::is_lvalue_reference_v<T&&>);  // Assume T is a URNG
+      return ranges::make_view_closure(ranges::bind_back(low_variance_sample_fn{}, std::ref(t)));
+    }
+  }
+
+  /// Overload that unwraps the engine reference from a view closure.
+  template <class Range, class URNG>
+  constexpr auto operator()(Range&& range, std::reference_wrapper<URNG> engine) const {
+    static_assert(ranges::range<Range>);
+    return low_variance_sample_from_range(std::forward<Range>(range), engine.get());
   }
 };
 
 }  // namespace detail
 
 /// [Range adaptor object](https://en.cppreference.com/w/cpp/named_req/RangeAdaptorObject) that
-/// will perform low-variance sampling on the input range using the provided algorithm.
+/// will randomly sample with replacement from an input range.
 /**
- * The input range should be a set of particles with associated weights.
- * This adaptor will return a new range of resampled particles using the low-variance sampling
- * algorithm described.
+ * Unlike `std::views::sample`, this does not require a size parameter and the samples will be taken
+ * from the population **with replacement**, making the sample values independent.
+ * To use this, the input range must model the
+ * [random_access_range](https://en.cppreference.com/w/cpp/ranges/random_access_range)
+ * and [sized_range](https://en.cppreference.com/w/cpp/ranges/sized_range) concepts.
+ *
+ * This view implements multinomial resampling for a given range of particles.
+ * The core idea is to draw random indices / iterators to the input particle range
+ * from a [multinomial distribution](https://en.wikipedia.org/wiki/Multinomial_distribution)
+ * parameterized after particle weights (and assumed uniform for non-weighted particle ranges).
+ *
+ * This view can also be used to convert any random distribution (a callable that takes a URNG as an
+ * input argument) into an infinite view that generates values from that distribution.
+ *
+ * This view is not cheap to copy, so care must be taken when moving it around.
+ * Range-v3 does not support move-only views at the time of this implementation.
  */
-inline constexpr detail::low_variance_sample_fn low_variance_sample;
+inline constexpr ranges::views::view_closure<detail::low_variance_sample_fn> low_variance_sample;
 
-}  // namespace views
-
-}  // namespace beluga
+}  // namespace beluga::views
 
 #endif

--- a/beluga/include/beluga/views/low_variance_sample.hpp
+++ b/beluga/include/beluga/views/low_variance_sample.hpp
@@ -1,0 +1,120 @@
+// Copyright 2023-2025 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BELUGA_VIEWS_LOW_VARIANCE_SAMPLE_HPP
+#define BELUGA_VIEWS_LOW_VARIANCE_SAMPLE_HPP
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <vector>
+
+#include <range/v3/all.hpp>
+
+#include <beluga/type_traits/particle_traits.hpp>
+
+namespace beluga {
+
+namespace views {
+
+namespace detail {
+
+/// Implementation detail for a low_variance_sample range adaptor object.
+struct low_variance_sample_fn {
+  /// Overload that implements the low_variance_sample algorithm.
+  /**
+   * \tparam Range An [input range](https://en.cppreference.com/w/cpp/ranges/input_range) with particle states
+   * or weights.
+   * \param range Source range from where to sample elements.
+   * \param n The number of samples to take (M in the algorithm).
+   */
+  template <class Range, std::enable_if_t<ranges::input_range<Range>, int> = 0>
+  constexpr auto operator()(Range&& range, std::size_t n) const {
+    static_assert(ranges::input_range<Range>);
+
+    using RangeValue = ranges::range_value_t<Range>;
+    std::vector<double> weights;
+    std::vector<RangeValue> particles;  // Store particles for direct access
+
+    if constexpr (is_particle_range_v<Range>) {
+      weights.reserve(ranges::distance(range));
+      particles.reserve(ranges::distance(range));
+      ranges::for_each(range, [&](const RangeValue& particle) {
+        weights.push_back(beluga::weight(particle));
+        particles.push_back(particle);
+      });
+    } else {
+      weights = ranges::to<std::vector<double>>(range);
+      particles = ranges::to<std::vector<RangeValue>>(range);
+    }
+
+    const std::size_t num_particles = weights.size();
+    if (num_particles == 0 || n == 0) {
+      return ranges::empty(range);
+    }
+
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_real_distribution<> distrib(0.0, 1.0);
+    const double r = distrib(gen);
+    const double inv_n = 1.0 / static_cast<double>(n);
+    double c = weights[0];
+    std::size_t i = 0;
+    std::vector<RangeValue> resampled_particles;
+    resampled_particles.reserve(n);
+
+    for (std::size_t m = 1; m <= n; ++m) {
+      const double u = r + static_cast<double>(m - 1) * inv_n;
+      while (u > c) {
+        i++;
+        if (i < num_particles) {
+          c += weights[i];
+        } else {
+          i = num_particles - 1;
+          break;
+        }
+      }
+      resampled_particles.push_back(particles[i]);
+    }
+
+    return resampled_particles | ranges::views::common;
+  }
+
+  /// Overload that returns a view closure to compose with other views.
+  /**
+   * \param n The number of samples to take.
+   */
+  constexpr auto operator()(std::size_t n) const {
+    return ranges::make_view_closure(ranges::bind_back(low_variance_sample_fn{}, n));
+  }
+};
+
+}  // namespace detail
+
+/// [Range adaptor object](https://en.cppreference.com/w/cpp/named_req/RangeAdaptorObject) that
+/// will perform low-variance sampling on the input range using the provided algorithm.
+/**
+ * The input range should be a set of particles with associated weights.
+ * This adaptor will return a new range of resampled particles using the low-variance sampling
+ * algorithm described.
+ */
+inline constexpr detail::low_variance_sample_fn low_variance_sample;
+
+}  // namespace views
+
+}  // namespace beluga
+
+#endif

--- a/beluga/test/beluga/CMakeLists.txt
+++ b/beluga/test/beluga/CMakeLists.txt
@@ -67,6 +67,7 @@ add_executable(
   type_traits/test_tuple_traits.cpp
   utility/test_forward_like.cpp
   utility/test_indexing_iterator.cpp
+  views/test_low_variance_sample.cpp
   views/test_random_intersperse.cpp
   views/test_sample.cpp
   views/test_take_evenly.cpp

--- a/beluga/test/beluga/views/test_low_variance_sample.cpp
+++ b/beluga/test/beluga/views/test_low_variance_sample.cpp
@@ -1,0 +1,187 @@
+// Copyright 2025 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstddef>
+#include <random>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
+#include <range/v3/algorithm/count.hpp>
+#include <range/v3/algorithm/find.hpp>
+#include <range/v3/range/access.hpp>
+#include <range/v3/range/concepts.hpp>
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/range/dangling.hpp>
+#include <range/v3/range/primitives.hpp>
+#include <range/v3/view/const.hpp>
+#include <range/v3/view/take_exactly.hpp>
+
+#include "beluga/containers/tuple_vector.hpp"
+#include "beluga/primitives.hpp"
+#include "beluga/views/low_variance_sample.hpp"
+#include "beluga/views/particles.hpp"
+
+namespace {
+
+TEST(LowVarianceSampleView, FromEmptyRange) {
+  auto input = std::vector<int>{};
+  ASSERT_DEBUG_DEATH(beluga::views::low_variance_sample(input), "Assertion");
+}
+
+TEST(LowVarianceSampleView, ConceptChecksFromContiguousRange) {
+  auto input = std::array{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  auto output = beluga::views::low_variance_sample(input);
+
+  static_assert(ranges::common_range<decltype(input)>);
+  static_assert(!ranges::common_range<decltype(output)>);
+
+  static_assert(!ranges::viewable_range<decltype(input)>);
+  static_assert(ranges::viewable_range<decltype(output)>);
+
+  static_assert(ranges::forward_range<decltype(input)>);
+  static_assert(!ranges::forward_range<decltype(output)>);
+
+  static_assert(ranges::sized_range<decltype(input)>);
+  static_assert(!ranges::sized_range<decltype(output)>);
+
+  static_assert(ranges::bidirectional_range<decltype(input)>);
+  static_assert(!ranges::bidirectional_range<decltype(output)>);
+
+  static_assert(ranges::random_access_range<decltype(input)>);
+  static_assert(!ranges::random_access_range<decltype(output)>);
+
+  static_assert(ranges::contiguous_range<decltype(input)>);
+  static_assert(!ranges::contiguous_range<decltype(output)>);
+
+  static_assert(ranges::range<decltype(output)>);
+  static_assert(ranges::semiregular<decltype(output)>);
+  static_assert(ranges::enable_view<decltype(output)>);
+}
+
+TEST(LowVarianceSampleView, UniformDistributionSingleElement) {
+  auto input = std::array{5};
+  auto output = input | beluga::views::low_variance_sample | ranges::views::take_exactly(20);
+  ASSERT_EQ(ranges::count(output, 5), 20);
+}
+
+TEST(LowVarianceSampleView, DiscreteDistributionSingleElement) {
+  auto input = std::array{5};
+  auto weights = std::array{1.0};
+  auto output = beluga::views::low_variance_sample(input, weights) | ranges::views::take_exactly(20);
+  ASSERT_EQ(ranges::count(output, 5), 20);
+}
+
+TEST(LowVarianceSampleView, DiscreteDistributionSingleElementFromParticleRange) {
+  auto input = std::array{std::make_tuple(5, beluga::Weight(5.0))};
+  auto output = input | beluga::views::low_variance_sample | ranges::views::take_exactly(20) | ranges::to<std::vector>;
+  ASSERT_EQ(ranges::count(output | beluga::views::states, 5), 20);
+  ASSERT_EQ(ranges::count(output | beluga::views::weights, beluga::Weight(1.0)), 20);
+}
+
+TEST(LowVarianceSampleView, DoubleDereference) {
+  auto engine = std::mt19937{std::random_device()()};
+  auto input = std::array{10, 42, 39, 20, 50};
+  auto output = beluga::views::low_variance_sample(input, engine);
+  auto it = ranges::begin(output);
+  ++it;
+  auto value = *it;
+  ASSERT_EQ(value, *it);
+  ASSERT_EQ(value, *it);
+}
+
+TEST(LowVarianceSampleView, NonBorrowedRange) {
+  auto input = std::array{42};
+  const auto create_view = [&]() { return input | beluga::views::low_variance_sample; };
+  auto it = ranges::find(create_view(), 42);
+  static_assert(std::is_same_v<decltype(it), ranges::dangling>);
+}
+
+TEST(LowVarianceSampleView, EngineArgument) {
+  auto engine = std::mt19937{std::random_device()()};
+  auto input = std::array{5};
+  auto weights = std::array{1.0};
+  auto particles = std::array{std::make_tuple(5, beluga::Weight(1.0))};
+  [[maybe_unused]] auto view1 = beluga::views::low_variance_sample(engine);
+  [[maybe_unused]] auto view2 = input | view1;
+  [[maybe_unused]] auto view3 = particles | view1;
+  [[maybe_unused]] auto view4 = beluga::views::low_variance_sample(input, engine);
+  [[maybe_unused]] auto view5 = beluga::views::low_variance_sample(input, weights, engine);
+  [[maybe_unused]] auto view6 = beluga::views::low_variance_sample(particles, engine);
+}
+
+// Additional tests specific to low variance sampling properties
+
+TEST(LowVarianceSampleView, DeterministicWithSameSeed) {
+  const auto size = 100;
+
+  const auto input = beluga::TupleVector<std::tuple<int, beluga::Weight>>{
+      std::make_tuple(1, beluga::Weight(0.3)),  //
+      std::make_tuple(2, beluga::Weight(0.7))   //
+  };
+
+  // First run
+  auto engine1 = std::mt19937{12345};
+  auto output1 =
+      input | beluga::views::low_variance_sample(engine1) | ranges::views::take_exactly(size) | ranges::to<std::vector>;
+
+  // Second run with same seed
+  auto engine2 = std::mt19937{12345};
+  auto output2 =
+      input | beluga::views::low_variance_sample(engine2) | ranges::views::take_exactly(size) | ranges::to<std::vector>;
+
+  // Results should be identical
+  ASSERT_EQ(output1.size(), output2.size());
+  for (std::size_t i = 0; i < output1.size(); ++i) {
+    ASSERT_EQ(beluga::views::states(output1)[i], beluga::views::states(output2)[i]);
+  }
+}
+
+TEST(LowVarianceSampleView, VerySmallWeights) {
+  auto input = std::array{1, 2, 3};
+  auto weights = std::array{1e-10, 1e-8, 1.0};
+  auto output =
+      beluga::views::low_variance_sample(input, weights) | ranges::views::take_exactly(100) | ranges::to<std::vector>;
+
+  // Element 3 should dominate due to much larger weight
+  auto count_3 = ranges::count(output, 3);
+  ASSERT_GT(count_3, 95);  // Should be almost all element 3
+}
+
+TEST(LowVarianceSampleView, LargeRangePerformance) {
+  // Test with larger input to verify performance characteristics
+  std::vector<int> large_input(1000);
+  std::iota(large_input.begin(), large_input.end(), 1);
+
+  std::vector<double> uniform_weights(1000, 1.0 / 1000.0);
+
+  auto engine = std::mt19937{42};
+  auto output = beluga::views::low_variance_sample(large_input, uniform_weights, engine) |
+                ranges::views::take_exactly(5000) | ranges::to<std::vector>;
+
+  // Should complete without issues and produce correct number of samples
+  ASSERT_EQ(output.size(), 5000);
+
+  // All samples should be from the original range
+  for (const auto& sample : output) {
+    ASSERT_GE(sample, 1);
+    ASSERT_LE(sample, 1000);
+  }
+}
+
+}  // namespace

--- a/beluga/test/benchmark/CMakeLists.txt
+++ b/beluga/test/benchmark/CMakeLists.txt
@@ -18,6 +18,7 @@ option(BELUGA_RUN_PERFORMANCE_TESTS
 add_executable(
   benchmark_beluga
   benchmark_likelihood_field_model.cpp
+  benchmark_low_variance_sample.cpp
   benchmark_main.cpp
   benchmark_raycasting.cpp
   benchmark_spatial_hash.cpp

--- a/beluga/test/benchmark/benchmark_low_variance_sample.cpp
+++ b/beluga/test/benchmark/benchmark_low_variance_sample.cpp
@@ -1,0 +1,193 @@
+// Copyright 2025 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <benchmark/benchmark.h>
+
+#include <array>
+#include <cstddef>
+#include <random>
+#include <tuple>
+#include <type_traits>
+
+#include <range/v3/algorithm/copy.hpp>
+#include <range/v3/range/access.hpp>
+#include <range/v3/range/primitives.hpp>
+#include <range/v3/view/subrange.hpp>
+#include <range/v3/view/take_exactly.hpp>
+
+#include "beluga/containers/tuple_vector.hpp"
+#include "beluga/primitives.hpp"
+#include "beluga/views/low_variance_sample.hpp"
+#include "beluga/views/sample.hpp"
+
+namespace {
+
+struct State {
+  double x = 0.;
+  double y = 0.;
+  double theta = 0.;
+};
+
+using Container = beluga::TupleVector<std::tuple<State, beluga::Weight>>;
+using Particle = typename Container::value_type;
+
+// Helper function to create a container with uniform weights
+Container create_uniform_container(std::size_t size) {
+  auto container = Container{size};
+  for (auto&& [state, weight] : container) {
+    weight = 1.0;
+  }
+  return container;
+}
+
+// Helper function to create a container with varied weights
+Container create_weighted_container(std::size_t size) {
+  auto container = Container{size};
+  std::mt19937 gen(42);  // Fixed seed for reproducibility
+  std::uniform_real_distribution<double> dist(0.1, 2.0);
+
+  for (auto&& [state, weight] : container) {
+    weight = dist(gen);
+  }
+  return container;
+}
+
+// Helper function to create a container with exponentially distributed weights
+Container create_exponential_container(std::size_t size) {
+  auto container = Container{size};
+  std::mt19937 gen(42);  // Fixed seed for reproducibility
+  std::exponential_distribution<double> dist(1.0);
+
+  for (auto&& [state, weight] : container) {
+    weight = dist(gen) + 0.01;  // Add small offset to avoid zero weights
+  }
+  return container;
+}
+
+}  // namespace
+
+// Benchmark low variance sampling with uniform weights
+void BM_LowVarianceSample_Uniform(benchmark::State& state) {
+  const auto particle_count = state.range(0);
+  state.SetComplexityN(particle_count);
+  const auto container_size = static_cast<std::size_t>(particle_count);
+
+  auto container = create_uniform_container(container_size);
+  auto new_container = Container{container_size};
+
+  for (auto _ : state) {
+    auto samples = container |                           //
+                   beluga::views::low_variance_sample |  //
+                   ranges::views::take_exactly(container_size);
+    auto first = ranges::begin(new_container);
+    auto last = ranges::copy(samples, first).out;
+    auto result = ranges::make_subrange(first, last);
+    benchmark::DoNotOptimize(result);
+  }
+}
+
+BENCHMARK(BM_LowVarianceSample_Uniform)->RangeMultiplier(2)->Range(128, 1'000'000)->Complexity();
+
+// Benchmark low variance sampling with varied weights
+void BM_LowVarianceSample_Weighted(benchmark::State& state) {
+  const auto particle_count = state.range(0);
+  state.SetComplexityN(particle_count);
+  const auto container_size = static_cast<std::size_t>(particle_count);
+
+  auto container = create_weighted_container(container_size);
+  auto new_container = Container{container_size};
+
+  for (auto _ : state) {
+    auto samples = container |                           //
+                   beluga::views::low_variance_sample |  //
+                   ranges::views::take_exactly(container_size);
+    auto first = ranges::begin(new_container);
+    auto last = ranges::copy(samples, first).out;
+    auto result = ranges::make_subrange(first, last);
+    benchmark::DoNotOptimize(result);
+  }
+}
+
+BENCHMARK(BM_LowVarianceSample_Weighted)->RangeMultiplier(2)->Range(128, 1'000'000)->Complexity();
+
+// Benchmark low variance sampling with exponentially distributed weights
+void BM_LowVarianceSample_Exponential(benchmark::State& state) {
+  const auto particle_count = state.range(0);
+  state.SetComplexityN(particle_count);
+  const auto container_size = static_cast<std::size_t>(particle_count);
+
+  auto container = create_exponential_container(container_size);
+  auto new_container = Container{container_size};
+
+  for (auto _ : state) {
+    auto samples = container |                           //
+                   beluga::views::low_variance_sample |  //
+                   ranges::views::take_exactly(container_size);
+    auto first = ranges::begin(new_container);
+    auto last = ranges::copy(samples, first).out;
+    auto result = ranges::make_subrange(first, last);
+    benchmark::DoNotOptimize(result);
+  }
+}
+
+BENCHMARK(BM_LowVarianceSample_Exponential)->RangeMultiplier(2)->Range(128, 1'000'000)->Complexity();
+
+// Benchmark sampling performance with different sample sizes (fixed population)
+void BM_LowVarianceSample_VariableSampleSize(benchmark::State& state) {
+  const auto sample_count = state.range(0);
+  state.SetComplexityN(sample_count);
+  const auto container_size = 10000;  // Fixed large population
+  const auto sample_size = static_cast<std::size_t>(sample_count);
+
+  auto container = create_weighted_container(container_size);
+  auto new_container = Container{sample_size};
+
+  for (auto _ : state) {
+    auto samples = container |                           //
+                   beluga::views::low_variance_sample |  //
+                   ranges::views::take_exactly(sample_size);
+    auto first = ranges::begin(new_container);
+    auto last = ranges::copy(samples, first).out;
+    auto result = ranges::make_subrange(first, last);
+    benchmark::DoNotOptimize(result);
+    state.counters["SampleSize"] = static_cast<double>(sample_size);
+    state.counters["PopulationSize"] = static_cast<double>(container_size);
+  }
+}
+
+BENCHMARK(BM_LowVarianceSample_VariableSampleSize)->RangeMultiplier(2)->Range(64, 8192)->Complexity();
+
+// Benchmark memory access patterns by testing small vs large sample sizes
+void BM_LowVarianceSample_MemoryPattern(benchmark::State& state) {
+  const auto particle_count = state.range(0);
+  state.SetComplexityN(particle_count);
+  const auto container_size = static_cast<std::size_t>(particle_count);
+  const auto sample_size = std::max(static_cast<std::size_t>(1), container_size / 10);  // Sample 10% of particles
+
+  auto container = create_weighted_container(container_size);
+  auto new_container = Container{sample_size};
+
+  for (auto _ : state) {
+    auto samples = container |                           //
+                   beluga::views::low_variance_sample |  //
+                   ranges::views::take_exactly(sample_size);
+    auto first = ranges::begin(new_container);
+    auto last = ranges::copy(samples, first).out;
+    auto result = ranges::make_subrange(first, last);
+    benchmark::DoNotOptimize(result);
+    state.counters["SampleRatio"] = static_cast<double>(sample_size) / static_cast<double>(container_size);
+  }
+}
+
+BENCHMARK(BM_LowVarianceSample_MemoryPattern)->RangeMultiplier(2)->Range(1000, 100'000)->Complexity();

--- a/beluga/test/benchmark/benchmark_low_variance_sample.cpp
+++ b/beluga/test/benchmark/benchmark_low_variance_sample.cpp
@@ -57,9 +57,17 @@ Container create_weighted_container(std::size_t size) {
   std::mt19937 gen(42);  // Fixed seed for reproducibility
   std::uniform_real_distribution<double> dist(0.1, 2.0);
 
+  double total_weight = 0.0;
   for (auto&& [state, weight] : container) {
     weight = dist(gen);
+    total_weight += weight;
   }
+
+  // Normalize weights
+  for (auto&& [state, weight] : container) {
+    weight /= total_weight;
+  }
+
   return container;
 }
 
@@ -69,9 +77,17 @@ Container create_exponential_container(std::size_t size) {
   std::mt19937 gen(42);  // Fixed seed for reproducibility
   std::exponential_distribution<double> dist(1.0);
 
+  double total_weight = 0.0;
   for (auto&& [state, weight] : container) {
     weight = dist(gen) + 0.01;  // Add small offset to avoid zero weights
+    total_weight += weight;
   }
+
+  // Normalize weights
+  for (auto&& [state, weight] : container) {
+    weight /= total_weight;
+  }
+
   return container;
 }
 
@@ -173,7 +189,7 @@ void BM_LowVarianceSample_MemoryPattern(benchmark::State& state) {
   const auto particle_count = state.range(0);
   state.SetComplexityN(particle_count);
   const auto container_size = static_cast<std::size_t>(particle_count);
-  const auto sample_size = std::max(static_cast<std::size_t>(1), container_size / 10);  // Sample 10% of particles
+  const auto sample_size = std::max(1UL, container_size / 10UL);  // Sample 10% of particles
 
   auto container = create_weighted_container(container_size);
   auto new_container = Container{sample_size};


### PR DESCRIPTION
### Proposed changes

This PR adds the strategy of low-variance sampling for the resampling step. Adds a new range adaptor called `beluga::views::low_variance_sample`. Related to: https://github.com/Ekumen-OS/beluga/issues/48

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [X] 🚀 Feature (change which adds functionality)
- [X] 📚 Documentation (change which fixes or extends documentation)

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

#### How to run it?

- Run tests:
```bash
colcon build --packages-up-to beluga && ./build/beluga/test/beluga/test_beluga --gtest_filter="*LowVarianceSampleView*"
```
- Run microbenchmarks
```bash
colcon build --packages-up-to beluga && ./build/beluga/test/benchmark/benchmark_beluga --benchmark_filter=Low
```