### PR TITLE
Add support for ROS 2 nodes test isolation

### DIFF
--- a/beluga_amcl/package.xml
+++ b/beluga_amcl/package.xml
@@ -31,8 +31,7 @@
   <depend condition="$ROS_VERSION == 2">rclcpp_lifecycle</depend>
 
   <test_depend condition="$ROS_VERSION == 1">rostest</test_depend>
-  <test_depend condition="$ROS_VERSION == 2">ament_cmake_gmock</test_depend>
-  <test_depend condition="$ROS_VERSION == 2">ament_cmake_gtest</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_cmake_ros</test_depend>
 
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>

--- a/beluga_amcl/test/cmake/ament.cmake
+++ b/beluga_amcl/test/cmake/ament.cmake
@@ -12,23 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_package(ament_cmake_gmock REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 
 file(COPY test_data DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
-ament_add_gmock(test_ros2_common test_ros2_common.cpp)
+ament_add_ros_isolated_gmock(test_ros2_common test_ros2_common.cpp)
 target_compile_options(test_ros2_common PRIVATE -Wno-deprecated-copy)
 target_link_libraries(test_ros2_common beluga_amcl_ros2_common)
 target_include_directories(test_ros2_common
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/test_utils)
 
-ament_add_gmock(test_amcl_node test_amcl_node.cpp)
+ament_add_ros_isolated_gmock(test_amcl_node test_amcl_node.cpp)
 target_compile_options(test_amcl_node PRIVATE -Wno-deprecated-copy)
 target_link_libraries(test_amcl_node amcl_node_component)
 target_include_directories(test_amcl_node
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/test_utils)
 
-ament_add_gmock(
+ament_add_ros_isolated_gmock(
   test_ndt_amcl_node
   test_ndt_amcl_node.cpp
   WORKING_DIRECTORY
@@ -38,7 +38,7 @@ target_include_directories(test_ndt_amcl_node
 target_compile_options(test_ndt_amcl_node PRIVATE -Wno-deprecated-copy)
 target_link_libraries(test_ndt_amcl_node ndt_amcl_node_component)
 
-ament_add_gmock(
+ament_add_ros_isolated_gmock(
   test_ndt_amcl_3d_node
   test_ndt_amcl_3d_node.cpp
   WORKING_DIRECTORY

--- a/beluga_ros/package.xml
+++ b/beluga_ros/package.xml
@@ -28,8 +28,7 @@
   <depend>visualization_msgs</depend>
 
   <test_depend condition="$ROS_VERSION == 1">rostest</test_depend>
-  <test_depend condition="$ROS_VERSION == 2">ament_cmake_gmock</test_depend>
-  <test_depend condition="$ROS_VERSION == 2">ament_cmake_gtest</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_cmake_ros</test_depend>
 
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>

--- a/beluga_ros/test/cmake/ament.cmake
+++ b/beluga_ros/test/cmake/ament.cmake
@@ -12,33 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_package(ament_cmake_gmock REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
-ament_add_gmock(test_amcl test_amcl.cpp)
+ament_add_ros_isolated_gmock(test_amcl test_amcl.cpp)
 target_compile_options(test_amcl PRIVATE -Wno-deprecated-copy)
 target_link_libraries(test_amcl beluga_ros)
 
-ament_add_gmock(test_messages test_messages.cpp)
+ament_add_ros_isolated_gmock(test_messages test_messages.cpp)
 target_compile_options(test_messages PRIVATE -Wno-deprecated-copy)
 target_link_libraries(test_messages beluga_ros)
 
-ament_add_gmock(test_occupancy_grid test_occupancy_grid.cpp)
+ament_add_ros_isolated_gmock(test_occupancy_grid test_occupancy_grid.cpp)
 target_compile_options(test_occupancy_grid PRIVATE -Wno-deprecated-copy)
 target_link_libraries(test_occupancy_grid beluga_ros)
 
-ament_add_gmock(test_tf2_sophus test_tf2_sophus.cpp)
+ament_add_ros_isolated_gmock(test_tf2_sophus test_tf2_sophus.cpp)
 target_compile_options(test_tf2_sophus PRIVATE -Wno-deprecated-copy)
 target_link_libraries(test_tf2_sophus beluga_ros)
 
-ament_add_gmock(test_laser_scan test_laser_scan.cpp)
+ament_add_ros_isolated_gmock(test_laser_scan test_laser_scan.cpp)
 target_compile_options(test_laser_scan PRIVATE -Wno-deprecated-copy)
 target_link_libraries(test_laser_scan beluga_ros)
 
-ament_add_gmock(test_particle_cloud test_particle_cloud.cpp)
+ament_add_ros_isolated_gmock(test_particle_cloud test_particle_cloud.cpp)
 target_compile_options(test_particle_cloud PRIVATE -Wno-deprecated-copy)
 target_link_libraries(test_particle_cloud beluga_ros)
 
-ament_add_gmock(test_point_cloud test_point_cloud.cpp)
+ament_add_ros_isolated_gmock(test_point_cloud test_point_cloud.cpp)
 target_compile_options(test_point_cloud PRIVATE -Wno-deprecated-copy)
 target_link_libraries(test_point_cloud beluga_ros)


### PR DESCRIPTION
### Proposed changes

This PR addresses https://github.com/Ekumen-OS/beluga/issues/496 by using [ament_cmake_ros](https://github.com/ros2/ament_cmake_ros/tree/jazzy/ament_cmake_ros) to provides ROS 2 node test isolation for packages `beluga_ros` and `beluga_amcl`. 
It also removes the unused `ament_cmake_gtest` test dependency, which is likely a leftover from past iterations.

Changes in both `beluga_ros` and `beluga_amcl`:
- Tests use `ament_add_ros_isolated_gmock` macro rather than `ament_add_gmock`.
- Test Cmake files find package `ament_cmake_ros` rather than `ament_cmake_gmock`.
- `package.xml` updates on test dependencies:
  - Removes unused `ament_cmake_gtest`.
  - Changes `ament_cmake_gmock` in favor of `ament_cmake_ros`.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes (jazzy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)
