### PR TITLE
Add new overload for reweight action that tracks likelihood

### DIFF
--- a/beluga/docs/_doxygen/beluga-main.md
+++ b/beluga/docs/_doxygen/beluga-main.md
@@ -36,6 +36,7 @@ They are lazily evaluated range adaptor objects compatible with the Range-v3 lib
 | | |
 |-|-|
 | [beluga::views::elements](@ref views/elements.hpp) | Takes a view of tuple-like values and a number N and produces a view of Nth element of each tuple |
+| [beluga::views::likelihoods](@ref views/likelihoods.hpp) | Produces a view of the likelihoods obtained after applying a specific model to a range of particles
 | [beluga::views::random_intersperse](@ref views/random_intersperse.hpp) | Inserts values from a generator function between contiguous elements based on a given probability |
 | [beluga::views::sample](@ref views/sample.hpp) | Implements multinomial resampling for a given range of particles or distribution |
 | [beluga::views::states](@ref views/particles.hpp) | Produces a view of the states of a range of particles |

--- a/beluga/include/beluga/actions/reweight.hpp
+++ b/beluga/include/beluga/actions/reweight.hpp
@@ -17,13 +17,14 @@
 
 #include <algorithm>
 #include <execution>
+#include <type_traits>
 
 #include <beluga/type_traits/particle_traits.hpp>
+#include <beluga/views/likelihoods.hpp>
 #include <beluga/views/particles.hpp>
 
 #include <range/v3/action/action.hpp>
-#include <range/v3/algorithm/max_element.hpp>
-#include <range/v3/view/common.hpp>
+#include <range/v3/view/zip.hpp>
 
 /**
  * \file
@@ -34,83 +35,129 @@ namespace beluga::actions {
 
 namespace detail {
 
+/// Internal trait to detect if a particle has a public 'likelihood' member variable.
+template <typename T, typename = void>
+struct has_likelihood_member : std::false_type {};
+
+template <typename T>
+struct has_likelihood_member<T, std::void_t<decltype(std::declval<T&>().likelihood)>> : std::true_type {};
+
+/// Helper constant for the likelihood member trait.
+template <typename T>
+inline constexpr bool has_likelihood_member_v = has_likelihood_member<T>::value;
+
 /// Implementation detail for a reweight range adaptor object.
-struct reweight_base_fn {
-  /// Overload that implements the reweight algorithm.
+struct reweight_fn {
+ private:
+  /// Internal core implementation for reweighting logic.
+  template <class ExecutionPolicy, class Range, class LikelihoodRange>
+  constexpr void apply_impl(ExecutionPolicy&& policy, Range& range, const LikelihoodRange& likelihoods) const {
+    // Update particle weights using std::transform.
+    auto weights = range | beluga::views::weights;
+    std::transform(
+        policy, std::begin(weights), std::end(weights), std::begin(likelihoods), std::begin(weights),
+        [](auto weight, auto likelihood) { return weight * likelihood; });
+
+    // Store raw likelihood if the particle type has storage for it.
+    // We use ranges::views::zip here because we are performing side-effects (writing to members)
+    // which std::transform is not designed for.
+    using ParticleType = ranges::range_value_t<Range>;
+    if constexpr (has_likelihood_member_v<ParticleType>) {
+      auto zipped = ranges::views::zip(range, likelihoods);
+      std::for_each(policy, std::begin(zipped), std::end(zipped), [](auto&& tuple) {
+        auto& particle = std::get<0>(tuple);
+        particle.likelihood = std::get<1>(tuple);
+      });
+    }
+  }
+
+ public:
+  /// Primary overload that applies a given range of likelihoods or a model to a particle range.
   /**
    * \tparam ExecutionPolicy An [execution policy](https://en.cppreference.com/w/cpp/algorithm/execution_policy_tag_t).
    * \tparam Range An [input range](https://en.cppreference.com/w/cpp/ranges/input_range) of particles.
-   * \tparam Model A callable that can compute the importance weight given a particle state.
+   * \tparam Input Either a LikelihoodRange or a Model callable.
    * \param policy The execution policy to use.
    * \param range An existing range of particles to apply this action to.
-   * \param model A callable instance to compute the weights given the particle states.
-   *
-   * For each particle, we multiply the current weight by the new importance weight to accumulate information from
-   * sensor updates.
+   * \param input A range of likelihood values or a sensor model to calculate them.
    */
   template <
       class ExecutionPolicy,
       class Range,
-      class Model,
+      class Input,
       std::enable_if_t<std::is_execution_policy_v<std::decay_t<ExecutionPolicy>>, int> = 0,
       std::enable_if_t<ranges::range<Range>, int> = 0>
-  constexpr auto operator()(ExecutionPolicy&& policy, Range& range, Model model) const -> Range& {
+  constexpr auto operator()(ExecutionPolicy&& policy, Range& range, Input&& input) const -> Range& {
     static_assert(beluga::is_particle_range_v<Range>);
-    auto states = range | beluga::views::states | ranges::views::common;
-    auto weights = range | beluga::views::weights | ranges::views::common;
-    std::transform(
-        policy,               //
-        std::begin(states),   //
-        std::end(states),     //
-        std::begin(weights),  //
-        std::begin(weights),  //
-        [model = std::move(model)](const auto& s, auto w) { return w * model(s); });
+    if constexpr (ranges::range<Input>) {
+      apply_impl(std::forward<ExecutionPolicy>(policy), range, input);
+    } else {
+      apply_impl(
+          std::forward<ExecutionPolicy>(policy), range, range | beluga::views::likelihoods(std::forward<Input>(input)));
+    }
     return range;
   }
 
-  /// Overload that re-orders arguments from a view closure.
+  /// Convenience overload that defines a default execution policy.
+  /**
+   * \param range An existing range of particles to apply this action to.
+   * \param input A range of likelihood values or a sensor model to calculate them.
+   */
   template <
       class Range,
-      class Model,
+      class Input,
+      std::enable_if_t<ranges::range<Range>, int> = 0,
+      std::enable_if_t<!std::is_execution_policy_v<std::decay_t<Input>>, int> = 0>
+  constexpr auto operator()(Range& range, Input&& input) const -> Range& {
+    return (*this)(std::execution::seq, range, std::forward<Input>(input));
+  }
+
+  /// Re-ordering overload to support range-v3 closure argument passing.
+  /**
+   * This is required to bridge the gap between piped closures and the primary implementation.
+   */
+  template <
+      class Range,
+      class Input,
       class ExecutionPolicy,
       std::enable_if_t<ranges::range<Range>, int> = 0,
-      std::enable_if_t<std::is_execution_policy_v<ExecutionPolicy>, int> = 0>
-  constexpr auto operator()(Range&& range, Model model, ExecutionPolicy policy) const -> Range& {
-    return (*this)(std::move(policy), std::forward<Range>(range), std::move(model));
+      std::enable_if_t<std::is_execution_policy_v<std::decay_t<ExecutionPolicy>>, int> = 0>
+  constexpr auto operator()(Range&& range, Input&& input, ExecutionPolicy&& policy) const -> auto& {
+    return (*this)(std::forward<ExecutionPolicy>(policy), range, std::forward<Input>(input));
   }
 
-  /// Overload that returns a view closure to compose with other views.
-  template <class ExecutionPolicy, class Model, std::enable_if_t<std::is_execution_policy_v<ExecutionPolicy>, int> = 0>
-  constexpr auto operator()(ExecutionPolicy policy, Model model) const {
-    return ranges::make_action_closure(ranges::bind_back(reweight_base_fn{}, std::move(model), std::move(policy)));
-  }
-};
-
-/// Implementation detail for a reweight range adaptor object with a default execution policy.
-struct reweight_fn : public reweight_base_fn {
-  using reweight_base_fn::operator();
-
-  /// Overload that defines a default execution policy.
-  template <class Range, class Model, std::enable_if_t<ranges::range<Range>, int> = 0>
-  constexpr auto operator()(Range&& range, Model model) const -> Range& {
-    return (*this)(std::execution::seq, std::forward<Range>(range), std::move(model));
+  /// Overload that returns a view closure to compose with other views using an execution policy.
+  /**
+   * \param policy The execution policy to use.
+   * \param input A range of likelihood values or a sensor model to calculate them.
+   */
+  template <
+      class ExecutionPolicy,
+      class Input,
+      std::enable_if_t<std::is_execution_policy_v<std::decay_t<ExecutionPolicy>>, int> = 0,
+      std::enable_if_t<!ranges::range<std::decay_t<ExecutionPolicy>>, int> = 0>
+  constexpr auto operator()(ExecutionPolicy policy, Input input) const {
+    return ranges::make_action_closure(ranges::bind_back(reweight_fn{}, std::move(input), std::move(policy)));
   }
 
-  /// Overload that returns a view closure to compose with other views.
-  template <class Model>
-  constexpr auto operator()(Model model) const {
-    return ranges::make_action_closure(ranges::bind_back(reweight_fn{}, std::move(model)));
+  /// Overload that returns a view closure to compose with other views using the default execution policy.
+  /**
+   * \param input A range of likelihood values or a sensor model to calculate them.
+   */
+  template <class Input, std::enable_if_t<!std::is_execution_policy_v<std::decay_t<Input>>, int> = 0>
+  constexpr auto operator()(Input input) const {
+    return ranges::make_action_closure(ranges::bind_back(reweight_fn{}, std::move(input)));
   }
 };
 
 }  // namespace detail
 
 /// [Range adaptor object](https://en.cppreference.com/w/cpp/named_req/RangeAdaptorObject) that
-/// can update the weights in a particle range using a sensor model.
+/// updates the weights in a particle range using a sensor model or a likelihood range.
 /**
  * This action updates particle weights by importance weight multiplication.
- * These importance weights are computed by a given measurement likelihood
- * function (or sensor model) for current particle states.
+ * If the particle type has a public `likelihood` member, the raw likelihood values
+ * used for the update are also stored in the particles.
  */
 inline constexpr detail::reweight_fn reweight;
 

--- a/beluga/include/beluga/views.hpp
+++ b/beluga/include/beluga/views.hpp
@@ -16,6 +16,7 @@
 #define BELUGA_VIEWS_HPP
 
 #include <beluga/views/elements.hpp>
+#include <beluga/views/likelihoods.hpp>
 #include <beluga/views/particles.hpp>
 #include <beluga/views/random_intersperse.hpp>
 #include <beluga/views/sample.hpp>

--- a/beluga/include/beluga/views/likelihoods.hpp
+++ b/beluga/include/beluga/views/likelihoods.hpp
@@ -1,0 +1,89 @@
+// Copyright 2025 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BELUGA_VIEWS_LIKELIHOODS_HPP
+#define BELUGA_VIEWS_LIKELIHOODS_HPP
+
+#include <utility>
+
+#include <beluga/views/particles.hpp>
+#include <range/v3/view/transform.hpp>
+
+/**
+ * \file
+ * \brief Implementation of the likelihoods range adaptor object.
+ */
+
+namespace beluga::views {
+
+namespace detail {
+
+/// \brief Implementation detail for the likelihoods range adaptor object.
+///
+/// This struct follows the common C++ standard library pattern for creating
+/// a customizable function object. We define a global constexpr instance of
+/// this struct, which makes the view easy to use and compose.
+struct likelihoods_fn {
+  /// \brief Creates a view that computes the likelihood for each particle in a source range.
+  /// \tparam Model A callable type that takes a particle's state and returns its likelihood (e.g., a double or float).
+  /// \param model An instance of the sensor model callable.
+  /// \return A range adaptor closure. When this closure is applied to a range of particles,
+  ///         it returns a new lazy-evaluated view containing the likelihoods.
+  template <class Model>
+  constexpr auto operator()(Model model) const {
+    // This is the core of the ranges composition pattern.
+    // A view is created by chaining together other views using the pipe operator `|`.
+    //
+    // 1. `beluga::views::states`: This is the first adaptor in the chain. It takes a range
+    //    of particles and produces a view of just their `state` members.
+    //
+    // 2. `ranges::views::transform(std::move(model))`: This is the second adaptor. It takes a
+    //    range of elements (which will be the particle states from the previous step)
+    //    and applies the `model` function to each one, producing a view of the results (the likelihoods).
+    //
+    // The result of piping these two adaptors together is a *new adaptor*. This new adaptor
+    // is a "range adaptor closure" object that can be stored and later piped with an actual
+    // range of particles to create the final view.
+    return beluga::views::states | ranges::views::transform(std::move(model));
+  }
+};
+
+}  // namespace detail
+
+/// \brief A [range adaptor object](https://en.cppreference.com/w/cpp/named_req/RangeAdaptorObject)
+/// that produces a view of particle likelihoods.
+///
+/// This view takes a range of particles and a sensor model, and returns a new lazy-evaluated
+/// range where each element is the likelihood of the corresponding particle's state, as
+/// computed by the model.
+///
+/// ### Example
+///
+/// \code{.cpp}
+/// auto particles = ...;
+/// auto sensor_model = [](const auto& state) -> double { return 0.5; };
+///
+/// // Create a lazy view of the likelihoods. No computation happens here.
+/// auto likelihoods_view = particles | beluga::views::likelihoods(sensor_model);
+///
+/// // The model is called only as we iterate.
+/// for (double likelihood : likelihoods_view) {
+///   // use likelihood...
+/// }
+/// \endcode
+inline constexpr detail::likelihoods_fn likelihoods;
+
+}  // namespace beluga::views
+
+#endif  // BELUGA_VIEWS_LIKELIHOODS_HPP

--- a/beluga/test/beluga/CMakeLists.txt
+++ b/beluga/test/beluga/CMakeLists.txt
@@ -67,6 +67,7 @@ add_executable(
   type_traits/test_tuple_traits.cpp
   utility/test_forward_like.cpp
   utility/test_indexing_iterator.cpp
+  views/test_likelihoods.cpp
   views/test_random_intersperse.cpp
   views/test_sample.cpp
   views/test_take_evenly.cpp

--- a/beluga/test/beluga/actions/test_reweight.cpp
+++ b/beluga/test/beluga/actions/test_reweight.cpp
@@ -21,11 +21,13 @@
 #include <vector>
 
 #include <range/v3/range/conversion.hpp>
+#include <range/v3/view/filter.hpp>
 #include <range/v3/view/intersperse.hpp>
 
 #include "beluga/actions/assign.hpp"
 #include "beluga/actions/reweight.hpp"
 #include "beluga/primitives.hpp"
+#include "beluga/views/likelihoods.hpp"
 #include "beluga/views/particles.hpp"
 
 namespace {
@@ -66,6 +68,38 @@ TEST(ReweightAction, StatefulModel) {
   auto weights = input | beluga::views::weights | ranges::to<std::vector>;
   ASSERT_THAT(weights, testing::ElementsAre(0, 1, 2));
   ASSERT_EQ(model(0), 3);  // the model was passed by reference
+}
+
+TEST(ReweightAction, WithLikelihoodsRange) {
+  auto particles = std::vector{
+      std::make_tuple(1, beluga::Weight(0.5)), std::make_tuple(2, beluga::Weight(1.0)),
+      std::make_tuple(3, beluga::Weight(4.0))};
+  // A pre-calculated range of likelihoods
+  const auto likelihoods = std::vector<double>{10.0, 2.0, 0.25};
+
+  particles |= beluga::actions::reweight(likelihoods);
+
+  auto weights = particles | beluga::views::weights | ranges::to<std::vector>;
+  // Expected weights:
+  // 0.5 * 10.0 = 5.0
+  // 1.0 * 2.0  = 2.0
+  // 4.0 * 0.25 = 1.0
+  ASSERT_THAT(weights, testing::ElementsAre(5.0, 2.0, 1.0));
+}
+
+TEST(ReweightAction, WithLikelihoodsView) {
+  auto particles = std::vector{std::make_tuple(5, beluga::Weight(2.0))};
+  auto model = [](int value) { return static_cast<double>(value); };
+
+  // Create the lazy view of likelihoods.
+  auto likelihoods_view = particles | beluga::views::likelihoods(model);
+
+  // Use the view in the reweight action.
+  // This directly tests the integration of the new view and the new action overload.
+  particles |= beluga::actions::reweight(likelihoods_view);
+
+  // Expected weight is 2.0 * model(5) = 10.0
+  ASSERT_EQ(particles.front(), std::make_tuple(5, 10.0));
 }
 
 }  // namespace

--- a/beluga/test/beluga/views/BUILD.bazel
+++ b/beluga/test/beluga/views/BUILD.bazel
@@ -28,6 +28,7 @@ load("@rules_cc//cc:defs.bzl", "cc_test")
         ],
     )
     for file in [
+        "test_likelihoods.cpp",
         "test_random_intersperse.cpp",
         "test_sample.cpp",
         "test_take_evenly.cpp",

--- a/beluga/test/beluga/views/test_likelihoods.cpp
+++ b/beluga/test/beluga/views/test_likelihoods.cpp
@@ -1,0 +1,100 @@
+// Copyright 2025 Ekumen, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include <range/v3/range/concepts.hpp>
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view/filter.hpp>
+
+#include "beluga/primitives.hpp"
+#include "beluga/views/likelihoods.hpp"
+
+namespace {
+
+// Use a simple tuple-based particle for testing, consistent with other tests.
+using TestParticle = std::tuple<int, beluga::Weight>;
+
+TEST(LikelihoodsView, CorrectlyTransformsStates) {
+  // Create a set of particles and a simple sensor model.
+  const auto particles = std::vector<TestParticle>{{10, 0.5}, {20, 0.4}, {30, 0.1}};
+  // The model simply doubles the state value.
+  auto model = [](int state) { return static_cast<double>(state * 2); };
+
+  // Apply the likelihoods view.
+  auto likelihoods_view = particles | beluga::views::likelihoods(model);
+
+  // The view should contain the results of applying the model to each particle's state.
+  const auto expected_likelihoods = std::vector<double>{20.0, 40.0, 60.0};
+  ASSERT_THAT(likelihoods_view | ranges::to<std::vector>, testing::ElementsAreArray(expected_likelihoods));
+}
+
+TEST(LikelihoodsView, IsLazy) {
+  // Create particles and a model along with a call counter.
+  const auto particles = std::vector<TestParticle>{{1, 0.5}, {2, 0.5}};
+  int call_count = 0;
+  auto model = [&](int state) {
+    call_count++;
+    return static_cast<double>(state);
+  };
+
+  // Create the view.
+  auto likelihoods_view = particles | beluga::views::likelihoods(model);
+
+  // The model should not have been called yet.
+  ASSERT_EQ(call_count, 0);
+
+  // Iterate over the view.
+  auto result = likelihoods_view | ranges::to<std::vector>;
+
+  // The model should now have been called for each particle.
+  ASSERT_EQ(call_count, 2);
+  ASSERT_EQ(result.size(), 2);
+}
+
+TEST(LikelihoodsView, ConceptChecks) {
+  // Create a vector of particles (std::vector is well known and fulfills several range concepts).
+  const auto particles = std::vector<TestParticle>{};
+  auto model = [](int state) { return static_cast<double>(state); };
+  auto output = particles | beluga::views::likelihoods(model);
+
+  // The likelihoods view, being a transform, it's structure-preserving and should preserve the properties
+  // of the input range.
+  static_assert(ranges::viewable_range<decltype(output)>);
+  static_assert(ranges::sized_range<decltype(output)>);
+  static_assert(ranges::forward_range<decltype(output)>);
+  static_assert(ranges::bidirectional_range<decltype(output)>);
+  static_assert(ranges::random_access_range<decltype(output)>);
+
+  // The size of the output view should be the same as the input.
+  ASSERT_EQ(ranges::size(particles), ranges::size(output));
+}
+
+TEST(LikelihoodsView, ComposesWithOtherViews) {
+  const auto particles = std::vector<TestParticle>{{5, 0.5}, {15, 0.25}, {25, 0.25}};
+  auto model = [](int state) { return static_cast<double>(state); };
+
+  // Create the likelihoods view and pipe it into another view (a filter for the likelihoods).
+  auto filtered_likelihoods = particles | beluga::views::likelihoods(model) |
+                              ranges::views::filter([](double likelihood) { return likelihood > 10.0; });
+
+  // The final output should be correct after composition.
+  const auto expected_likelihoods = std::vector<double>{15.0, 25.0};
+  ASSERT_THAT(filtered_likelihoods | ranges::to<std::vector>, testing::ElementsAreArray(expected_likelihoods));
+}
+
+}  // namespace


### PR DESCRIPTION
### Proposed changes

Closes #524. Changes include a new overload for the `reweight` action, tracking likelihood as well and storing it in the particle structure if there is a member for it.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

_Anything worth mentioning to the reviewers._
