### PR TITLE
add missing Eigen/Eigenvalues include for GCC 15 / Eigen5 compatibility

### DIFF
--- a/beluga/include/beluga/algorithm/estimation.hpp
+++ b/beluga/include/beluga/algorithm/estimation.hpp
@@ -19,6 +19,7 @@
 #include <range/v3/view/repeat_n.hpp>
 #include <range/v3/view/transform.hpp>
 
+#include <Eigen/Eigenvalues>
 #include <sophus/se2.hpp>
 #include <sophus/se3.hpp>
 #include <sophus/so3.hpp>

--- a/beluga/include/beluga/random/multivariate_normal_distribution.hpp
+++ b/beluga/include/beluga/random/multivariate_normal_distribution.hpp
@@ -18,6 +18,7 @@
 #include <random>
 #include <utility>
 
+#include <Eigen/Eigenvalues>
 #include <beluga/random/multivariate_distribution_traits.hpp>
 
 /**


### PR DESCRIPTION
### Proposed changes

GCC 15 adds a new -Wtemplate-body diagnostic that validates template bodies at definition time, not just at instantiation. This exposed two missing #include <Eigen/Eigenvalues> in beluga's headers.

Unlike typical warnings, this is a hard error at instantiation time unfortunately.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 **Breaking change!** _Explain why a non-backwards compatible change is necessary or remove this line entirely if not applicable._

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

_Anything worth mentioning to the reviewers._
