### PR TITLE
Do not promote warnings for maximum compatibility

### DIFF
--- a/beluga/CMakeLists.txt
+++ b/beluga/CMakeLists.txt
@@ -44,6 +44,9 @@ find_package(range-v3 REQUIRED)
 find_package(Sophus REQUIRED)
 find_package(TBB REQUIRED)
 
+# Older Eigen version doing fancy (or unorthodox) stuff
+set_target_properties(Eigen3::Eigen PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${EIGEN_INCLUDE_DIRS}")
+
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(
   ${PROJECT_NAME}


### PR DESCRIPTION
### Proposed changes

New compiler version introduce new warnings. But your branch still targets ROS Humble which is gcc11.
Removing the promotion of warnings to errors solves this.

I recommend developers to remove warnings anyhow or optionally run with `-Wall` in CI environments to make sure they don't propagate into your codebase.

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

💥 **Breaking change!** _Explain why a non-backwards compatible change is necessary or remove this line entirely if not applicable._

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

_Anything worth mentioning to the reviewers._
