### PR TITLE
Add paranoid mode

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -31,6 +31,8 @@ jobs:
             upload_artifacts: true
     container:
       image: ros:${{ matrix.ros_distro }}-ros-base
+    env:
+      BELUGA_PARANOID: "1"
     steps:
       - name: Install debian packages
         run: >-

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -44,6 +44,9 @@ To bring up a development environment:
 
 The Beluga project started as a ROS 2 project and therefore relies on a typical ROS 2 workflow. In particular, the Beluga project subscribes to [REP-2004](https://ros.org/reps/rep-2004.html) and aims for Quality Level 1. For development, this translates to mandatory API documentation and a 95% code coverage policy for unit and integration testing.
 
+> [!IMPORTANT]
+> Quality standards are enforced by CI/CD pipelines and within development containers. In particular, `$BELUGA_PARANOID` is always set to `1` in both environments, heightening code scrutiny. This is equivalent to forcing `-DPARANOID:BOOL=ON` for `colcon` builds in other settings.
+
 Within a development environment:
 
 1. **Build and test the project**. You will usually use `colcon`.

--- a/beluga/CMakeLists.txt
+++ b/beluga/CMakeLists.txt
@@ -25,15 +25,22 @@ if(NOT CMAKE_BUILD_TYPE)
       CACHE STRING "Build type" FORCE)
 endif()
 
+set(DEFAULT_PARANOID OFF)
+if(DEFINED ENV{BELUGA_PARANOID})
+  set(DEFAULT_PARANOID $ENV{BELUGA_PARANOID})
+endif()
+option(PARANOID "Enable paranoid mode" ${DEFAULT_PARANOID})
+unset(DEFAULT_PARANOID)
+
 add_library(beluga_compile_options INTERFACE)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   target_compile_options(
     beluga_compile_options
     INTERFACE -Wall
               -Wconversion
-              -Werror
               -Wextra
-              -Wpedantic)
+              -Wpedantic
+              $<$<BOOL:${PARANOID}>:-Werror>)
 endif()
 if(CMAKE_BUILD_TYPE MATCHES "Debug")
   target_compile_options(beluga_compile_options INTERFACE -fno-inline)
@@ -45,24 +52,37 @@ find_package(range-v3 REQUIRED)
 find_package(Sophus REQUIRED)
 find_package(TBB REQUIRED)
 
+set(_deps
+    Eigen3::Eigen
+    range-v3::range-v3
+    Sophus::Sophus
+    TBB::tbb)
+if(NOT PARANOID)
+  foreach(target IN ITEMS ${_deps})
+    if(TARGET ${target})
+      set_target_properties(${target} PROPERTIES SYSTEM ON)
+    endif()
+  endforeach()
+endif()
+
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(
   ${PROJECT_NAME}
   INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
             "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
-target_link_libraries(
-  ${PROJECT_NAME}
-  INTERFACE Eigen3::Eigen
-            ${HDF5_CXX_LIBRARIES}
-            Sophus::Sophus
-            TBB::tbb
-            range-v3::range-v3)
+target_link_libraries(${PROJECT_NAME} INTERFACE ${_deps})
 target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_17)
 target_compile_definitions(${PROJECT_NAME} INTERFACE EIGEN_NO_DEBUG
                                                      SOPHUS_USE_BASIC_LOGGING)
 
 if(HDF5_FOUND)
-  target_include_directories(${PROJECT_NAME} INTERFACE ${HDF5_INCLUDE_DIRS})
+  if(PARANOID)
+    target_include_directories(${PROJECT_NAME} INTERFACE ${HDF5_INCLUDE_DIRS})
+  else()
+    target_include_directories(${PROJECT_NAME} SYSTEM
+                               INTERFACE ${HDF5_INCLUDE_DIRS})
+  endif()
+  target_link_libraries(${PROJECT_NAME} INTERFACE ${HDF5_CXX_LIBRARIES})
   target_compile_definitions(${PROJECT_NAME} INTERFACE BELUGA_HAS_HDF5)
 else()
   message(

--- a/beluga_amcl/CMakeLists.txt
+++ b/beluga_amcl/CMakeLists.txt
@@ -60,7 +60,6 @@ set(_deps
     rclcpp::rclcpp
     rclcpp_components::component
     rclcpp_lifecycle::rclcpp_lifecycle
-    std_srvs::std_srvs_library
     message_filters::message_filters
     ${std_srvs_TARGETS}
     tf2_ros::tf2_ros)
@@ -79,7 +78,7 @@ target_sources(beluga_amcl_ros2_common PRIVATE src/ros2_common.cpp)
 target_include_directories(
   beluga_amcl_ros2_common
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-         $<INSTALL_INTERFACE:include/${PROJECT_NAME}> ${std_srvs_INCLUDE_DIRS})
+         $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 
 target_link_libraries(beluga_amcl_ros2_common
                       PUBLIC beluga::beluga beluga_ros::beluga_ros ${_deps})

--- a/beluga_amcl/CMakeLists.txt
+++ b/beluga_amcl/CMakeLists.txt
@@ -25,13 +25,20 @@ if(NOT CMAKE_BUILD_TYPE)
       CACHE STRING "Build type" FORCE)
 endif()
 
+set(DEFAULT_PARANOID OFF)
+if(DEFINED ENV{BELUGA_PARANOID})
+  set(DEFAULT_PARANOID $ENV{BELUGA_PARANOID})
+endif()
+option(PARANOID "Enable paranoid mode" ${DEFAULT_PARANOID})
+unset(DEFAULT_PARANOID)
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(
     -Wall
     -Wconversion
     -Wextra
-    -Werror
-    -Wpedantic)
+    -Wpedantic
+    $<$<BOOL:${PARANOID}>:-Werror>)
 endif()
 if(CMAKE_BUILD_TYPE MATCHES "Debug")
   add_compile_options(-fno-inline)
@@ -48,6 +55,24 @@ find_package(std_srvs REQUIRED)
 find_package(message_filters REQUIRED)
 find_package(tf2_ros REQUIRED)
 
+set(_deps
+    bondcpp::bondcpp
+    rclcpp::rclcpp
+    rclcpp_components::component
+    rclcpp_lifecycle::rclcpp_lifecycle
+    std_srvs::std_srvs_library
+    message_filters::message_filters
+    ${std_srvs_TARGETS}
+    tf2_ros::tf2_ros)
+
+if(NOT PARANOID)
+  foreach(target IN ITEMS ${_deps})
+    if(TARGET ${target})
+      set_target_properties(${target} PROPERTIES SYSTEM ON)
+    endif()
+  endforeach()
+endif()
+
 add_library(beluga_amcl_ros2_common SHARED)
 target_sources(beluga_amcl_ros2_common PRIVATE src/ros2_common.cpp)
 
@@ -56,15 +81,8 @@ target_include_directories(
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
          $<INSTALL_INTERFACE:include/${PROJECT_NAME}> ${std_srvs_INCLUDE_DIRS})
 
-target_link_libraries(
-  beluga_amcl_ros2_common
-  PUBLIC beluga_ros::beluga_ros
-         bondcpp::bondcpp
-         rclcpp::rclcpp
-         rclcpp_components::component
-         rclcpp_lifecycle::rclcpp_lifecycle
-         tf2_ros::tf2_ros
-         ${std_srvs_TARGETS})
+target_link_libraries(beluga_amcl_ros2_common
+                      PUBLIC beluga::beluga beluga_ros::beluga_ros ${_deps})
 
 target_compile_definitions(
   beluga_amcl_ros2_common
@@ -92,15 +110,8 @@ target_link_libraries(amcl_node_component PUBLIC beluga_amcl_ros2_common)
 
 target_compile_features(amcl_node_component PUBLIC cxx_std_17)
 
-target_link_libraries(
-  amcl_node_component
-  PUBLIC beluga::beluga
-         beluga_ros::beluga_ros
-         bondcpp::bondcpp
-         rclcpp::rclcpp
-         rclcpp_components::component
-         rclcpp_lifecycle::rclcpp_lifecycle
-         ${std_srvs_TARGETS})
+target_link_libraries(amcl_node_component
+                      PUBLIC beluga::beluga beluga_ros::beluga_ros ${_deps})
 
 rclcpp_components_register_node(
   amcl_node_component
@@ -129,15 +140,8 @@ target_compile_features(ndt_amcl_node_component PUBLIC cxx_std_17)
 
 target_link_libraries(ndt_amcl_node_component PUBLIC beluga_amcl_ros2_common)
 
-target_link_libraries(
-  ndt_amcl_node_component
-  PUBLIC beluga::beluga
-         beluga_ros::beluga_ros
-         bondcpp::bondcpp
-         rclcpp::rclcpp
-         rclcpp_components::component
-         rclcpp_lifecycle::rclcpp_lifecycle
-         ${std_srvs_TARGETS})
+target_link_libraries(ndt_amcl_node_component
+                      PUBLIC beluga::beluga beluga_ros::beluga_ros ${_deps})
 
 rclcpp_components_register_node(
   ndt_amcl_node_component
@@ -165,15 +169,8 @@ target_compile_features(ndt_amcl_node_3d_component PUBLIC cxx_std_17)
 
 target_link_libraries(ndt_amcl_node_3d_component PUBLIC beluga_amcl_ros2_common)
 
-target_link_libraries(
-  ndt_amcl_node_3d_component
-  PUBLIC beluga::beluga
-         beluga_ros::beluga_ros
-         bondcpp::bondcpp
-         rclcpp::rclcpp
-         rclcpp_components::component
-         rclcpp_lifecycle::rclcpp_lifecycle
-         ${std_srvs_TARGETS})
+target_link_libraries(ndt_amcl_node_3d_component
+                      PUBLIC beluga::beluga beluga_ros::beluga_ros ${_deps})
 
 rclcpp_components_register_node(
   ndt_amcl_node_3d_component

--- a/beluga_ros/CMakeLists.txt
+++ b/beluga_ros/CMakeLists.txt
@@ -25,13 +25,20 @@ if(NOT CMAKE_BUILD_TYPE)
       CACHE STRING "Build type" FORCE)
 endif()
 
+set(DEFAULT_PARANOID OFF)
+if(DEFINED ENV{BELUGA_PARANOID})
+  set(DEFAULT_PARANOID $ENV{BELUGA_PARANOID})
+endif()
+option(PARANOID "Enable paranoid mode" ${DEFAULT_PARANOID})
+unset(DEFAULT_PARANOID)
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(
     -Wall
     -Wconversion
     -Wextra
-    -Werror
-    -Wpedantic)
+    -Wpedantic
+    $<$<BOOL:${PARANOID}>:-Werror>)
 endif()
 if(CMAKE_BUILD_TYPE MATCHES "Debug")
   add_compile_options(-fno-inline)
@@ -48,23 +55,30 @@ find_package(tf2_eigen REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
 
+set(_deps
+    ${geometry_msgs_TARGETS}
+    ${nav_msgs_TARGETS}
+    ${sensor_msgs_TARGETS}
+    ${std_msgs_TARGETS}
+    ${visualization_msgs_TARGETS}
+    tf2::tf2
+    tf2_eigen::tf2_eigen
+    tf2_geometry_msgs::tf2_geometry_msgs)
+
+if(NOT PARANOID)
+  foreach(target IN ITEMS ${_deps})
+    if(TARGET ${target})
+      set_target_properties(${target} PROPERTIES SYSTEM ON)
+    endif()
+  endforeach()
+endif()
+
 add_library(beluga_ros)
 target_sources(beluga_ros PRIVATE src/amcl.cpp src/ndt_ellipsoid.cpp)
 target_include_directories(
   beluga_ros PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                     $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
-target_link_libraries(beluga_ros PUBLIC beluga::beluga)
-target_link_libraries(
-  beluga_ros
-  PUBLIC ${geometry_msgs_TARGETS}
-         ${nav_msgs_TARGETS}
-         ${sensor_msgs_TARGETS}
-         ${std_msgs_TARGETS}
-         ${visualization_msgs_TARGETS}
-         sensor_msgs::sensor_msgs_library
-         tf2::tf2
-         tf2_eigen::tf2_eigen
-         tf2_geometry_msgs::tf2_geometry_msgs)
+target_link_libraries(beluga_ros PUBLIC beluga::beluga ${_deps})
 target_compile_features(beluga_ros PUBLIC cxx_std_17)
 
 set_target_properties(beluga_ros PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/beluga_system_tests/CMakeLists.txt
+++ b/beluga_system_tests/CMakeLists.txt
@@ -25,13 +25,20 @@ if(NOT CMAKE_BUILD_TYPE)
       CACHE STRING "Build type" FORCE)
 endif()
 
+set(DEFAULT_PARANOID OFF)
+if(DEFINED ENV{BELUGA_PARANOID})
+  set(DEFAULT_PARANOID $ENV{BELUGA_PARANOID})
+endif()
+option(PARANOID "Enable paranoid mode" ${DEFAULT_PARANOID})
+unset(DEFAULT_PARANOID)
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(
     -Wall
     -Wconversion
-    -Werror
     -Wextra
-    -Wpedantic)
+    -Wpedantic
+    $<$<BOOL:${PARANOID}>:-Werror>)
 endif()
 
 option(BUILD_TESTING "Build the testing tree." ON)

--- a/beluga_tutorial/CMakeLists.txt
+++ b/beluga_tutorial/CMakeLists.txt
@@ -25,13 +25,20 @@ if(NOT CMAKE_BUILD_TYPE)
       CACHE STRING "Build type" FORCE)
 endif()
 
+set(DEFAULT_PARANOID OFF)
+if(DEFINED ENV{BELUGA_PARANOID})
+  set(DEFAULT_PARANOID $ENV{BELUGA_PARANOID})
+endif()
+option(PARANOID "Enable paranoid mode" ${DEFAULT_PARANOID})
+unset(DEFAULT_PARANOID)
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(
     -Wall
     -Wconversion
     -Wextra
-    -Werror
-    -Wpedantic)
+    -Wpedantic
+    $<$<BOOL:${PARANOID}>:-Werror>)
 endif()
 
 find_package(beluga REQUIRED)
@@ -46,6 +53,9 @@ target_include_directories(
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
          $<INSTALL_INTERFACE:include> ${yaml_cpp_vendor_INCLUDE_DIRS})
 
+if(NOT PARANOID)
+  set_target_properties(yaml-cpp PROPERTIES SYSTEM ON)
+endif()
 target_link_libraries(${PROJECT_NAME} beluga::beluga yaml-cpp)
 
 install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION lib/${PROJECT_NAME})

--- a/beluga_vdb/CMakeLists.txt
+++ b/beluga_vdb/CMakeLists.txt
@@ -29,11 +29,14 @@ if(NOT CMAKE_BUILD_TYPE)
       CACHE STRING "Build type" FORCE)
 endif()
 
-find_package(beluga REQUIRED)
+set(DEFAULT_PARANOID OFF)
+if(DEFINED ENV{BELUGA_PARANOID})
+  set(DEFAULT_PARANOID $ENV{BELUGA_PARANOID})
+endif()
+option(PARANOID "Enable paranoid mode" ${DEFAULT_PARANOID})
+unset(DEFAULT_PARANOID)
 
-find_package(Eigen3 REQUIRED NO_MODULE)
-find_package(range-v3 REQUIRED)
-find_package(Sophus REQUIRED)
+find_package(beluga REQUIRED)
 
 if(NOT OPENVDB_CMAKE_MODULE_PATH)
   file(
@@ -65,6 +68,10 @@ if(OPENVDB_CMAKE_MODULE_PATH)
   list(POP_BACK CMAKE_MODULE_PATH)
 endif()
 
+if(NOT PARANOID)
+  set_target_properties(OpenVDB::openvdb PROPERTIES SYSTEM ON)
+endif()
+
 add_library(${PROJECT_NAME} INTERFACE)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -73,8 +80,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     INTERFACE -Wall
               -Wconversion
               -Wextra
-              -Werror
-              -Wpedantic)
+              -Wpedantic
+              $<$<BOOL:${PARANOID}>:-Werror>)
 endif()
 if(CMAKE_BUILD_TYPE MATCHES "Debug")
   target_compile_options(${PROJECT_NAME} INTERFACE -fno-inline)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - DISPLAY
       - QT_X11_NO_MITSHM=1
       - XAUTHORITY=/tmp/.docker.xauth
+      - BELUGA_PARANOID=1
     stdin_open: true
     tty: true
     user: ${USERID:-1000}:${GROUPID:-1000}


### PR DESCRIPTION
### Proposed changes

This patch allows us to keep our strict warnings are errors policy while cutting some slack to users, as per discussion in [Ekumen-OS/beluga#554](https://github.com/Ekumen-OS/beluga/pull/554#discussion_r3044883570).

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [x] Lint and unit tests (if any) pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)
