### PR TITLE
Add localization quality estimation metric

### DIFF
--- a/beluga_amcl/include/beluga_amcl/amcl_node.hpp
+++ b/beluga_amcl/include/beluga_amcl/amcl_node.hpp
@@ -154,8 +154,10 @@ class AmclNode : public BaseAMCLNode {
   /// Likelihood field publisher
   rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::OccupancyGrid>::SharedPtr likelihood_field_pub_;
 
-  /// Localization quality publisher
-  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Float64>::SharedPtr quality_pub_;
+  /// Per-axis localization quality publishers (x, y, yaw).
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Float64>::SharedPtr quality_x_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Float64>::SharedPtr quality_y_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Float64>::SharedPtr quality_yaw_pub_;
 
   /// Global relocalization service server.
   rclcpp::Service<std_srvs::srv::Empty>::SharedPtr global_localization_server_;

--- a/beluga_amcl/include/beluga_amcl/amcl_node.hpp
+++ b/beluga_amcl/include/beluga_amcl/amcl_node.hpp
@@ -36,6 +36,7 @@
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
+#include <std_msgs/msg/float64.hpp>
 #include <std_srvs/srv/empty.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
@@ -152,6 +153,9 @@ class AmclNode : public BaseAMCLNode {
 
   /// Likelihood field publisher
   rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::OccupancyGrid>::SharedPtr likelihood_field_pub_;
+
+  /// Localization quality publisher
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Float64>::SharedPtr quality_pub_;
 
   /// Global relocalization service server.
   rclcpp::Service<std_srvs::srv::Empty>::SharedPtr global_localization_server_;

--- a/beluga_amcl/src/amcl_node.cpp
+++ b/beluga_amcl/src/amcl_node.cpp
@@ -58,6 +58,7 @@
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
 #include <sensor_msgs/msg/point_field.hpp>
+#include <std_msgs/msg/float64.hpp>
 #include <std_srvs/srv/empty.hpp>
 
 #include <beluga/motion/differential_drive_model.hpp>
@@ -201,6 +202,28 @@ AmclNode::AmclNode(const rclcpp::NodeOptions& options) : BaseAMCLNode{"amcl", ""
         "increase resource usage and potentially degrade performance.";
     declare_parameter("debug", false, descriptor);
   }
+
+  {
+    const auto defaults = beluga_ros::AmclParams{};
+    auto descriptor = rcl_interfaces::msg::ParameterDescriptor();
+    descriptor.floating_point_range.resize(1);
+    descriptor.floating_point_range[0].from_value = 0.0;
+    descriptor.floating_point_range[0].to_value = 1.0;
+    descriptor.floating_point_range[0].step = 0.0;
+
+    descriptor.description =
+        "Expected standard deviation of x in a healthy particle distribution, used for quality estimation [m].";
+    declare_parameter("expected_pose_x_stddev", rclcpp::ParameterValue(defaults.expected_pose_x_stddev), descriptor);
+
+    descriptor.description =
+        "Expected standard deviation of y in a healthy particle distribution, used for quality estimation [m].";
+    declare_parameter("expected_pose_y_stddev", rclcpp::ParameterValue(defaults.expected_pose_y_stddev), descriptor);
+
+    descriptor.description =
+        "Expected standard deviation of yaw in a healthy particle distribution, used for quality estimation [rad].";
+    declare_parameter(
+        "expected_pose_yaw_stddev", rclcpp::ParameterValue(defaults.expected_pose_yaw_stddev), descriptor);
+  }
 }
 
 AmclNode::~AmclNode() {
@@ -214,6 +237,9 @@ void AmclNode::do_activate(const rclcpp_lifecycle::State&) {
   if (likelihood_field_pub_) {
     likelihood_field_pub_->on_activate();
   }
+
+  quality_pub_ = create_publisher<std_msgs::msg::Float64>("localization_quality", rclcpp::SystemDefaultsQoS());
+  quality_pub_->on_activate();
 
   {
     map_sub_ = create_subscription<nav_msgs::msg::OccupancyGrid>(
@@ -311,6 +337,9 @@ void AmclNode::do_deactivate(const rclcpp_lifecycle::State&) {
   if (likelihood_field_pub_) {
     likelihood_field_pub_->on_deactivate();
   }
+  if (quality_pub_) {
+    quality_pub_->on_deactivate();
+  }
 }
 
 void AmclNode::do_cleanup(const rclcpp_lifecycle::State&) {
@@ -318,6 +347,7 @@ void AmclNode::do_cleanup(const rclcpp_lifecycle::State&) {
   particle_filter_.reset();
   enable_tf_broadcast_ = false;
   likelihood_field_pub_.reset();
+  quality_pub_.reset();
 }
 
 auto AmclNode::get_initial_estimate() const -> std::optional<std::pair<Sophus::SE2d, Eigen::Matrix3d>> {
@@ -423,6 +453,9 @@ auto AmclNode::make_particle_filter(nav_msgs::msg::OccupancyGrid::SharedPtr map)
   params.spatial_resolution_x = get_parameter("spatial_resolution_x").as_double();
   params.spatial_resolution_y = get_parameter("spatial_resolution_y").as_double();
   params.spatial_resolution_theta = get_parameter("spatial_resolution_theta").as_double();
+  params.expected_pose_x_stddev = get_parameter("expected_pose_x_stddev").as_double();
+  params.expected_pose_y_stddev = get_parameter("expected_pose_y_stddev").as_double();
+  params.expected_pose_yaw_stddev = get_parameter("expected_pose_yaw_stddev").as_double();
 
   return std::make_unique<beluga_ros::Amcl>(
       beluga_ros::OccupancyGrid{map},                                        //
@@ -644,6 +677,10 @@ void AmclNode::sensor_callback(const std::shared_ptr<const MessageT>& sensor_msg
     tf2::toMsg(base_pose_in_map, message.pose.pose);
     tf2::covarianceEigenToRowMajor(base_pose_covariance, message.pose.covariance);
     pose_pub_->publish(message);
+
+    auto quality_msg = std_msgs::msg::Float64{};
+    quality_msg.data = particle_filter_->quality();
+    quality_pub_->publish(quality_msg);
   }
 }
 

--- a/beluga_amcl/src/amcl_node.cpp
+++ b/beluga_amcl/src/amcl_node.cpp
@@ -208,7 +208,7 @@ AmclNode::AmclNode(const rclcpp::NodeOptions& options) : BaseAMCLNode{"amcl", ""
     auto descriptor = rcl_interfaces::msg::ParameterDescriptor();
     descriptor.floating_point_range.resize(1);
     descriptor.floating_point_range[0].from_value = 0.0;
-    descriptor.floating_point_range[0].to_value = 1.0;
+    descriptor.floating_point_range[0].to_value = std::numeric_limits<double>::max();
     descriptor.floating_point_range[0].step = 0.0;
 
     descriptor.description =

--- a/beluga_amcl/src/amcl_node.cpp
+++ b/beluga_amcl/src/amcl_node.cpp
@@ -212,15 +212,18 @@ AmclNode::AmclNode(const rclcpp::NodeOptions& options) : BaseAMCLNode{"amcl", ""
     descriptor.floating_point_range[0].step = 0.0;
 
     descriptor.description =
-        "Expected standard deviation of x in a healthy particle distribution, used for quality estimation [m].";
+        "Typical standard deviation of x in the output covariance matrix of a healthy filter, used for quality "
+        "estimation [m].";
     declare_parameter("expected_pose_x_stddev", rclcpp::ParameterValue(defaults.expected_pose_x_stddev), descriptor);
 
     descriptor.description =
-        "Expected standard deviation of y in a healthy particle distribution, used for quality estimation [m].";
+        "Typical standard deviation of y in the output covariance matrix of a healthy filter, used for quality "
+        "estimation [m].";
     declare_parameter("expected_pose_y_stddev", rclcpp::ParameterValue(defaults.expected_pose_y_stddev), descriptor);
 
     descriptor.description =
-        "Expected standard deviation of yaw in a healthy particle distribution, used for quality estimation [rad].";
+        "Typical standard deviation of yaw in the output covariance matrix of a healthy filter, used for quality "
+        "estimation [rad].";
     declare_parameter(
         "expected_pose_yaw_stddev", rclcpp::ParameterValue(defaults.expected_pose_yaw_stddev), descriptor);
   }

--- a/beluga_amcl/src/amcl_node.cpp
+++ b/beluga_amcl/src/amcl_node.cpp
@@ -238,8 +238,12 @@ void AmclNode::do_activate(const rclcpp_lifecycle::State&) {
     likelihood_field_pub_->on_activate();
   }
 
-  quality_pub_ = create_publisher<std_msgs::msg::Float64>("localization_quality", rclcpp::SystemDefaultsQoS());
-  quality_pub_->on_activate();
+  quality_x_pub_ = create_publisher<std_msgs::msg::Float64>("localization_quality_x", rclcpp::SystemDefaultsQoS());
+  quality_x_pub_->on_activate();
+  quality_y_pub_ = create_publisher<std_msgs::msg::Float64>("localization_quality_y", rclcpp::SystemDefaultsQoS());
+  quality_y_pub_->on_activate();
+  quality_yaw_pub_ = create_publisher<std_msgs::msg::Float64>("localization_quality_yaw", rclcpp::SystemDefaultsQoS());
+  quality_yaw_pub_->on_activate();
 
   {
     map_sub_ = create_subscription<nav_msgs::msg::OccupancyGrid>(
@@ -337,8 +341,14 @@ void AmclNode::do_deactivate(const rclcpp_lifecycle::State&) {
   if (likelihood_field_pub_) {
     likelihood_field_pub_->on_deactivate();
   }
-  if (quality_pub_) {
-    quality_pub_->on_deactivate();
+  if (quality_x_pub_) {
+    quality_x_pub_->on_deactivate();
+  }
+  if (quality_y_pub_) {
+    quality_y_pub_->on_deactivate();
+  }
+  if (quality_yaw_pub_) {
+    quality_yaw_pub_->on_deactivate();
   }
 }
 
@@ -347,7 +357,9 @@ void AmclNode::do_cleanup(const rclcpp_lifecycle::State&) {
   particle_filter_.reset();
   enable_tf_broadcast_ = false;
   likelihood_field_pub_.reset();
-  quality_pub_.reset();
+  quality_x_pub_.reset();
+  quality_y_pub_.reset();
+  quality_yaw_pub_.reset();
 }
 
 auto AmclNode::get_initial_estimate() const -> std::optional<std::pair<Sophus::SE2d, Eigen::Matrix3d>> {
@@ -678,9 +690,14 @@ void AmclNode::sensor_callback(const std::shared_ptr<const MessageT>& sensor_msg
     tf2::covarianceEigenToRowMajor(base_pose_covariance, message.pose.covariance);
     pose_pub_->publish(message);
 
+    const auto quality = particle_filter_->quality();
     auto quality_msg = std_msgs::msg::Float64{};
-    quality_msg.data = particle_filter_->quality();
-    quality_pub_->publish(quality_msg);
+    quality_msg.data = quality[0];
+    quality_x_pub_->publish(quality_msg);
+    quality_msg.data = quality[1];
+    quality_y_pub_->publish(quality_msg);
+    quality_msg.data = quality[2];
+    quality_yaw_pub_->publish(quality_msg);
   }
 }
 

--- a/beluga_ros/include/beluga_ros/amcl.hpp
+++ b/beluga_ros/include/beluga_ros/amcl.hpp
@@ -95,6 +95,15 @@ struct AmclParams {
 
   /// \brief Spatial resolution around the z-axis to create buckets for KLD resampling.
   double spatial_resolution_theta = 10 * Sophus::Constants<double>::pi() / 180;
+
+  /// \brief Expected standard deviation of x in a healthy particle distribution, used for quality estimation [m].
+  double expected_pose_x_stddev = 0.1;
+
+  /// \brief Expected standard deviation of y in a healthy particle distribution, used for quality estimation [m].
+  double expected_pose_y_stddev = 0.1;
+
+  /// \brief Expected standard deviation of yaw in a healthy particle distribution, used for quality estimation [rad].
+  double expected_pose_yaw_stddev = 0.05;
 };
 
 /// Implementation of the 2D Adaptive Monte Carlo Localization (AMCL) algorithm.
@@ -262,6 +271,14 @@ class Amcl {
   /// Force a manual update of the particles on the next iteration of the filter.
   void force_update() { force_update_ = true; }
 
+  /// Returns the localization quality score from the last filter update.
+  /**
+   * The score is in [0, 1], where close to 1 means the filter covariance is within the expected
+   * and values approaching 0 indicate the filter may be diverging.
+   * Returns 1.0 before the first successful update.
+   */
+  [[nodiscard]] double quality() const { return last_quality_; }
+
  private:
   beluga::TupleVector<particle_type> particles_;
 
@@ -279,6 +296,9 @@ class Amcl {
   beluga::RollingWindow<Sophus::SE2d, 2> control_action_window_;
 
   bool force_update_{true};
+  double last_quality_{1.0};
+
+  double compute_quality(const Sophus::Matrix3d& actual_covariance);
 };
 
 }  // namespace beluga_ros

--- a/beluga_ros/include/beluga_ros/amcl.hpp
+++ b/beluga_ros/include/beluga_ros/amcl.hpp
@@ -15,6 +15,7 @@
 #ifndef BELUGA_ROS_AMCL_HPP
 #define BELUGA_ROS_AMCL_HPP
 
+#include <array>
 #include <optional>
 #include <utility>
 #include <variant>
@@ -272,13 +273,14 @@ class Amcl {
   /// Force a manual update of the particles on the next iteration of the filter.
   void force_update() { force_update_ = true; }
 
-  /// Returns the localization quality score from the last filter update.
+  /// Returns the per-axis localization quality scores from the last filter update.
   /**
-   * The score is in [0, 1], where close to 1 means the filter covariance is within the expected
-   * and values approaching 0 indicate the filter may be diverging.
-   * Returns 1.0 before the first successful update.
+   * Each element is in [0, 1]: index 0 = x, 1 = y, 2 = yaw.
+   * A value close to 1 means the filter covariance for that axis is within the expected range;
+   * values approaching 0 indicate the filter may be diverging on that axis.
+   * Returns {1.0, 1.0, 1.0} before the first successful update.
    */
-  [[nodiscard]] double quality() const { return last_quality_; }
+  [[nodiscard]] std::array<double, 3> quality() const { return last_quality_; }
 
  private:
   beluga::TupleVector<particle_type> particles_;
@@ -297,10 +299,10 @@ class Amcl {
   beluga::RollingWindow<Sophus::SE2d, 2> control_action_window_;
 
   bool force_update_{true};
-  double last_quality_{1.0};
+  std::array<double, 3> last_quality_{1.0, 1.0, 1.0};
   std::vector<Sophus::SE2d> ref_states_;
 
-  double compute_quality(const Sophus::Matrix3d& actual_covariance);
+  std::array<double, 3> compute_quality(const Sophus::Matrix3d& actual_covariance);
 };
 
 }  // namespace beluga_ros

--- a/beluga_ros/include/beluga_ros/amcl.hpp
+++ b/beluga_ros/include/beluga_ros/amcl.hpp
@@ -98,13 +98,16 @@ struct AmclParams {
   /// \brief Spatial resolution around the z-axis to create buckets for KLD resampling.
   double spatial_resolution_theta = 10 * Sophus::Constants<double>::pi() / 180;
 
-  /// \brief Expected standard deviation of x in a healthy particle distribution, used for quality estimation [m].
+  /// \brief Typical standard deviation of x in the output covariance matrix of a healthy filter, used for quality
+  /// estimation [m].
   double expected_pose_x_stddev = 0.1;
 
-  /// \brief Expected standard deviation of y in a healthy particle distribution, used for quality estimation [m].
+  /// \brief Typical standard deviation of y in the output covariance matrix of a healthy filter, used for quality
+  /// estimation [m].
   double expected_pose_y_stddev = 0.1;
 
-  /// \brief Expected standard deviation of yaw in a healthy particle distribution, used for quality estimation [rad].
+  /// \brief Typical standard deviation of yaw in the output covariance matrix of a healthy filter, used for quality
+  /// estimation [rad].
   double expected_pose_yaw_stddev = 0.05;
 };
 
@@ -300,7 +303,6 @@ class Amcl {
 
   bool force_update_{true};
   std::array<double, 3> last_quality_{1.0, 1.0, 1.0};
-  std::vector<Sophus::SE2d> ref_states_;
 
   std::array<double, 3> compute_quality(const Sophus::Matrix3d& actual_covariance);
 };

--- a/beluga_ros/include/beluga_ros/amcl.hpp
+++ b/beluga_ros/include/beluga_ros/amcl.hpp
@@ -18,6 +18,7 @@
 #include <optional>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include <range/v3/range/conversion.hpp>
 #include <range/v3/view/take_exactly.hpp>
@@ -297,6 +298,7 @@ class Amcl {
 
   bool force_update_{true};
   double last_quality_{1.0};
+  std::vector<Sophus::SE2d> ref_states_;
 
   double compute_quality(const Sophus::Matrix3d& actual_covariance);
 };

--- a/beluga_ros/src/amcl.cpp
+++ b/beluga_ros/src/amcl.cpp
@@ -21,7 +21,11 @@
 #include <beluga/algorithm/cluster_based_estimation.hpp>
 #include <beluga/views/random_intersperse.hpp>
 #include <beluga/views/take_while_kld.hpp>
+#include <algorithm>
 #include <cmath>
+#include <limits>
+#include <random>
+#include <vector>
 
 namespace beluga_ros {
 
@@ -122,7 +126,47 @@ auto Amcl::update(
   }
 
   force_update_ = false;
-  return beluga::cluster_based_estimate(beluga::views::states(particles_), beluga::views::weights(particles_));
+  auto estimate =
+      beluga::cluster_based_estimate(beluga::views::states(particles_), beluga::views::weights(particles_));
+  last_quality_ = compute_quality(estimate.second);
+  return estimate;
+}
+
+double Amcl::compute_quality(const Sophus::Matrix3d& actual_covariance) {
+  const std::size_t N = params_.min_particles;
+
+  // a known seed is required to provide the exact same reference each time quality is computed.
+  std::mt19937 gen{42};
+  std::normal_distribution<double> dx{0.0, params_.expected_pose_x_stddev};
+  std::normal_distribution<double> dy{0.0, params_.expected_pose_y_stddev};
+  std::normal_distribution<double> dyaw{0.0, params_.expected_pose_yaw_stddev};
+
+  std::vector<Sophus::SE2d> ref_states;
+  ref_states.reserve(N);
+  for (std::size_t i = 0; i < N; ++i) {
+    ref_states.emplace_back(Sophus::SO2d{dyaw(gen)}, Sophus::Vector2d{dx(gen), dy(gen)});
+  }
+
+  std::visit(
+      [&](const auto& motion_model) {
+        auto sampling_fn = motion_model(control_action_window_);
+        for (auto& state : ref_states) {
+          state = sampling_fn(state, gen);
+        }
+      },
+      motion_model_);
+
+  const std::vector<double> uniform_weights(N, 1.0);
+  const auto [ref_mean, ref_covariance] = beluga::estimate(ref_states, uniform_weights);
+
+  double quality = 1.0;
+  for (int i = 0; i < 3; ++i) {
+    const double actual = actual_covariance.coeff(i, i);
+    if (actual > std::numeric_limits<double>::epsilon()) {
+      quality = std::min(quality, ref_covariance.coeff(i, i) / actual);
+    }
+  }
+  return std::clamp(quality, 0.0, 1.0);
 }
 
 }  // namespace beluga_ros

--- a/beluga_ros/src/amcl.cpp
+++ b/beluga_ros/src/amcl.cpp
@@ -142,7 +142,7 @@ auto Amcl::update(
   return estimate;
 }
 
-double Amcl::compute_quality(const Sophus::Matrix3d& actual_covariance) {
+std::array<double, 3> Amcl::compute_quality(const Sophus::Matrix3d& actual_covariance) {
   std::vector<Sophus::SE2d> ref_states;
   ref_states.reserve(ref_states_.size());
 
@@ -159,14 +159,14 @@ double Amcl::compute_quality(const Sophus::Matrix3d& actual_covariance) {
   const std::vector<double> uniform_weights(ref_states.size(), 1.0);
   const auto [ref_mean, ref_covariance] = beluga::estimate(ref_states, uniform_weights);
 
-  double quality = 1.0;
+  std::array<double, 3> quality{1.0, 1.0, 1.0};
   for (int i = 0; i < 3; ++i) {
     const double actual = actual_covariance.coeff(i, i);
     if (actual > std::numeric_limits<double>::epsilon()) {
-      quality = std::min(quality, ref_covariance.coeff(i, i) / actual);
+      quality[i] = std::clamp(ref_covariance.coeff(i, i) / actual, 0.0, 1.0);
     }
   }
-  return std::clamp(quality, 0.0, 1.0);
+  return quality;
 }
 
 }  // namespace beluga_ros

--- a/beluga_ros/src/amcl.cpp
+++ b/beluga_ros/src/amcl.cpp
@@ -132,7 +132,7 @@ auto Amcl::update(
 }
 
 double Amcl::compute_quality(const Sophus::Matrix3d& actual_covariance) {
-  const std::size_t N = params_.min_particles;
+  const std::size_t n = params_.min_particles;
 
   // a known seed is required to provide the exact same reference each time quality is computed.
   std::mt19937 gen{42};
@@ -141,8 +141,8 @@ double Amcl::compute_quality(const Sophus::Matrix3d& actual_covariance) {
   std::normal_distribution<double> dyaw{0.0, params_.expected_pose_yaw_stddev};
 
   std::vector<Sophus::SE2d> ref_states;
-  ref_states.reserve(N);
-  for (std::size_t i = 0; i < N; ++i) {
+  ref_states.reserve(n);
+  for (std::size_t i = 0; i < n; ++i) {
     ref_states.emplace_back(Sophus::SO2d{dyaw(gen)}, Sophus::Vector2d{dx(gen), dy(gen)});
   }
 
@@ -155,7 +155,7 @@ double Amcl::compute_quality(const Sophus::Matrix3d& actual_covariance) {
       },
       motion_model_);
 
-  const std::vector<double> uniform_weights(N, 1.0);
+  const std::vector<double> uniform_weights(n, 1.0);
   const auto [ref_mean, ref_covariance] = beluga::estimate(ref_states, uniform_weights);
 
   double quality = 1.0;

--- a/beluga_ros/src/amcl.cpp
+++ b/beluga_ros/src/amcl.cpp
@@ -14,6 +14,7 @@
 
 #include <beluga_ros/amcl.hpp>
 
+#include <algorithm>
 #include <beluga/actions/assign.hpp>
 #include <beluga/actions/normalize.hpp>
 #include <beluga/actions/propagate.hpp>
@@ -21,7 +22,6 @@
 #include <beluga/algorithm/cluster_based_estimation.hpp>
 #include <beluga/views/random_intersperse.hpp>
 #include <beluga/views/take_while_kld.hpp>
-#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <random>
@@ -126,8 +126,7 @@ auto Amcl::update(
   }
 
   force_update_ = false;
-  auto estimate =
-      beluga::cluster_based_estimate(beluga::views::states(particles_), beluga::views::weights(particles_));
+  auto estimate = beluga::cluster_based_estimate(beluga::views::states(particles_), beluga::views::weights(particles_));
   last_quality_ = compute_quality(estimate.second);
   return estimate;
 }

--- a/beluga_ros/src/amcl.cpp
+++ b/beluga_ros/src/amcl.cpp
@@ -47,6 +47,17 @@ Amcl::Amcl(
   if (params_.selective_resampling) {
     resample_policy_ = resample_policy_ && beluga::policies::on_effective_size_drop;
   }
+
+  Sophus::Matrix3d covariance = Sophus::Matrix3d::Zero();
+  covariance(0, 0) = params_.expected_pose_x_stddev * params_.expected_pose_x_stddev;
+  covariance(1, 1) = params_.expected_pose_y_stddev * params_.expected_pose_y_stddev;
+  covariance(2, 2) = params_.expected_pose_yaw_stddev * params_.expected_pose_yaw_stddev;
+  auto dist = beluga::MultivariateNormalDistribution<Sophus::SE2d>{covariance};
+  std::mt19937 gen{42};
+  ref_states_.reserve(params_.min_particles);
+  for (std::size_t i = 0; i < params_.min_particles; ++i) {
+    ref_states_.emplace_back(dist(gen));
+  }
 }
 
 void Amcl::update_map(beluga_ros::OccupancyGrid map) {
@@ -132,30 +143,20 @@ auto Amcl::update(
 }
 
 double Amcl::compute_quality(const Sophus::Matrix3d& actual_covariance) {
-  const std::size_t n = params_.min_particles;
-
-  // a known seed is required to provide the exact same reference each time quality is computed.
-  std::mt19937 gen{42};
-  std::normal_distribution<double> dx{0.0, params_.expected_pose_x_stddev};
-  std::normal_distribution<double> dy{0.0, params_.expected_pose_y_stddev};
-  std::normal_distribution<double> dyaw{0.0, params_.expected_pose_yaw_stddev};
-
   std::vector<Sophus::SE2d> ref_states;
-  ref_states.reserve(n);
-  for (std::size_t i = 0; i < n; ++i) {
-    ref_states.emplace_back(Sophus::SO2d{dyaw(gen)}, Sophus::Vector2d{dx(gen), dy(gen)});
-  }
+  ref_states.reserve(ref_states_.size());
 
+  std::mt19937 gen{42};
   std::visit(
       [&](const auto& motion_model) {
         auto sampling_fn = motion_model(control_action_window_);
-        for (auto& state : ref_states) {
-          state = sampling_fn(state, gen);
+        for (const auto& state : ref_states_) {
+          ref_states.push_back(sampling_fn(state, gen));
         }
       },
       motion_model_);
 
-  const std::vector<double> uniform_weights(n, 1.0);
+  const std::vector<double> uniform_weights(ref_states.size(), 1.0);
   const auto [ref_mean, ref_covariance] = beluga::estimate(ref_states, uniform_weights);
 
   double quality = 1.0;

--- a/beluga_ros/src/amcl.cpp
+++ b/beluga_ros/src/amcl.cpp
@@ -24,7 +24,6 @@
 #include <beluga/views/take_while_kld.hpp>
 #include <cmath>
 #include <limits>
-#include <random>
 #include <vector>
 
 namespace beluga_ros {
@@ -46,17 +45,6 @@ Amcl::Amcl(
       resample_policy_{beluga::policies::every_n(params_.resample_interval)} {
   if (params_.selective_resampling) {
     resample_policy_ = resample_policy_ && beluga::policies::on_effective_size_drop;
-  }
-
-  Sophus::Matrix3d covariance = Sophus::Matrix3d::Zero();
-  covariance(0, 0) = params_.expected_pose_x_stddev * params_.expected_pose_x_stddev;
-  covariance(1, 1) = params_.expected_pose_y_stddev * params_.expected_pose_y_stddev;
-  covariance(2, 2) = params_.expected_pose_yaw_stddev * params_.expected_pose_yaw_stddev;
-  auto dist = beluga::MultivariateNormalDistribution<Sophus::SE2d>{covariance};
-  std::mt19937 gen{42};
-  ref_states_.reserve(params_.min_particles);
-  for (std::size_t i = 0; i < params_.min_particles; ++i) {
-    ref_states_.emplace_back(dist(gen));
   }
 }
 
@@ -143,27 +131,16 @@ auto Amcl::update(
 }
 
 std::array<double, 3> Amcl::compute_quality(const Sophus::Matrix3d& actual_covariance) {
-  std::vector<Sophus::SE2d> ref_states;
-  ref_states.reserve(ref_states_.size());
-
-  std::mt19937 gen{42};
-  std::visit(
-      [&](const auto& motion_model) {
-        auto sampling_fn = motion_model(control_action_window_);
-        for (const auto& state : ref_states_) {
-          ref_states.push_back(sampling_fn(state, gen));
-        }
-      },
-      motion_model_);
-
-  const std::vector<double> uniform_weights(ref_states.size(), 1.0);
-  const auto [ref_mean, ref_covariance] = beluga::estimate(ref_states, uniform_weights);
-
+  const std::array<double, 3> expected_variance = {
+      params_.expected_pose_x_stddev * params_.expected_pose_x_stddev,
+      params_.expected_pose_y_stddev * params_.expected_pose_y_stddev,
+      params_.expected_pose_yaw_stddev * params_.expected_pose_yaw_stddev,
+  };
   std::array<double, 3> quality{1.0, 1.0, 1.0};
   for (int i = 0; i < 3; ++i) {
     const double actual = actual_covariance.coeff(i, i);
     if (actual > std::numeric_limits<double>::epsilon()) {
-      quality[i] = std::clamp(ref_covariance.coeff(i, i) / actual, 0.0, 1.0);
+      quality[i] = std::clamp(expected_variance[i] / actual, 0.0, 1.0);
     }
   }
   return quality;


### PR DESCRIPTION
### Proposed changes

Implements a quality/degradation metric based in a comparison between a expected covariance and the real covariance. It is based in the answer in https://github.com/Ekumen-OS/beluga/discussions/562.
A new publisher "localization_quality" provides a float between [0, 1] , the closer to 1 better quality.

#### Type of change

- [ ] 🐛 Bugfix (change which fixes an issue)
- [x] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

_Put an `x` in the boxes that apply. This is simply a reminder of what we will require before merging your code._

- [ ] Lint and unit tests (if any) pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] All commits have been signed for [DCO](https://developercertificate.org/)

### Additional comments

It is my first PR. Need some help to test this and to add a test to check the feature.
